### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+
+language: c
+
+services:
+  - docker
+
+before_install:
+  - docker pull fedora
+  - export CONTAINER=$(docker run -d fedora sleep 1800)
+  - docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
+  - docker exec $CONTAINER dnf -y builddep p11-kit
+  - docker exec $CONTAINER dnf -y install gettext-devel libtool make
+  - docker exec $CONTAINER useradd user
+  - docker exec $CONTAINER mkdir /builddir
+  - docker exec $CONTAINER chown -R user /builddir
+
+install:
+  - docker cp . $CONTAINER:/srcdir
+  # FIXME: This is needed because some files are included in distribution
+  # and need to be generated in $srcdir rather than $builddir
+  - docker exec $CONTAINER chown -R user /srcdir
+
+script:
+  - docker exec $CONTAINER sh -c "cd /srcdir && NOCONFIGURE=1 ./autogen.sh"
+  - docker exec $CONTAINER su - user sh -c "cd /builddir && ../srcdir/configure --prefix=/usr --libdir=/usr/lib64"
+  - docker exec $CONTAINER su - user sh -c "cd /builddir && make && make check"


### PR DESCRIPTION
Although p11-kit already has a CI on gnome-continuous, it could benefit from Travis as it supports some proprietary build environments.
