### PR TITLE
trust: Reject invalid UTF-8 input

### DIFF
--- a/trust/test-utf8.c
+++ b/trust/test-utf8.c
@@ -221,6 +221,8 @@ test_utf8_fail (void)
 		{ "Good news everyone\x88", -1 },
 		{ "Bad \xe0v following chars should be |0x80", -1 },
 		{ "Truncated \xe0", -1 },
+		{ "Surrogate \xed\xa0\x80", -1, },
+		{ "Out of range \xf4\x90\x80\x80", -1, },
 	};
 
 	for (i = 0; i < ELEMS (fixtures); i++) {

--- a/trust/utf8.c
+++ b/trust/utf8.c
@@ -156,6 +156,12 @@ utf8_to_uchar (const char *str,
 		 */
 		return -1;
 	}
+	if ((uch >= 0xd800 && uch <= 0xdfff) || uch > 0x10ffff) {
+		/*
+		 * Malformed input; invalid code points.
+		 */
+		return -1;
+	}
 
 	*uc = uch;
 	return want;


### PR DESCRIPTION
Merge changes from utf8.c in FreeBSD's libc:
https://svnweb.freebsd.org/base/head/lib/libc/locale/utf8.c?revision=290494&view=markup#l196

https://bugzilla.redhat.com/show_bug.cgi?id=985449