### PR TITLE
common, trust: Avoid integer overflow

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -41,6 +41,7 @@
 #define _XOPEN_SOURCE 700
 
 #include "compat.h"
+#include "debug.h"
 
 #include <assert.h>
 #include <dirent.h>
@@ -503,8 +504,11 @@ strconcat (const char *first,
 
 	va_start (va, first);
 
-	for (arg = first; arg; arg = va_arg (va, const char*))
-	       length += strlen (arg);
+	for (arg = first; arg; arg = va_arg (va, const char*)) {
+		size_t old_length = length;
+		length += strlen (arg);
+		return_val_if_fail (length >= old_length, NULL);
+	}
 
 	va_end (va);
 

--- a/common/path.c
+++ b/common/path.c
@@ -214,7 +214,9 @@ p11_path_build (const char *path,
 	len = 1;
 	va_start (va, path);
 	while (path != NULL) {
+		size_t old_len = len;
 		len += strlen (path) + 1;
+		return_val_if_fail (len >= old_len, NULL);
 		path = va_arg (va, const char *);
 	}
 	va_end (va);

--- a/common/url.c
+++ b/common/url.c
@@ -71,7 +71,7 @@ p11_url_decode (const char *value,
 		 */
 		if (*value == '%') {
 			value++;
-			if (value + 2 > end) {
+			if (end - value < 2) {
 				free (result);
 				return NULL;
 			}

--- a/trust/base64.c
+++ b/trust/base64.c
@@ -43,9 +43,11 @@
 #include "config.h"
 
 #include "base64.h"
+#include "debug.h"
 
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -99,6 +101,7 @@ p11_b64_pton (const char *src,
 			state = 1;
 			break;
 		case 1:
+			return_val_if_fail (tarindex < INT_MAX, -1);
 			if (target) {
 				if ((size_t) tarindex + 1 >= targsize)
 					return (-1);
@@ -110,6 +113,7 @@ p11_b64_pton (const char *src,
 			state = 2;
 			break;
 		case 2:
+			return_val_if_fail (tarindex < INT_MAX, -1);
 			if (target) {
 				if ((size_t) tarindex + 1 >= targsize)
 					return (-1);
@@ -121,6 +125,7 @@ p11_b64_pton (const char *src,
 			state = 3;
 			break;
 		case 3:
+			return_val_if_fail (tarindex < INT_MAX, -1);
 			if (target) {
 				if ((size_t) tarindex >= targsize)
 					return (-1);


### PR DESCRIPTION
This fixes issues pointed in:
https://bugzilla.redhat.com/show_bug.cgi?id=985445
except for p11-kit/conf.c:read_config_file(), which was rewritten using
mmap() and thus length calculation is no longer needed.