### PR TITLE
Fixes in TMPDIR handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ install:
 script:
   - docker exec $CONTAINER sh -c "cd /srcdir && NOCONFIGURE=1 ./autogen.sh"
   - docker exec $CONTAINER su - user sh -c "cd /builddir && ../srcdir/configure --prefix=/usr --libdir=/usr/lib64 CFLAGS=\"$CFLAGS\" CXXFLAGS=\"$CXXFLAGS\" LDFLAGS=\"$LDFLAGS\" LIBS=\"$LIBS\""
-  - docker exec $CONTAINER su - user sh -c "cd /builddir && make V=1 && make check V=1"
+  - docker exec $CONTAINER su - user sh -c "cd /builddir && make V=1 && make check TMPDIR=./ V=1"

--- a/common/test.c
+++ b/common/test.c
@@ -483,11 +483,12 @@ char *
 p11_test_copy_setgid (const char *input)
 {
 	gid_t groups[128];
-		char *path;
-		gid_t group = 0;
-		int ret;
-		int fd;
-		int i;
+	char *path;
+	gid_t group = 0;
+	int ret;
+	int fd;
+	int i;
+	char *tmpdir;
 
 	ret = getgroups (128, groups);
 	for (i = 0; i < ret; ++i) {
@@ -501,8 +502,11 @@ p11_test_copy_setgid (const char *input)
 		return NULL;
 	}
 
-	path = strdup ("/tmp/test-setgid.XXXXXX");
-	assert (path != NULL);
+	tmpdir = getenv ("TMPDIR");
+	if (tmpdir == NULL)
+		tmpdir = "/tmp";
+
+	assert (asprintf (&path, "%s/test-setgid.XXXXXX", tmpdir) >= 0);
 
 	fd = mkstemp (path);
 	assert (fd >= 0);


### PR DESCRIPTION
This patch set allows using alternatives to /tmp for writing temp files and switches travis build to ./ for temp directory.