### PR TITLE
test-conf: don't create the setuid copy in /tmp

### DIFF
--- a/common/test.c
+++ b/common/test.c
@@ -501,7 +501,7 @@ p11_test_copy_setgid (const char *input)
 		return NULL;
 	}
 
-	path = strdup ("/tmp/test-setgid.XXXXXX");
+	path = strdup (BUILDDIR "/test-setgid.XXXXXX");
 	assert (path != NULL);
 
 	fd = mkstemp (path);


### PR DESCRIPTION
The temporary directory is often mounted with nosuid, thus whatever runs
from there doesn't get AT_SECURE in auxv.