### PR TITLE
Improve usefullness of remoting

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -171,7 +171,7 @@ p11_mutex_init (p11_mutex_t *mutex)
 	int ret;
 
 	pthread_mutexattr_init (&attr);
-	pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_DEFAULT);
+	pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
 	ret = pthread_mutex_init (mutex, &attr);
 	assert (ret == 0);
 	pthread_mutexattr_destroy (&attr);

--- a/doc/manual/p11-kit-docs.xml
+++ b/doc/manual/p11-kit-docs.xml
@@ -14,6 +14,7 @@
 	<xi:include href="p11-kit-config.xml"/>
 	<xi:include href="p11-kit-sharing.xml"/>
 	<xi:include href="p11-kit-proxy.xml"/>
+	<xi:include href="p11-kit-remote-proxy.xml"/>
 	<xi:include href="p11-kit-trust.xml"/>
 
 	<chapter xml:id="tools">

--- a/doc/manual/p11-kit-remote-proxy.xml
+++ b/doc/manual/p11-kit-remote-proxy.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+]>
+<chapter xml:id="remote-proxy">
+	<title>Remote Proxy Module</title>
+
+	<para>While the proxy module exposes the configured modules, the remoting
+	functionality of <literal>p11-kit</literal> often needs to be set up
+	dynamically (while the module for an actual token is selected by the remote
+	end).</para>
+
+	<para>To allow use of the remoting capability for PKCS#11 consumers that don't
+	link to p11-kit, a separate proxy module is provided that can be used in place
+	of an ordinary PKCS#11 module. It proxies the PKCS#11 calls to a remote specified
+	by the <envar>P11_REMOTE</envar> environment variable, using the same syntax as
+	a <literal>remote</literal> module in the configuration file.</para>
+</chapter>

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -28,7 +28,8 @@ MODULE_SRCS = \
 	$(inc_HEADERS)
 
 lib_LTLIBRARIES += \
-	libp11-kit.la
+	libp11-kit.la \
+	p11-kit-remote-proxy.la
 
 libp11_kit_la_CFLAGS = \
 	-DP11_SYSTEM_CONFIG_FILE=\""$(p11_system_config_file)"\" \
@@ -53,6 +54,17 @@ libp11_kit_la_LIBADD = \
 	$(LIBFFI_LIBS) \
 	$(LTLIBINTL) \
 	$(NULL)
+
+p11_kit_remote_proxy_la_SOURCES = \
+	p11-kit/remote-proxy.c
+
+p11_kit_remote_proxy_la_LDFLAGS = \
+	-module \
+	-avoid-version \
+	-export-symbols-regex '^C_GetFunctionList'
+
+p11_kit_remote_proxy_la_LIBADD = \
+	libp11-kit.la
 
 noinst_LTLIBRARIES += \
 	libp11-kit-testable.la

--- a/p11-kit/p11-kit-1.pc.in
+++ b/p11-kit/p11-kit-1.pc.in
@@ -10,6 +10,7 @@ p11_module_configs=@p11_package_config_modules@
 p11_module_path=@p11_module_path@
 p11_trust_paths=@with_trust_paths@
 proxy_module=@libdir@/p11-kit-proxy.so
+remote_proxy_module=@libdir@/p11-kit-remote-proxy.so
 
 # This is for compatibility. Other packages were using this to determine
 # the directory they should install their module configs to, so override

--- a/p11-kit/p11-kit.h
+++ b/p11-kit/p11-kit.h
@@ -57,6 +57,7 @@ enum {
 	P11_KIT_MODULE_UNMANAGED = 1 << 0,
 	P11_KIT_MODULE_CRITICAL = 1 << 1,
 	P11_KIT_MODULE_TRUSTED = 1 << 2,
+	P11_KIT_MODULE_REMOTING = 1 << 3,
 };
 
 typedef void        (* p11_kit_destroyer)                   (void *data);

--- a/p11-kit/p11-kit.h
+++ b/p11-kit/p11-kit.h
@@ -87,6 +87,9 @@ int                    p11_kit_module_get_flags             (CK_FUNCTION_LIST *m
 CK_FUNCTION_LIST *     p11_kit_module_load                  (const char *module_path,
                                                              int flags);
 
+CK_FUNCTION_LIST *     p11_kit_module_remote                (const char *remote,
+                                                             int flags);
+
 CK_RV                  p11_kit_module_initialize            (CK_FUNCTION_LIST *module);
 
 CK_RV                  p11_kit_module_finalize              (CK_FUNCTION_LIST *module);

--- a/p11-kit/remote-proxy.c
+++ b/p11-kit/remote-proxy.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Lubomir Rintel <lkundrak@v3.sk>
+ */
+
+#include "config.h"
+#include "p11-kit.h"
+
+#include <stdlib.h>
+
+CK_RV
+C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
+{
+	char *remote;
+
+	remote = getenv ("P11_REMOTE");
+	if (remote == NULL)
+		return CKR_ARGUMENTS_BAD;
+
+	*list = p11_kit_module_remote (remote, 0);
+	if (*list == NULL)
+		return CKR_GENERAL_ERROR;
+
+	return CKR_OK;
+}

--- a/p11-kit/remote.c
+++ b/p11-kit/remote.c
@@ -100,7 +100,7 @@ main (int argc,
 		return 2;
 	}
 
-	module = p11_kit_module_load (argv[0], 0);
+	module = p11_kit_module_load (argv[0], P11_KIT_MODULE_REMOTING);
 	if (module == NULL)
 		return 1;
 


### PR DESCRIPTION
This is in general done to allow forwarding the modules from the desktop session (such as the GNOME keyring or physical tokens the console user can access) to NetworkManager helpers (think VPN daemons or wpa_supplicants) running in system scope.

Related: https://bugzilla.gnome.org/show_bug.cgi?id=767872