### PR TITLE
move privatedir from libdir to libexecdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -498,7 +498,7 @@ esac
 AC_DEFINE_UNQUOTED(SHLEXT, ["$SHLEXT"], [File extension for shared libraries])
 AC_SUBST(SHLEXT)
 
-privatedir='${libdir}/p11-kit'
+privatedir='${libexecdir}/p11-kit'
 AC_SUBST(privatedir)
 
 AC_CONFIG_FILES([Makefile


### PR DESCRIPTION
From https://bugs.freedesktop.org/show_bug.cgi?id=98817

According to the GNU Coding Standards[1], private executables should be
installed to libexecdir, not libdir.

Move privatedir to libexecdir.

[1] https://www.gnu.org/prep/standards/
