### PR TITLE
uri: fix dealing with the query part

### DIFF
--- a/p11-kit/test-uri.c
+++ b/p11-kit/test-uri.c
@@ -1335,7 +1335,7 @@ test_uri_pin_source (void)
 	assert (strstr (string, "pin-source=%7cmy-pin-file") != NULL);
 	free (string);
 
-	ret = p11_kit_uri_parse ("pkcs11:pin-source=blah%2Fblah", P11_KIT_URI_FOR_ANY, uri);
+	ret = p11_kit_uri_parse ("pkcs11:?pin-source=blah%2Fblah", P11_KIT_URI_FOR_ANY, uri);
 	assert_num_eq (P11_KIT_URI_OK, ret);
 
 	pin_source = p11_kit_uri_get_pin_source (uri);
@@ -1371,7 +1371,7 @@ test_uri_pin_value (void)
 	assert (strstr (string, "pkcs11:pin-value=1%2a%26%23%25%26%40%28") != NULL);
 	free (string);
 
-	ret = p11_kit_uri_parse ("pkcs11:pin-value=blah%2Fblah", P11_KIT_URI_FOR_ANY, uri);
+	ret = p11_kit_uri_parse ("pkcs11:?pin-value=blah%2Fblah", P11_KIT_URI_FOR_ANY, uri);
 	assert_num_eq (P11_KIT_URI_OK, ret);
 
 	pin_value = p11_kit_uri_get_pin_value (uri);
@@ -1389,7 +1389,7 @@ test_uri_pin_value_bad (void)
 	uri = p11_kit_uri_new ();
 	assert_ptr_not_null (uri);
 
-	ret = p11_kit_uri_parse ("pkcs11:pin-value=blahblah%2", P11_KIT_URI_FOR_ANY, uri);
+	ret = p11_kit_uri_parse ("pkcs11:?pin-value=blahblah%2", P11_KIT_URI_FOR_ANY, uri);
 	assert_num_eq (P11_KIT_URI_BAD_ENCODING, ret);
 
 	p11_kit_uri_free (uri);

--- a/p11-kit/test-uri.c
+++ b/p11-kit/test-uri.c
@@ -1368,7 +1368,7 @@ test_uri_pin_value (void)
 
 	ret = p11_kit_uri_format (uri, P11_KIT_URI_FOR_ANY, &string);
 	assert_num_eq (P11_KIT_URI_OK, ret);
-	assert (strstr (string, "pkcs11:pin-value=1%2a%26%23%25%26%40%28") != NULL);
+	assert (strstr (string, "pkcs11:?pin-value=1%2a%26%23%25%26%40%28") != NULL);
 	free (string);
 
 	ret = p11_kit_uri_parse ("pkcs11:?pin-value=blah%2Fblah", P11_KIT_URI_FOR_ANY, uri);


### PR DESCRIPTION
The current code accepts and produces the query attributes as path attributes. That's wrong (and perhaps dangerous, when used recklessly). Hopefully I'm improving it a bit here.

Note that this potentially breaks compatibility with existing (broken!) URIs. I think that's okay, but perhaps need some consideration.

Please consult the grammar in section 2.3. for details: https://tools.ietf.org/html/rfc7512#section-2.3