### PR TITLE
build: improve p11-kit-proxy symlink handling

### DIFF
--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -87,8 +87,16 @@ libp11_kit_testable_la_CFLAGS = \
 
 # Proxy module is actually same as library, so install a link
 install-exec-hook:
-	$(LN_S) -f `readlink $(DESTDIR)$(libdir)/libp11-kit.{so,dylib}` $(DESTDIR)$(libdir)/p11-kit-proxy.so
+	for i in so dylib; do \
+		test -f $(DESTDIR)$(libdir)/libp11-kit.$$i && \
+			$(LN_S) -f `readlink $(DESTDIR)$(libdir)/libp11-kit.$$i` $(DESTDIR)$(libdir)/p11-kit-proxy.$$i || true; \
+	done
 	$(MKDIR_P) $(DESTDIR)$(p11_package_config_modules)
+
+uninstall-local:
+	for i in so dylib; do \
+		rm -f $(DESTDIR)$(libdir)/p11-kit-proxy.$$i; \
+	done
 
 endif
 


### PR DESCRIPTION
 - Current command for creation of the p11-kit-proxy symlink
   uses shell brace expansion that isn't supported by all
   the shells (e.g. FreeBSD's /bin/sh does not support that).
   Replace it with the old-fashioned 'for' loop
 - Match extension of the source and the target, i.e. so links
   to so, dylib links to dylib (previously dylib linked to so)
 - Add an uninstall-local target to clean up the symlink

PS Apparently, there was an attempt to avoid using of the `.dylib` extension on macOS: 6132376b. But it doesn't seem to work.