### PR TITLE
uri: Avoid typecasting confusion on s390x

### DIFF
--- a/p11-kit/uri.c
+++ b/p11-kit/uri.c
@@ -765,8 +765,10 @@ format_name_equals (p11_buffer *buffer,
                     enum uri_sep *sep,
                     const char *name)
 {
-	if (*sep)
-		p11_buffer_add (buffer, sep, 1);
+	if (*sep) {
+		char c = *sep;
+		p11_buffer_add (buffer, &c, 1);
+	}
 	p11_buffer_add (buffer, name, -1);
 	p11_buffer_add (buffer, "=", 1);
 


### PR DESCRIPTION
Like memcpy(), the 'void *' argument of p11_buffer_add() points to the
memory area ordered in host's endianness.  Add typecast of int->char to
avoid the confusion.

Reported by Andreas Metzler in:
https://lists.freedesktop.org/archives/p11-glue/2017-January/000633.html