### PR TITLE
systemd: add per-user remoting socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ x86_64-w64-mingw32
 /p11-kit/p11-kit.pc
 /p11-kit/p11-kit-1.pc
 /p11-kit/pkcs11.conf.example
+/p11-kit/p11-kit-remote@.service
 
 /po/POTFILES
 /po/stamp-po

--- a/configure.ac
+++ b/configure.ac
@@ -507,6 +507,7 @@ AC_CONFIG_FILES([Makefile
 	po/Makefile.in
 	p11-kit/p11-kit-1.pc
 	p11-kit/pkcs11.conf.example
+	p11-kit/p11-kit-remote@.service
 	trust/trust-extract-compat
 	trust/test-extract
 ])

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -93,12 +93,22 @@ install-exec-hook:
 	done
 	$(MKDIR_P) $(DESTDIR)$(p11_package_config_modules)
 
+install-data-hook:
+	$(MKDIR_P) $(DESTDIR)$(systemduserdir)/sockets.target.wants
+	$(LN_S) -f ../p11-kit-remote.socket $(DESTDIR)$(systemduserdir)/sockets.target.wants/p11-kit-remote.socket
+
 uninstall-local:
 	for i in so dylib; do \
 		rm -f $(DESTDIR)$(libdir)/p11-kit-proxy.$$i; \
 	done
+	rm -f $(DESTDIR)$(systemduserdir)/sockets.target.wants/p11-kit-remote.socket
 
 endif
+
+systemduserdir = $(prefix)/lib/systemd/user
+systemduser_DATA = \
+	p11-kit/p11-kit-remote.socket \
+	p11-kit/p11-kit-remote@.service
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = p11-kit/p11-kit-1.pc
@@ -108,6 +118,7 @@ example_DATA = p11-kit/pkcs11.conf.example
 
 EXTRA_DIST += \
 	p11-kit/docs.h \
+	p11-kit/p11-kit-remote.socket \
 	$(NULL)
 
 bin_PROGRAMS += p11-kit/p11-kit

--- a/p11-kit/p11-kit-remote.socket
+++ b/p11-kit/p11-kit-remote.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=PKCS#11 Remote Access Socket
+
+[Socket]
+Accept=true
+ListenStream=%t/p11-kit-remote
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target

--- a/p11-kit/p11-kit-remote@.service.in
+++ b/p11-kit/p11-kit-remote@.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=PKCS#11 Remote Access
+Documentation=man:p11-kit(8)
+Requires=p11-kit-remote.socket
+
+[Service]
+StandardInput=socket
+StandardOutput=socket
+StandardError=journal
+ExecStart=@libdir@/p11-kit/p11-kit-remote @libdir@/p11-kit-proxy.so


### PR DESCRIPTION
This allows daemons outside user's session to use per-user PKCS#11
modules. Useful for letting VPN daemons or wpa_supplicant use
certificates stored in user's GNOME keyring, etc.