### PR TITLE
uri: Support query attributes to specify module

### DIFF
--- a/doc/manual/p11-kit-sections.txt
+++ b/doc/manual/p11-kit-sections.txt
@@ -30,6 +30,10 @@ p11_kit_uri_get_pin_source
 p11_kit_uri_set_pin_source
 p11_kit_uri_get_pinfile
 p11_kit_uri_set_pinfile
+p11_kit_uri_get_module_name
+p11_kit_uri_set_module_name
+p11_kit_uri_get_module_path
+p11_kit_uri_set_module_path
 p11_kit_uri_format
 p11_kit_uri_parse
 p11_kit_uri_free

--- a/p11-kit/uri.h
+++ b/p11-kit/uri.h
@@ -153,6 +153,16 @@ void                p11_kit_uri_set_pinfile                 (P11KitUri *uri,
 
 #endif /* P11_KIT_DISABLE_DEPRECATED */
 
+const char*         p11_kit_uri_get_module_name             (P11KitUri *uri);
+
+void                p11_kit_uri_set_module_name             (P11KitUri *uri,
+                                                             const char *name);
+
+const char*         p11_kit_uri_get_module_path             (P11KitUri *uri);
+
+void                p11_kit_uri_set_module_path             (P11KitUri *uri,
+                                                             const char *path);
+
 void                p11_kit_uri_set_unrecognized            (P11KitUri *uri,
                                                              int unrecognized);
 


### PR DESCRIPTION
Accept and produce 'module-name' and 'module-path' query attributes
defined in RFC 7512.