### PR TITLE
rpc: New rpc_unix transport based on Unix socket

### DIFF
--- a/common/path.c
+++ b/common/path.c
@@ -38,9 +38,11 @@
 
 #include "config.h"
 
+#include "buffer.h"
 #include "debug.h"
 #include "message.h"
 #include "path.h"
+#include "url.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -324,4 +326,35 @@ p11_path_canon (char *name)
 		if (strchr (VALID, name[i]) == NULL)
 			name[i] = '_';
 	}
+}
+
+char *
+p11_path_encode (const char *path)
+{
+	static const char *VALID =
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_/\\";
+	p11_buffer buf;
+	char *result;
+
+	return_val_if_fail (path != NULL, NULL);
+
+	if (!p11_buffer_init_null (&buf, strlen (path)))
+		return_val_if_reached (NULL);
+
+	p11_url_encode ((unsigned char *)path,
+			(unsigned char *)path + strlen (path),
+			VALID,
+			&buf);
+	return_val_if_fail (p11_buffer_ok (&buf), NULL);
+
+	result = p11_buffer_steal (&buf, NULL);
+	p11_buffer_uninit (&buf);
+
+	return result;
+}
+
+char *
+p11_path_decode (const char *path)
+{
+	return (char *) p11_url_decode (path, path + strlen (path), "", NULL);
 }

--- a/common/path.h
+++ b/common/path.h
@@ -66,4 +66,8 @@ bool         p11_path_prefix    (const char *string,
 
 void         p11_path_canon     (char *name);
 
+char *       p11_path_encode    (const char *path);
+
+char *       p11_path_decode    (const char *path);
+
 #endif /* P11_PATH_H__ */

--- a/common/test-path.c
+++ b/common/test-path.c
@@ -200,6 +200,26 @@ test_canon (void)
 	free (test);
 }
 
+static void
+test_encode (void)
+{
+	char *test;
+
+	test = p11_path_encode ("2309haonutb;/AOE@#$O ");
+	assert_str_eq (test, "2309haonutb%3b/AOE%40%23%24O%20");
+	free (test);
+}
+
+static void
+test_decode (void)
+{
+	char *test;
+
+	test = p11_path_decode ("2309haonutb%3b/AOE%40%23%24O%20");
+	assert_str_eq (test, "2309haonutb;/AOE@#$O ");
+	free (test);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -211,6 +231,8 @@ main (int argc,
 	p11_test (test_parent, "/path/parent");
 	p11_test (test_prefix, "/path/prefix");
 	p11_test (test_canon, "/path/canon");
+	p11_test (test_encode, "/path/encode");
+	p11_test (test_decode, "/path/decode");
 
 	return p11_test_run (argc, argv);
 }


### PR DESCRIPTION
This is split from #15 and basically identical to https://github.com/NetworkManager/p11-kit/commit/fbd884b40f1763c1ef54d3eb41d1f4eba368a726.  The only differences are:

- rpc_unix_connect() does not return CKR_DEVICE_ERROR, so make rpc_C_Initialize() happy
- use '/' as the prefix, instead of 'unix:path=', as suggested in https://lists.freedesktop.org/archives/p11-glue/2014-November/000516.html