### PR TITLE
Fix compiler warnings on FreeBSD

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -40,6 +40,10 @@
  */
 #define _XOPEN_SOURCE 700
 
+#if defined(HAVE_ISSETUGID) && defined(__FreeBSD__)
+#define __BSD_VISIBLE 1
+#endif
+
 #include "compat.h"
 #include "debug.h"
 

--- a/common/test-message.c
+++ b/common/test-message.c
@@ -39,6 +39,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 static void
 test_with_err (void)

--- a/p11-kit/test-iter.c
+++ b/p11-kit/test-iter.c
@@ -780,7 +780,7 @@ test_slot_match_by_id (void)
 	modules = initialize_and_get_modules ();
 
 	uri = p11_kit_uri_new ();
-	ret = asprintf (&string, "pkcs11:slot-id=%lu", MOCK_SLOT_ONE_ID);
+	ret = asprintf (&string, "pkcs11:slot-id=%d", MOCK_SLOT_ONE_ID);
 	assert (ret > 0);
 	ret = p11_kit_uri_parse (string, P11_KIT_URI_FOR_SLOT, uri);
 	free (string);


### PR DESCRIPTION
 * common/compat.c: Fix "implicit declaration of function 'issetugid'"
   warning. On FreeBSD, it's required to define __BSD_VISIBLE to make
   issetugid(2) visible
 * common/test-message.c: Fix "implicit declaration of function
   'asprintf'" by including <stdio.h>
 * p11-kit/test-iter.c: Fix "format '%lu' expects argument of
   type 'long unsigned int', but argument 3 has type 'int'" by
   changing format string to "%d"