### PR TITLE
NSS attribute CKA_NSS_MOZILLA_CA_POLICY in p11-kit files

### DIFF
--- a/common/constants.c
+++ b/common/constants.c
@@ -174,7 +174,7 @@ const p11_constant p11_constant_types[] = {
 	CT (CKA_CERT_SHA1_HASH, "cert-sha1-hash")
 	CT (CKA_CERT_MD5_HASH, "cert-md5-hash")
 	CT (CKA_X_ASSERTION_TYPE, "x-assertion-type")
-	CT (CKA_X_CERTIFICATE_VALUE, "x-cetrificate-value")
+	CT (CKA_X_CERTIFICATE_VALUE, "x-certificate-value")
 	CT (CKA_X_PURPOSE, "x-purpose")
 	CT (CKA_X_PEER, "x-peer")
 	CT (CKA_X_DISTRUSTED, "x-distrusted")

--- a/common/constants.c
+++ b/common/constants.c
@@ -154,6 +154,7 @@ const p11_constant p11_constant_types[] = {
 	CT (CKA_NSS_PQG_H, "nss-pqg-h")
 	CT (CKA_NSS_PQG_SEED_BITS, "nss-pqg-seed-bits")
 	CT (CKA_NSS_MODULE_SPEC, "nss-module-spec")
+	CT (CKA_NSS_MOZILLA_CA_POLICY, "nss-mozilla-ca-policy")
 	CT (CKA_TRUST_DIGITAL_SIGNATURE, "trust-digital-signature")
 	CT (CKA_TRUST_NON_REPUDIATION, "trust-non-repudiation")
 	CT (CKA_TRUST_KEY_ENCIPHERMENT, "trust-key-encipherment")

--- a/common/pkcs11x.h
+++ b/common/pkcs11x.h
@@ -74,6 +74,7 @@ extern "C" {
 #define CKA_NSS_PQG_H                   0xce534366UL
 #define CKA_NSS_PQG_SEED_BITS           0xce534367UL
 #define CKA_NSS_MODULE_SPEC             0xce534368UL
+#define CKA_NSS_MOZILLA_CA_POLICY       0xce534372UL
 
 /* NSS trust attributes */
 #define CKA_TRUST_DIGITAL_SIGNATURE     0xce536351UL

--- a/trust/builder.c
+++ b/trust/builder.c
@@ -792,6 +792,7 @@ const static builder_schema certificate_schema = {
 	  { CKA_CERTIFICATE_TYPE, REQUIRE | CREATE, type_ulong },
 	  { CKA_TRUSTED, CREATE | WANT, type_bool },
 	  { CKA_X_DISTRUSTED, CREATE | WANT, type_bool },
+	  { CKA_NSS_MOZILLA_CA_POLICY, CREATE | WANT, type_bool },
 	  { CKA_CERTIFICATE_CATEGORY, CREATE | WANT, type_ulong },
 	  { CKA_CHECK_VALUE, CREATE | WANT, },
 	  { CKA_START_DATE, CREATE | MODIFY | WANT, type_date },

--- a/trust/persist.c
+++ b/trust/persist.c
@@ -200,6 +200,7 @@ format_bool (CK_ATTRIBUTE *attr,
 	case CKA_HAS_RESET:
 	case CKA_COLOR:
 	case CKA_X_DISTRUSTED:
+	case CKA_NSS_MOZILLA_CA_POLICY:
 		break;
 	default:
 		return false;


### PR DESCRIPTION
Support loading new NSS attribute CKA_NSS_MOZILLA_CA_POLICY from .p11-kit files.
See also NSS bug https://bugzilla.mozilla.org/show_bug.cgi?id=1334976
and p11-kit bug https://bugs.freedesktop.org/show_bug.cgi?id=99453
