### PR TITLE
trust: Revert to the original 'extract' behavior

### DIFF
--- a/trust/extract.c
+++ b/trust/extract.c
@@ -285,6 +285,7 @@ p11_trust_extract (int argc,
 	if (!p11_enumerate_ready (&ex, "ca-anchors"))
 		exit (1);
 
+	ex.flags |= P11_ENUMERATE_CORRELATE;
 	ret = (format) (&ex, argv[0]) ? 0 : 1;
 
 	p11_enumerate_cleanup (&ex);


### PR DESCRIPTION
Since commit f4384a40, due to a missing ex->flags setting, the 'trust
extract' command didn't retrieve correlation between related objects and
that was causing assertion failure when writing PEM files.

https://bugs.freedesktop.org/show_bug.cgi?id=99795