### PR TITLE
virtual: Move mutex into p11_library_init()

### DIFF
--- a/common/library.c
+++ b/common/library.c
@@ -59,6 +59,8 @@ static p11_local * _p11_library_get_thread_local (void);
 
 p11_mutex_t p11_library_mutex;
 
+p11_mutex_t p11_virtual_mutex;
+
 #ifdef OS_UNIX
 pthread_once_t p11_library_once = PTHREAD_ONCE_INIT;
 #endif
@@ -118,6 +120,7 @@ p11_library_init_impl (void)
 	p11_debug_init ();
 	p11_debug ("initializing library");
 	p11_mutex_init (&p11_library_mutex);
+	p11_mutex_init (&p11_virtual_mutex);
 	pthread_key_create (&thread_local, free);
 	p11_message_storage = thread_local_message;
 

--- a/common/library.h
+++ b/common/library.h
@@ -44,6 +44,9 @@
 
 extern p11_mutex_t p11_library_mutex;
 
+/* Used in virtual.c to maintain the global list of precompiled closures */
+extern p11_mutex_t p11_virtual_mutex;
+
 extern unsigned int p11_forkid;
 
 #define       p11_lock()                   p11_mutex_lock (&p11_library_mutex);

--- a/p11-kit/util.c
+++ b/p11-kit/util.c
@@ -45,7 +45,6 @@
 #include "p11-kit.h"
 #include "private.h"
 #include "proxy.h"
-#include "virtual-fixed.h"
 
 #include <assert.h>
 #include <stdarg.h>
@@ -252,7 +251,6 @@ void
 _p11_kit_init (void)
 {
 	p11_library_init_once ();
-	p11_virtual_fixed_init ();
 }
 
 #ifdef __GNUC__
@@ -262,7 +260,6 @@ void
 _p11_kit_fini (void)
 {
 	p11_proxy_module_cleanup ();
-	p11_virtual_fixed_uninit ();
 	p11_library_uninit ();
 }
 
@@ -280,14 +277,12 @@ DllMain (HINSTANCE instance,
 	switch (reason) {
 	case DLL_PROCESS_ATTACH:
 		p11_library_init ();
-		p11_virtual_fixed_init ();
 		break;
 	case DLL_THREAD_DETACH:
 		p11_library_thread_cleanup ();
 		break;
 	case DLL_PROCESS_DETACH:
 		p11_proxy_module_cleanup ();
-		p11_virtual_fixed_uninit ();
 		p11_library_uninit ();
 		break;
 	default:

--- a/p11-kit/virtual-fixed.h
+++ b/p11-kit/virtual-fixed.h
@@ -1138,7 +1138,4 @@ fixed ## fixed_index ## _C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list) \
 	fixed ## fixed_index ## _C_WaitForSlotEvent \
 }
 
-void                    p11_virtual_fixed_init   (void);
-void                    p11_virtual_fixed_uninit (void);
-
 #endif /* __P11_VIRTUAL_FIXED_H__ */


### PR DESCRIPTION
We used to provide p11_virtual_fixed_{,un}init() to only initialize a
mutex used in virtual.c.  That required all the tests calling virtual
functions to call p11_virtual_fixed_{,un}init() in main().

For simplicity, move the mutex variable initialization into
p11_library_init().