### PR TITLE
trust: Honor "modifiable" setting in persist file

### DIFF
--- a/trust/input/verisign-v1.p11-kit
+++ b/trust/input/verisign-v1.p11-kit
@@ -1,5 +1,6 @@
 [p11-kit-object-v1]
 trusted: true
+modifiable: false
 
 -----BEGIN CERTIFICATE-----
 MIICPDCCAaUCED9pHoGc8JpK83P/uUii5N0wDQYJKoZIhvcNAQEFBQAwXzELMAkG

--- a/trust/parser.c
+++ b/trust/parser.c
@@ -610,6 +610,7 @@ p11_parser_format_persist (p11_parser *parser,
 {
 	CK_BBOOL modifiablev = CK_TRUE;
 	CK_ATTRIBUTE *attrs;
+	CK_ATTRIBUTE *attr;
 	p11_array *objects;
 	bool ret;
 	int i;
@@ -630,7 +631,14 @@ p11_parser_format_persist (p11_parser *parser,
 	ret = p11_persist_read (parser->persist, parser->basename, data, length, objects);
 	if (ret) {
 		for (i = 0; i < objects->num; i++) {
-			attrs = p11_attrs_build (objects->elem[i], &modifiable, NULL);
+			/* By default, we mark objects read from a persist
+			 * file as modifiable, as the persist format is
+			 * writable.  However, if CKA_MODIFIABLE is explictly
+			 * set in the file, respect the setting.  */
+			attrs = objects->elem[i];
+			attr = p11_attrs_find_valid (objects->elem[i], CKA_MODIFIABLE);
+			if (!attr)
+				attrs = p11_attrs_build (attrs, &modifiable, NULL);
 			sink_object (parser, attrs);
 		}
 	}

--- a/trust/test-parser.c
+++ b/trust/test-parser.c
@@ -168,6 +168,7 @@ test_parse_p11_kit_persist (void)
 		{ CKA_CLASS, &certificate, sizeof (certificate) },
 		{ CKA_VALUE, (void *)verisign_v1_ca, sizeof (verisign_v1_ca) },
 		{ CKA_TRUSTED, &truev, sizeof (truev) },
+		{ CKA_MODIFIABLE, &falsev, sizeof (falsev) },
 		{ CKA_X_DISTRUSTED, &falsev, sizeof (falsev) },
 		{ CKA_INVALID },
 	};


### PR DESCRIPTION
Previously, all objects read from p11-kit persist files are marked as
modifiable when parsing, regardless of the explicit "modifiable: false"
setting in the file.

Reported by Kai Engert in:
https://bugs.freedesktop.org/show_bug.cgi?id=99797