### PR TITLE
remote: Fix typo when writing a credential byte

### DIFF
--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -1953,7 +1953,7 @@ p11_kit_remote_serve_module (CK_FUNCTION_LIST *module,
 	}
 
 	version = 0;
-	switch (write (out_fd, &version, out_fd)) {
+	switch (write (out_fd, &version, 1)) {
 	case 1:
 		break;
 	default:


### PR DESCRIPTION
out_fd is not always 1 when p11_kit_remote_serve_module() is used for
writing a custom server.