### PR TITLE
trust: Check magic comment in persist file for modifiablity

### DIFF
--- a/trust/input/verisign-v1.p11-kit
+++ b/trust/input/verisign-v1.p11-kit
@@ -1,6 +1,5 @@
 [p11-kit-object-v1]
 trusted: true
-modifiable: false
 
 -----BEGIN CERTIFICATE-----
 MIICPDCCAaUCED9pHoGc8JpK83P/uUii5N0wDQYJKoZIhvcNAQEFBQAwXzELMAkG

--- a/trust/parser.c
+++ b/trust/parser.c
@@ -49,6 +49,7 @@
 #include "pem.h"
 #include "pkcs11x.h"
 #include "persist.h"
+#include "types.h"
 #include "x509.h"
 
 #include <libtasn1.h>
@@ -630,7 +631,10 @@ p11_parser_format_persist (p11_parser *parser,
 	ret = p11_persist_read (parser->persist, parser->basename, data, length, objects);
 	if (ret) {
 		for (i = 0; i < objects->num; i++) {
-			attrs = p11_attrs_build (objects->elem[i], &modifiable, NULL);
+			CK_BBOOL generatedv;
+			attrs = objects->elem[i];
+			if (p11_attrs_find_bool (attrs, CKA_X_GENERATED, &generatedv) && generatedv)
+				attrs = p11_attrs_build (attrs, &modifiable, NULL);
 			sink_object (parser, attrs);
 		}
 	}

--- a/trust/parser.c
+++ b/trust/parser.c
@@ -610,7 +610,6 @@ p11_parser_format_persist (p11_parser *parser,
 {
 	CK_BBOOL modifiablev = CK_TRUE;
 	CK_ATTRIBUTE *attrs;
-	CK_ATTRIBUTE *attr;
 	p11_array *objects;
 	bool ret;
 	int i;
@@ -631,14 +630,7 @@ p11_parser_format_persist (p11_parser *parser,
 	ret = p11_persist_read (parser->persist, parser->basename, data, length, objects);
 	if (ret) {
 		for (i = 0; i < objects->num; i++) {
-			/* By default, we mark objects read from a persist
-			 * file as modifiable, as the persist format is
-			 * writable.  However, if CKA_MODIFIABLE is explictly
-			 * set in the file, respect the setting.  */
-			attrs = objects->elem[i];
-			attr = p11_attrs_find_valid (objects->elem[i], CKA_MODIFIABLE);
-			if (!attr)
-				attrs = p11_attrs_build (attrs, &modifiable, NULL);
+			attrs = p11_attrs_build (objects->elem[i], &modifiable, NULL);
 			sink_object (parser, attrs);
 		}
 	}

--- a/trust/persist.c
+++ b/trust/persist.c
@@ -631,6 +631,9 @@ p11_persist_read (p11_persist *persist,
 	CK_ATTRIBUTE *attrs;
 	bool failed;
 	bool skip;
+	CK_BBOOL generatedv = CK_FALSE;
+	CK_ATTRIBUTE generated = { CKA_X_GENERATED, &generatedv, sizeof (generatedv) };
+	static const char comment[] = "# This file has been auto-generated and written by p11-kit.";
 
 	return_val_if_fail (persist != NULL, false);
 	return_val_if_fail (objects != NULL, false);
@@ -638,6 +641,10 @@ p11_persist_read (p11_persist *persist,
 	skip = false;
 	attrs = NULL;
 	failed = false;
+
+	if (length >= sizeof (comment) - 1 &&
+	    memcmp ((const char *)data, comment, sizeof (comment) - 1) == 0)
+		generatedv = CK_TRUE;
 
 	p11_lexer_init (&lexer, filename, (const char *)data, length);
 	while (p11_lexer_next (&lexer, &failed)) {
@@ -650,7 +657,7 @@ p11_persist_read (p11_persist *persist,
 				p11_lexer_msg (&lexer, "unrecognized or invalid section header");
 				skip = true;
 			} else {
-				attrs = p11_attrs_build (NULL, NULL);
+				attrs = p11_attrs_build (NULL, &generated, NULL);
 				return_val_if_fail (attrs != NULL, false);
 				skip = false;
 			}

--- a/trust/test-parser.c
+++ b/trust/test-parser.c
@@ -168,7 +168,6 @@ test_parse_p11_kit_persist (void)
 		{ CKA_CLASS, &certificate, sizeof (certificate) },
 		{ CKA_VALUE, (void *)verisign_v1_ca, sizeof (verisign_v1_ca) },
 		{ CKA_TRUSTED, &truev, sizeof (truev) },
-		{ CKA_MODIFIABLE, &falsev, sizeof (falsev) },
 		{ CKA_X_DISTRUSTED, &falsev, sizeof (falsev) },
 		{ CKA_INVALID },
 	};

--- a/trust/test-token.c
+++ b/trust/test-token.c
@@ -610,6 +610,7 @@ static void
 test_modify_multiple (void)
 {
 	const char *test_data =
+		"# This file has been auto-generated and written by p11-kit.\n"
 		"[p11-kit-object-v1]\n"
 		"class: data\n"
 		"label: \"first\"\n"


### PR DESCRIPTION
This supersedes #66.

A persistent file written by the trust module starts with the line "#
This file has been auto-generated and written by p11-kit".  This can
be used as a magic word to determine whether the objects read from a
.p11-kit file are read-only.