### PR TITLE
trust: Simplify the check for the magic

### DIFF
--- a/trust/parser.c
+++ b/trust/parser.c
@@ -630,11 +630,10 @@ p11_parser_format_persist (p11_parser *parser,
 
 	ret = p11_persist_read (parser->persist, parser->basename, data, length, objects);
 	if (ret) {
+		if (!p11_persist_is_generated (data, length))
+			modifiablev = CK_FALSE;
 		for (i = 0; i < objects->num; i++) {
-			CK_BBOOL generatedv;
-			attrs = objects->elem[i];
-			if (p11_attrs_find_bool (attrs, CKA_X_GENERATED, &generatedv) && generatedv)
-				attrs = p11_attrs_build (attrs, &modifiable, NULL);
+			attrs = p11_attrs_build (objects->elem[i], &modifiable, NULL);
 			sink_object (parser, attrs);
 		}
 	}

--- a/trust/persist.h
+++ b/trust/persist.h
@@ -60,4 +60,7 @@ bool             p11_persist_write  (p11_persist *persist,
 
 void             p11_persist_free   (p11_persist *persist);
 
+bool             p11_persist_is_generated (const unsigned char *data,
+					   size_t length);
+
 #endif /* P11_PERSIST_H_ */


### PR DESCRIPTION
Instead of reusing the CKA_X_GENERATED attribute, check the file
contents directly in the caller side.