### PR TITLE
rpc: Convert mechanism parameters for portability

### DIFF
--- a/common/pkcs11.h
+++ b/common/pkcs11.h
@@ -179,6 +179,7 @@ extern "C" {
 #define ck_rsa_pkcs_mgf_type_t CK_RSA_PKCS_MGF_TYPE
 #define ck_rsa_pkcs_oaep_source_type_t CK_RSA_PKCS_OAEP_SOURCE_TYPE
 #define hash_alg hashAlg
+#define s_len sLen
 #define source_data pSourceData
 #define source_data_len ulSourceDataLen
 
@@ -745,6 +746,13 @@ struct ck_mechanism_info
 #define CKG_MGF1_SHA512 0x00000004UL
 
 typedef unsigned long ck_rsa_pkcs_mgf_type_t;
+
+struct ck_rsa_pkcs_pss_params {
+  ck_mechanism_type_t hash_alg;
+  ck_rsa_pkcs_mgf_type_t mgf;
+  unsigned long s_len;
+};
+
 typedef unsigned long ck_rsa_pkcs_oaep_source_type_t;
 
 struct ck_rsa_pkcs_oaep_params {
@@ -1324,6 +1332,9 @@ typedef struct ck_function_list **CK_FUNCTION_LIST_PTR_PTR;
 
 typedef struct ck_c_initialize_args CK_C_INITIALIZE_ARGS;
 typedef struct ck_c_initialize_args *CK_C_INITIALIZE_ARGS_PTR;
+
+typedef struct ck_rsa_pkcs_pss_params CK_RSA_PKCS_PSS_PARAMS;
+typedef struct ck_rsa_pkcs_pss_params *CK_RSA_PKCS_PSS_PARAMS_PTR;
 
 typedef struct ck_rsa_pkcs_oaep_params CK_RSA_PKCS_OAEP_PARAMS;
 typedef struct ck_rsa_pkcs_oaep_params *CK_RSA_PKCS_OAEP_PARAMS_PTR;

--- a/common/pkcs11.h
+++ b/common/pkcs11.h
@@ -738,6 +738,12 @@ struct ck_mechanism_info
   ck_flags_t flags;
 };
 
+#define CKG_MGF1_SHA1 0x00000001UL
+#define CKG_MGF1_SHA224 0x00000005UL
+#define CKG_MGF1_SHA256 0x00000002UL
+#define CKG_MGF1_SHA384 0x00000003UL
+#define CKG_MGF1_SHA512 0x00000004UL
+
 typedef unsigned long ck_rsa_pkcs_mgf_type_t;
 typedef unsigned long ck_rsa_pkcs_oaep_source_type_t;
 
@@ -1319,7 +1325,7 @@ typedef struct ck_function_list **CK_FUNCTION_LIST_PTR_PTR;
 typedef struct ck_c_initialize_args CK_C_INITIALIZE_ARGS;
 typedef struct ck_c_initialize_args *CK_C_INITIALIZE_ARGS_PTR;
 
-typedef struct ck_rsa_pkcs_oaep_params CK_RSA_PKCS_OAEP_PARAM;
+typedef struct ck_rsa_pkcs_oaep_params CK_RSA_PKCS_OAEP_PARAMS;
 typedef struct ck_rsa_pkcs_oaep_params *CK_RSA_PKCS_OAEP_PARAMS_PTR;
 
 #define NULL_PTR NULL

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -980,7 +980,7 @@ p11_rpc_buffer_add_date_value (p11_buffer *buffer,
 	unsigned char array[8];
 
 	/* Check if value can be converted to CK_DATE. */
-	if (value_length > sizeof (CK_DATE)) {
+	if (value_length != sizeof (CK_DATE)) {
 		p11_buffer_fail (buffer);
 		return;
 	}

--- a/p11-kit/rpc-message.h
+++ b/p11-kit/rpc-message.h
@@ -444,4 +444,35 @@ bool             p11_rpc_buffer_get_byte_array_value     (p11_buffer *buffer,
 							  void *value,
 							  CK_ULONG *value_length);
 
+bool             p11_rpc_mechanism_is_supported          (CK_MECHANISM_TYPE mech);
+
+void             p11_rpc_buffer_add_mechanism            (p11_buffer *buffer,
+							  const CK_MECHANISM *mech);
+
+bool             p11_rpc_buffer_get_mechanism            (p11_buffer *buffer,
+							  size_t *offset,
+							  CK_MECHANISM *mech);
+
+void             p11_rpc_buffer_add_rsa_pkcs_pss_mechanism_value
+                                                         (p11_buffer *buffer,
+							  const void *value,
+							  CK_ULONG value_length);
+
+bool             p11_rpc_buffer_get_rsa_pkcs_pss_mechanism_value
+                                                         (p11_buffer *buffer,
+							  size_t *offset,
+							  void *value,
+							  CK_ULONG *value_length);
+
+void             p11_rpc_buffer_add_rsa_pkcs_oaep_mechanism_value
+                                                          (p11_buffer *buffer,
+							   const void *value,
+							   CK_ULONG value_length);
+
+bool             p11_rpc_buffer_get_rsa_pkcs_oaep_mechanism_value
+                                                          (p11_buffer *buffer,
+							   size_t *offset,
+							   void *value,
+							   CK_ULONG *value_length);
+
 #endif /* _RPC_MESSAGE_H */

--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -305,6 +305,7 @@ proto_read_attribute_array (p11_rpc_message *msg,
 		size_t offset = msg->parsed;
 		CK_ATTRIBUTE temp;
 
+		/* Check the length needed to store the value */
 		memset (&temp, 0, sizeof (temp));
 		if (!p11_rpc_buffer_get_attribute (msg->input, &offset, &temp)) {
 			msg->parsed = offset;


### PR DESCRIPTION
This is similar to commit #67, but for mechanism parameters.