### PR TITLE
Add Solaris support

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -278,12 +278,6 @@ p11_dl_error (void)
 	return msg_buf;
 }
 
-void
-p11_dl_close (void *dl)
-{
-	FreeLibrary (dl);
-}
-
 int
 p11_thread_create (p11_thread_t *thread,
                    p11_thread_routine routine,
@@ -860,6 +854,17 @@ strerror_r (int errnum,
 }
 
 #endif /* HAVE_STRERROR_R */
+
+void
+p11_dl_close (void *dl)
+{
+#ifdef OS_WIN32
+	FreeLibrary (dl);
+#else
+	(void) dlclose (dl);
+#endif
+}
+
 
 #ifdef OS_UNIX
 

--- a/common/compat.h
+++ b/common/compat.h
@@ -91,6 +91,8 @@ char *       mkdtemp     (char *template);
 
 char *       strdup_path_mangle (const char *template);
 
+void         p11_dl_close       (void * dl);
+
 /* -----------------------------------------------------------------------------
  * WIN32
  */
@@ -146,8 +148,6 @@ typedef HMODULE dl_module_t;
 	((void *)GetProcAddress ((d), (s)))
 
 char *    p11_dl_error       (void);
-
-void      p11_dl_close       (void * dl);
 
 #define p11_sleep_ms(ms) \
 	(Sleep (ms))
@@ -206,8 +206,6 @@ typedef void * dl_module_t;
 
 #define p11_dl_open(f) \
 	(dlopen ((f), RTLD_LOCAL | RTLD_NOW))
-#define p11_dl_close \
-	dlclose
 #define p11_dl_symbol(d, s) \
 	(dlsym ((d), (s)))
 

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ if test "$os_unix" = "yes"; then
 	])
 
 	# These are thngs we can work around
-	AC_CHECK_HEADERS([locale.h sys/resource.h])
+	AC_CHECK_HEADERS([locale.h sys/resource.h ucred.h])
 	AC_CHECK_MEMBERS([struct dirent.d_type],,,[#include <dirent.h>])
 	AC_CHECK_FUNCS([getprogname getexecname basename mkstemp mkdtemp])
 	AC_CHECK_FUNCS([getauxval issetugid getresuid secure_getenv])
@@ -104,6 +104,7 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([fdwalk])
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])
+	AC_CHECK_FUNCS([getpeerucred])
 
 	# Required functions
 	AC_CHECK_FUNCS([gmtime_r],

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,13 @@ if test "$os_unix" = "yes"; then
 		AC_MSG_ERROR([could not find dlopen])
 	])
 
+	# for Solaris we need -lsocket -lnsl for socket stuff, gethostbyname
+	# is just a dummy to find -lnsl
+	AC_SEARCH_LIBS([gethostbyname], [nsl])
+	AC_SEARCH_LIBS([connect], [socket], [], [
+		AC_MSG_ERROR([could not find socket])
+	])
+
 	# These are thngs we can work around
 	AC_CHECK_HEADERS([locale.h sys/resource.h])
 	AC_CHECK_MEMBERS([struct dirent.d_type],,,[#include <dirent.h>])


### PR DESCRIPTION
These commits add support for compilation on Solaris-like platforms.  We need some special libs for socket funcs, a slightly different invocation of getpwnam_r, we can use ucred for p11_get_upeer_id, and we need to work around a linkage problem with dlclose.