### PR TITLE
Allow use of _GNU_SOURCE

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -40,10 +40,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef _GNU_SOURCE
-#error Make the crap stop. _GNU_SOURCE is completely unportable and breaks all sorts of behavior
-#endif
-
 #if !defined(__cplusplus) && (__GNUC__ > 2)
 #define GNUC_PRINTF(x, y) __attribute__((__format__(__printf__, x, y)))
 #else

--- a/common/debug.h
+++ b/common/debug.h
@@ -56,6 +56,11 @@ void              p11_debug_message             (int flag,
                                                  const char *format,
                                                  ...) GNUC_PRINTF (2, 3);
 
+void              p11_debug_message_err         (int flag,
+						 int errnum,
+                                                 const char *format,
+                                                 ...) GNUC_PRINTF (3, 4);
+
 void              p11_debug_precond             (const char *format,
                                                  ...) GNUC_PRINTF (1, 2)
                                                  CLANG_ANALYZER_NORETURN;
@@ -127,14 +132,20 @@ void              p11_debug_precond             (const char *format,
 		p11_debug_message (P11_DEBUG_FLAG, "%s: " format, __PRETTY_FUNCTION__, ##__VA_ARGS__); \
 	} while (0)
 
+#undef p11_debug_err
+#define p11_debug_err(errnum, format, ...) do {	      \
+	if (P11_DEBUG_FLAG & p11_debug_current_flags) \
+		p11_debug_message_err (P11_DEBUG_FLAG, errnum, "%s: " format, __PRETTY_FUNCTION__, ##__VA_ARGS__); \
+	} while (0)
+
 #undef p11_debugging
 #define p11_debugging \
 	(P11_DEBUG_FLAG & p11_debug_current_flags)
 
 #else /* !defined (WITH_DEBUG) */
 
-#undef p11_debug
-#define p11_debug(format, ...) \
+#undef p11_debug_err
+#define p11_debug_err(errnum, format, ...) \
 	do {} while (false)
 
 #undef p11_debugging

--- a/common/unix-peer.c
+++ b/common/unix-peer.c
@@ -34,11 +34,6 @@
 
 #include "config.h"
 
-/* needed for struct ucred */
-#if defined(__linux__) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
-
 #include "unix-peer.h"
 
 #include <unistd.h>

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,9 @@ AM_SANITY_CHECK
 AM_MAINTAINER_MODE([enable])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],)
 
+dnl Enable platform specific extensions.
+AC_USE_SYSTEM_EXTENSIONS
+
 LT_PREREQ([2.2.6])
 LT_INIT([dlopen disable-static])
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,11 +86,11 @@ if test "$os_unix" = "yes"; then
 	])
 
 	# These are thngs we can work around
-	AC_CHECK_HEADERS([sys/resource.h])
+	AC_CHECK_HEADERS([locale.h sys/resource.h])
 	AC_CHECK_MEMBERS([struct dirent.d_type],,,[#include <dirent.h>])
 	AC_CHECK_FUNCS([getprogname getexecname basename mkstemp mkdtemp])
 	AC_CHECK_FUNCS([getauxval issetugid getresuid secure_getenv])
-	AC_CHECK_FUNCS([strnstr memdup strndup strerror_r])
+	AC_CHECK_FUNCS([strnstr memdup strndup strerror_l strerror_r])
 	AC_CHECK_FUNCS([fdwalk])
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])

--- a/p11-kit/rpc-transport.c
+++ b/p11-kit/rpc-transport.c
@@ -1065,7 +1065,7 @@ rpc_unix_connect (p11_rpc_client_vtable *vtable,
 	}
 
 	if (connect (fd, (struct sockaddr *)&run->sa, sizeof (run->sa)) < 0) {
-		p11_debug ("failed to connect to socket: %s", strerror (errno));
+		p11_debug_err (errno, "failed to connect to socket");
 		close (fd);
 		return CKR_DEVICE_REMOVED;
 	}


### PR DESCRIPTION
In commit 6b457ffc ```_GNU_SOURCE``` was disabled for the incompatibility of ```strerror_r```.
However, given that all the uses of ```strerror_r``` can easily be replaced with a more preferable ```strerror_l```, it has no point to keep it disabled.

Related to #81.