### PR TITLE
Be silent by default and do not print messages on stderr

### DIFF
--- a/common/message.c
+++ b/common/message.c
@@ -58,7 +58,7 @@
 #include <stdio.h>
 #include <string.h>
 
-static bool print_messages = true;
+static bool print_messages = false;
 
 static char *
 default_message_storage (void)


### PR DESCRIPTION
As p11-kit is a library there are cases where it is not desirable
to log on stderr by default. See for example this report
https://bugzilla.redhat.com/show_bug.cgi?id=1464490
where wget prints an error due to an unconfigured pkcs11 module.

Signed-off-by: Nikos Mavrogiannopoulos <nmav@redhat.com>