### PR TITLE
conf: Introduce P11_KIT_NO_USER_CONFIG

### DIFF
--- a/p11-kit/conf.c
+++ b/p11-kit/conf.c
@@ -228,9 +228,15 @@ _p11_conf_load_globals (const char *system_conf, const char *user_conf,
 		goto finished;
 	}
 
-	if (mode != CONF_USER_NONE && getauxval (AT_SECURE)) {
-		p11_debug ("skipping user config in setuid or setgid program");
-		mode = CONF_USER_NONE;
+	if (mode != CONF_USER_NONE) {
+		if (getauxval (AT_SECURE)) {
+			p11_debug ("skipping user config in setuid or setgid program");
+			mode = CONF_USER_NONE;
+		} else if (secure_getenv ("P11_KIT_NO_USER_CONFIG")) {
+			/* This one should be used in RPM %post and equivalent */
+			p11_debug ("skipping user config due to P11_NO_USER_CONFIG");
+			mode = CONF_USER_NONE;
+		}
 	}
 
 	if (mode != CONF_USER_NONE) {


### PR DESCRIPTION
Currently `ca-certificates.spec` in Fedora ends up doing in `%post`:
```
/usr/bin/p11-kit extract --format=openssl-bundle --filter=certificates --overwrite --comment $DEST/openssl/ca-bundle.trust.crt
```
etc.

And due to this bit of code in p11-kit, we end up looking for the home
directory for configuration.  In "traditional" dnf/yum, that'd be `/root`.

It's categorically wrong to do this; the root user is distinct from
"the system".  This issue is equivalent to one I fixed in Pango:
https://git.gnome.org/browse/pango/commit/?id=aecbe27c1b08f517c0e05f03308d3ac55cef490c

Fast forward to today, and the reason I'm making this change is I'm working on
`rpm-ostree ex container`, which builds containers as *non-root* (like
gnome-continuous does, but now with RPMs), keeping the invoking uid. And this
bug causes the `ca-certificates` `%post` to fail because it's trying to look for
my uid 1000 which doesn't exist in the target rootfs' password database.

Again, there's no reason to be looking for a home directory for system triggers,
regadless of UID, so once this patch lands, I'll update `ca-certificates` to use
it, and traditional RPM `%post` will stop looking in `/root` too.