### PR TITLE
uri: Make vendor query attribute handling reliable

### DIFF
--- a/common/array.c
+++ b/common/array.c
@@ -49,13 +49,16 @@ maybe_expand_array (p11_array *array,
 		return true;
 
 
-	new_allocated = array->allocated * 2;
-	if (new_allocated == 0)
+	if (array->allocated == 0)
 		new_allocated = 16;
+	else {
+		return_val_if_fail (SIZE_MAX / array->allocated >= 2, false);
+		new_allocated = array->allocated * 2;
+	}
 	if (new_allocated < length)
 		new_allocated = length;
 
-	new_memory = realloc (array->elem, new_allocated * sizeof (void*));
+	new_memory = reallocarray (array->elem, new_allocated, sizeof (void*));
 	return_val_if_fail (new_memory != NULL, false);
 
 	array->elem = new_memory;

--- a/common/array.c
+++ b/common/array.c
@@ -107,6 +107,22 @@ p11_array_push (p11_array *array,
 	return true;
 }
 
+bool
+p11_array_insert (p11_array *array,
+		  unsigned int index,
+		  void *value)
+{
+	return_val_if_fail (index <= array->num, false);
+	if (!maybe_expand_array (array, array->num + 1))
+		return_val_if_reached (false);
+
+	memmove (array->elem + index + 1, array->elem + index,
+	         (array->num - index) * sizeof (void*));
+	array->elem[index] = value;
+	array->num++;
+	return true;
+}
+
 void
 p11_array_remove (p11_array *array,
                   unsigned int index)

--- a/common/array.h
+++ b/common/array.h
@@ -60,6 +60,10 @@ void                 p11_array_free               (p11_array *array);
 bool                 p11_array_push               (p11_array *array,
                                                    void *value);
 
+bool                 p11_array_insert             (p11_array *array,
+						   unsigned int index,
+						   void *value);
+
 void                 p11_array_remove             (p11_array *array,
                                                    unsigned int index);
 

--- a/common/attrs.c
+++ b/common/attrs.c
@@ -101,12 +101,15 @@ attrs_build (CK_ATTRIBUTE *attrs,
 	CK_ULONG at;
 	CK_ULONG j;
 	CK_ULONG i;
+	size_t length;
 
 	/* How many attributes we already have */
 	current = p11_attrs_count (attrs);
 
 	/* Reallocate for how many we need */
-	attrs = realloc (attrs, (current + count_to_add + 1) * sizeof (CK_ATTRIBUTE));
+	length = current + count_to_add;
+	return_val_if_fail (current <= length && length < SIZE_MAX, NULL);
+	attrs = reallocarray (attrs, length + 1, sizeof (CK_ATTRIBUTE));
 	return_val_if_fail (attrs != NULL, NULL);
 
 	at = current;

--- a/common/compat.c
+++ b/common/compat.c
@@ -487,6 +487,23 @@ strndup (const char *data,
 
 #endif /* HAVE_STRNDUP */
 
+#ifndef HAVE_REALLOCARRAY
+
+void *
+reallocarray (void *ptr,
+	      size_t nmemb,
+	      size_t size)
+{
+	assert (nmemb > 0 && size > 0);
+	if (SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc (ptr, nmemb * size);
+}
+
+#endif /* HAVE_MEMDUP */
+
 #ifndef HAVE_STRCONCAT
 
 #include <stdarg.h>

--- a/common/compat.h
+++ b/common/compat.h
@@ -258,6 +258,14 @@ char *     strndup          (const char *data,
 
 #endif /* HAVE_STRDUP */
 
+#ifndef HAVE_REALLOCARRAY
+
+void *     reallocarray     (void *ptr,
+                             size_t nmemb,
+                             size_t size);
+
+#endif /* HAVE_REALLOCARRAY */
+
 #ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
 #else

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([getprogname getexecname basename mkstemp mkdtemp])
 	AC_CHECK_FUNCS([getauxval issetugid getresuid secure_getenv])
 	AC_CHECK_FUNCS([strnstr memdup strndup strerror_l strerror_r])
+	AC_CHECK_FUNCS([reallocarray])
 	AC_CHECK_FUNCS([fdwalk])
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])

--- a/p11-kit/test-uri.c
+++ b/p11-kit/test-uri.c
@@ -1542,6 +1542,16 @@ test_uri_vendor_query (void)
 	ret = p11_kit_uri_set_vendor_query (uri, "my-query-three", NULL);
 	assert_num_eq (0, ret);
 
+	/* Check if duplicate vendor query attributes are accepted and
+	 * sorted alphabetically.  */
+	ret = p11_kit_uri_parse ("pkcs11:?bbb=zzz&aaa=xxx&aaa=yyy", P11_KIT_URI_FOR_ANY, uri);
+	assert_num_eq (P11_KIT_URI_OK, ret);
+
+	ret = p11_kit_uri_format (uri, P11_KIT_URI_FOR_ANY, &string);
+	assert_num_eq (P11_KIT_URI_OK, ret);
+	assert_str_eq ("pkcs11:?aaa=xxx&aaa=yyy&bbb=zzz", string);
+	free (string);
+
 	p11_kit_uri_free (uri);
 }
 


### PR DESCRIPTION
Previously we used p11_dict to keep track of vendor query attributes.
This had a couple of limitations: duplicate attributes are not allowed while they are actually allowed in RFC 7512, and the order of attributes is unpredictable.

This patch switches to using an array instead of p11_dict and ensures that the attributes are sorted in alphabetical order.

Fixes #88.