### PR TITLE
client: Fix order of cleanup

### DIFF
--- a/p11-kit/client.c
+++ b/p11-kit/client.c
@@ -220,7 +220,7 @@ p11_client_module_cleanup (void)
 
 	for (; state != NULL; state = next) {
 		next = state->next;
-		p11_virtual_unwrap (state->wrapped);
 		p11_rpc_transport_free (state->rpc);
+		p11_virtual_unwrap (state->wrapped);
 	}
 }


### PR DESCRIPTION
In C_GetFunctionList, state->virt is wrapped with a destroyer function
free().  Thus p11_rpc_transport_free must be called before
p11_virtual_unwrap.