### PR TITLE
common: Re-add placeholder definition of p11_debug

### DIFF
--- a/common/debug.h
+++ b/common/debug.h
@@ -144,6 +144,10 @@ void              p11_debug_precond             (const char *format,
 
 #else /* !defined (WITH_DEBUG) */
 
+#undef p11_debug
+#define p11_debug(format, ...) \
+	do {} while (false)
+
 #undef p11_debug_err
 #define p11_debug_err(errnum, format, ...) \
 	do {} while (false)


### PR DESCRIPTION
This was mistakenly removed in commit efe6dc56c.
Pointed by Lars Wendler in issue #97.