### PR TITLE
trust: Respect anyExtendedKeyUsage in CA certificates

### DIFF
--- a/trust/enumerate.c
+++ b/trust/enumerate.c
@@ -374,6 +374,11 @@ on_iterate_load_filter (p11_kit_iter *iter,
 	if (ex->limit_to_purposes && ex->purposes) {
 		*matches = CK_FALSE;
 		for (i = 0; i < ex->purposes->num; i++) {
+			if (strcmp (ex->purposes->elem[i], P11_OID_ANY_EXTENDED_KEY_USAGE_STR) == 0) {
+				p11_debug ("anyExtendedKeyUsage is set, skipping filtering by purposes");
+				*matches = CK_TRUE;
+				break;
+			}
 			if (p11_dict_get (ex->limit_to_purposes, ex->purposes->elem[i])) {
 				*matches = CK_TRUE;
 				break;

--- a/trust/oid.h
+++ b/trust/oid.h
@@ -118,6 +118,15 @@ static const unsigned char P11_OID_EXTENDED_KEY_USAGE[] =
 static const char P11_OID_EXTENDED_KEY_USAGE_STR[] = "2.5.29.37";
 
 /*
+ * 2.5.29.37.0: anyExtendedKeyUsage
+ *
+ * Defined in RFC 5280
+ */
+static const unsigned char P11_OID_ANY_EXTENDED_KEY_USAGE[] =
+	{ 0x06, 0x03, 0x55, 0x1d, 0x25, 0x00 };
+static const char P11_OID_ANY_EXTENDED_KEY_USAGE_STR[] = "2.5.29.37.0";
+
+/*
  * 1.3.6.1.4.1.3319.6.10.1: OpenSSL reject extension
  *
  * An internally defined certificate extension.


### PR DESCRIPTION
A CA certificate can include anyExtendedKeyUsage (2.5.29.37.0) in the extended key usage extension, if the CA doesn't want to restrict usages of the key.   However, previously the trust module treated it as a custom key purpose and failed to match if the search criteria included a key purpose.