### PR TITLE
Include stdint.h for SIZE_MAX

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -52,6 +52,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 /*-


### PR DESCRIPTION
On some systems (e.g. FreeBSD 10.x) build fails with:

common/compat.c:498:6: error: use of undeclared identifier 'SIZE_MAX'
        if (SIZE_MAX / nmemb < size) {

Fix by including stdint.h.