### PR TITLE
       server: Better shell integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,7 @@ install:
 script:
   - docker exec $CONTAINER sh -c "cd /srcdir && NOCONFIGURE=1 ./autogen.sh"
   - docker exec $CONTAINER su - user sh -c "cd /builddir && ../srcdir/configure --enable-strict $BUILD_OPTS"
-  - docker exec $CONTAINER su - user sh -c "cd /builddir && $SCAN_BUILD make V=1 && make check V=1 TESTS_ENVIRONMENT=\"$TESTS_ENVIRONMENT\""
+  - docker exec $CONTAINER su - user sh -c "cd /builddir && $SCAN_BUILD make -j$(nproc) V=1 && make check -j$(nproc) V=1 TESTS_ENVIRONMENT=\"$TESTS_ENVIRONMENT\""
+
+after_failure:
+  - docker exec $CONTAINER su - user sh -c "cd /builddir && cat test-suite.log"

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ AM_CPPFLAGS = \
 bin_PROGRAMS =
 private_PROGRAMS =
 check_PROGRAMS =
+check_SCRIPTS =
 
 CLEANFILES =
 
@@ -31,7 +32,7 @@ noinst_LTLIBRARIES =
 noinst_PROGRAMS =
 noinst_SCRIPTS =
 
-TESTS = $(check_PROGRAMS)
+TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
 moduledir = $(p11_module_path)
 module_LTLIBRARIES =
@@ -53,6 +54,9 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-strict \
 	CFLAGS='-O2'
 
+AM_TESTS_ENVIRONMENT = \
+	abs_top_builddir="$(abs_top_builddir)"; \
+	export abs_top_builddir;
 
 MEMCHECK_ENV = $(TEST_RUNNER) valgrind --error-exitcode=80 --quiet
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 AM_TESTS_ENVIRONMENT = \
 	abs_top_builddir="$(abs_top_builddir)"; \
 	export abs_top_builddir;
+AM_TESTS_FD_REDIRECT = 9>&2;
 
 MEMCHECK_ENV = $(TEST_RUNNER) valgrind --error-exitcode=80 --quiet
 

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ P11KIT_AGE=3
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([build/m4])
 AC_CONFIG_AUX_DIR([build/litter])
-AM_INIT_AUTOMAKE([1.12 foreign serial-tests subdir-objects])
+AM_INIT_AUTOMAKE([1.12 foreign subdir-objects])
 AM_SANITY_CHECK
 AM_MAINTAINER_MODE([enable])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],)

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -208,6 +208,10 @@ check_PROGRAMS += \
 	test-rpc \
 	$(NULL)
 
+if !OS_WIN32
+check_SCRIPTS += p11-kit/test-server.sh
+endif
+
 test_conf_SOURCES = p11-kit/test-conf.c
 test_conf_LDADD = $(p11_kit_LIBS)
 
@@ -306,4 +310,5 @@ mock_five_la_LIBADD = $(mock_one_la_LIBADD)
 EXTRA_DIST += \
 	p11-kit/fixtures \
 	p11-kit/test-mock.c \
+	$(check_SCRIPTS) \
 	$(NULL)

--- a/p11-kit/test-server.sh
+++ b/p11-kit/test-server.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+testdir=$PWD/test-server-$$
+test -d "$testdir" || mkdir "$testdir"
+
+cleanup () {
+  rm -rf "$testdir"
+}
+trap cleanup 0
+
+cd "$testdir"
+
+unset P11_KIT_SERVER_ADDRESS
+unset P11_KIT_SERVER_PID
+
+XDG_RUNTIME_DIR="$testdir"
+export XDG_RUNTIME_DIR
+
+"$abs_top_builddir"/p11-kit-server -s --provider "$abs_top_builddir"/.libs/mock-one.so pkcs11: > start.env 2> start.err
+if test $? -ne 0; then
+    cat start.err
+    exit 1
+fi
+
+. ./start.env
+
+test "${P11_KIT_SERVER_ADDRESS+set}" == set || exit 1
+test "${P11_KIT_SERVER_PID+set}" == set || exit 1
+
+"$abs_top_builddir"/p11-kit-server -s -k > stop.env 2> stop.err
+if test $? -ne 0; then
+    cat stop.err
+    exit 1
+fi
+
+. ./stop.env
+
+test "${P11_KIT_SERVER_ADDRESS-unset}" == unset || exit 1
+test "${P11_KIT_SERVER_PID-unset}" == unset || exit 1


### PR DESCRIPTION
This adds -k, -c, and -s options to the "p11-kit server" command,
which allows you to terminate the server process, select which C-shell
or Bourne shell command line is printed on startup, respectively.