### PR TITLE
proxy: Reuse the existing slot ID mapping after fork

### DIFF
--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -307,6 +307,13 @@ mock_five_la_SOURCES = p11-kit/mock-module-ep3.c
 mock_five_la_LDFLAGS = $(mock_one_la_LDFLAGS)
 mock_five_la_LIBADD = $(mock_one_la_LIBADD)
 
+if !OS_WIN32
+noinst_LTLIBRARIES += mock-six.la
+mock_six_la_SOURCES = p11-kit/mock-module-ep4.c
+mock_six_la_LDFLAGS = $(mock_one_la_LDFLAGS)
+mock_six_la_LIBADD = $(mock_one_la_LIBADD)
+endif
+
 EXTRA_DIST += \
 	p11-kit/fixtures \
 	p11-kit/test-mock.c \

--- a/p11-kit/fixtures/package-modules/six.module
+++ b/p11-kit/fixtures/package-modules/six.module
@@ -1,0 +1,7 @@
+
+module: mock-six.so
+
+enable-in: test-proxy
+
+# the highest priority among others loaded by test-proxy
+priority: 100

--- a/p11-kit/mock-module-ep4.c
+++ b/p11-kit/mock-module-ep4.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 Stefan Walter
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Stef Walter <stef@thewalter.net>
+ */
+
+#include "config.h"
+
+#define CRYPTOKI_EXPORTS 1
+#include "pkcs11.h"
+
+#include "mock.h"
+#include "test.h"
+
+#include <unistd.h>
+
+static pid_t init_pid;
+
+static CK_RV
+override_initialize (CK_VOID_PTR init_args)
+{
+	if (init_pid != getpid ())
+		return CKR_GENERAL_ERROR;
+	return mock_C_Initialize (init_args);
+}
+
+#ifdef OS_WIN32
+__declspec(dllexport)
+#endif
+CK_RV
+C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
+{
+	mock_module_init ();
+	mock_module.C_GetFunctionList = C_GetFunctionList;
+	if (list == NULL)
+		return CKR_ARGUMENTS_BAD;
+	init_pid = getpid ();
+	mock_module.C_Initialize = override_initialize;
+	*list = &mock_module;
+	return CKR_OK;
+}


### PR DESCRIPTION
While the proxy module reassigns slot IDs in ```C_Initialize()```, some applications assume that valid slot IDs should never change across multiple calls to ```C_Initialize()```.  This patch mitigates this by preserving the slot IDs, if they are known to the proxy module.

Note that this change is experimental.  @ansasaki, @nmav this is what I was talking yesterday.