### PR TITLE
Allow filtering of tokens exposed by proxy module

### DIFF
--- a/p11-kit/fixtures/test-system-allow-tokens.conf
+++ b/p11-kit/fixtures/test-system-allow-tokens.conf
@@ -1,0 +1,9 @@
+
+# Merge in user config
+user-config: merge
+
+key1: system1
+key2: system2
+key3: system3
+
+allow-tokens: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL

--- a/p11-kit/fixtures/test-system-deny-tokens.conf
+++ b/p11-kit/fixtures/test-system-deny-tokens.conf
@@ -1,0 +1,9 @@
+
+# Merge in user config
+user-config: merge
+
+key1: system1
+key2: system2
+key3: system3
+
+deny-tokens: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL

--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -256,6 +256,11 @@ proxy_create (Proxy **res)
 	CK_ULONG i, count;
 	CK_RV rv = CKR_OK;
 	Proxy *py;
+	const char *envvar;
+
+	envvar = secure_getenv ("P11_KIT_PROXY_CONFIG");
+	if (envvar && *envvar != '\0')
+		p11_kit_override_system_files (envvar, NULL, NULL, NULL, NULL);
 
 	py = calloc (1, sizeof (Proxy));
 	return_val_if_fail (py != NULL, CKR_HOST_MEMORY);

--- a/p11-kit/test-modules.c
+++ b/p11-kit/test-modules.c
@@ -462,6 +462,54 @@ test_config_option (void)
 	finalize_and_free_modules (modules);
 }
 
+static void
+test_filter_tokens (void)
+{
+	CK_FUNCTION_LIST_PTR_PTR modules;
+	CK_FUNCTION_LIST_PTR module;
+	CK_ULONG count;
+	CK_RV rv;
+
+	modules = initialize_and_get_modules ();
+	module = lookup_module_with_name (modules, "four");
+	assert (module != NULL);
+	count = 32;
+	rv = (module->C_GetSlotList) (CK_TRUE, NULL, &count);
+	assert_num_eq (CKR_OK, rv);
+	assert_num_eq (1, count);
+	finalize_and_free_modules (modules);
+
+	p11_kit_override_system_files (SRCDIR "/p11-kit/fixtures/test-system-deny-tokens.conf",
+				       NULL,
+				       NULL,
+				       NULL,
+				       NULL);
+
+	modules = initialize_and_get_modules ();
+	module = lookup_module_with_name (modules, "four");
+	assert (module != NULL);
+	count = 32;
+	rv = (module->C_GetSlotList) (CK_TRUE, NULL, &count);
+	assert_num_eq (CKR_OK, rv);
+	assert_num_eq (0, count);
+	finalize_and_free_modules (modules);
+
+	p11_kit_override_system_files (SRCDIR "/p11-kit/fixtures/test-system-allow-tokens.conf",
+				       NULL,
+				       NULL,
+				       NULL,
+				       NULL);
+
+	modules = initialize_and_get_modules ();
+	module = lookup_module_with_name (modules, "four");
+	assert (module != NULL);
+	count = 32;
+	rv = (module->C_GetSlotList) (CK_TRUE, NULL, &count);
+	assert_num_eq (CKR_OK, rv);
+	assert_num_eq (1, count);
+	finalize_and_free_modules (modules);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -480,6 +528,7 @@ main (int argc,
 	p11_test (test_config_option, "/modules/test_config_option");
 	p11_test (test_module_trusted_only, "/modules/trusted-only");
 	p11_test (test_module_trust_flags, "/modules/trust-flags");
+	p11_test (test_filter_tokens, "/modules/test_filter_tokens");
 
 	p11_kit_be_quiet ();
 


### PR DESCRIPTION
This is a proof-of-concept implementation of #113:
- add an option in the global configuration file (```/etc/pkcs11/pkcs11.conf```), which takes a list of allowed/disallowed token URIs (e.g., ```allow-tokens``` or ```deny-tokens```), and
- enable ```p11-kit-proxy.so``` to switch configuration profile through an envvar (e.g., ```P11_KIT_PROXY_CONFIG```)