### PR TITLE
trust: Forcibly mark "Default Trust" read-only

### DIFF
--- a/trust/Makefile.am
+++ b/trust/Makefile.am
@@ -46,6 +46,8 @@ module_LTLIBRARIES += \
 	p11-kit-trust.la
 
 p11_kit_trust_la_CFLAGS = \
+	-DP11_DEFAULT_TRUST_PREFIX=DATA_DIR \
+	-DP11_SYSTEM_TRUST_PREFIX=SYSCONFDIR \
 	$(LIBTASN1_CFLAGS)
 
 p11_kit_trust_la_LIBADD = \
@@ -70,6 +72,8 @@ libtrust_testable_la_LDFLAGS = \
 libtrust_testable_la_SOURCES = $(TRUST_SRCS)
 
 libtrust_testable_la_CFLAGS = \
+	-DP11_DEFAULT_TRUST_PREFIX=\"$(builddir)/trust/default\" \
+	-DP11_SYSTEM_TRUST_PREFIX=\"$(builddir)/trust/system\" \
 	$(LIBTASN1_CFLAGS)
 
 libtrust_testable_la_LIBADD = \
@@ -125,7 +129,7 @@ asn:
 # Tests ----------------------------------------------------------------
 
 trust_CFLAGS = \
-        $(LIBTASN1_CFLAGS) \
+        $(libtrust_testable_la_CFLAGS) \
 	$(NULL)
 
 trust_LIBS = \

--- a/trust/frob-token.c
+++ b/trust/frob-token.c
@@ -52,7 +52,7 @@ main (int argc,
 		return 2;
 	}
 
-	token = p11_token_new (1, argv[1], "Label");
+	token = p11_token_new (1, argv[1], "Label", P11_TOKEN_FLAG_NONE);
 	count = p11_token_load (token);
 
 	printf ("%d files loaded\n", count);

--- a/trust/test-token.c
+++ b/trust/test-token.c
@@ -63,7 +63,7 @@ struct {
 static void
 setup (void *path)
 {
-	test.token = p11_token_new (333, path, "Label");
+	test.token = p11_token_new (333, path, "Label", P11_TOKEN_FLAG_NONE);
 	assert_ptr_not_null (test.token);
 
 	test.index = p11_token_index (test.token);
@@ -241,18 +241,18 @@ test_not_writable (void)
 #ifdef OS_UNIX
 	if (getuid () != 0) {
 #endif
-		token = p11_token_new (333, "/", "Label");
+		token = p11_token_new (333, "/", "Label", P11_TOKEN_FLAG_NONE);
 		assert (!p11_token_is_writable (token));
 		p11_token_free (token);
 #ifdef OS_UNIX
 	}
 #endif
 
-	token = p11_token_new (333, "", "Label");
+	token = p11_token_new (333, "", "Label", P11_TOKEN_FLAG_NONE);
 	assert (!p11_token_is_writable (token));
 	p11_token_free (token);
 
-	token = p11_token_new (333, "/non-existant", "Label");
+	token = p11_token_new (333, "/non-existant", "Label", P11_TOKEN_FLAG_NONE);
 	assert (!p11_token_is_writable (token));
 	p11_token_free (token);
 }
@@ -276,7 +276,7 @@ test_writable_no_exist (void)
 	path = p11_path_build (directory, "subdir", NULL);
 	assert (path != NULL);
 
-	token = p11_token_new (333, path, "Label");
+	token = p11_token_new (333, path, "Label", P11_TOKEN_FLAG_NONE);
 	free (path);
 
 	/* A writable directory since parent is writable */

--- a/trust/token.c
+++ b/trust/token.c
@@ -817,7 +817,8 @@ p11_token_free (p11_token *token)
 p11_token *
 p11_token_new (CK_SLOT_ID slot,
                const char *path,
-               const char *label)
+               const char *label,
+               int flags)
 {
 	p11_token *token;
 
@@ -858,6 +859,12 @@ p11_token_new (CK_SLOT_ID slot,
 	return_val_if_fail (token->label != NULL, NULL);
 
 	token->slot = slot;
+
+	if (flags & P11_TOKEN_FLAG_WRITE_PROTECTED) {
+		token->checked_path = true;
+		token->make_directory = false;
+		token->is_writable = false;
+	}
 
 	load_builtin_objects (token);
 

--- a/trust/token.h
+++ b/trust/token.h
@@ -40,11 +40,17 @@
 #include "parser.h"
 #include "pkcs11.h"
 
+enum {
+	P11_TOKEN_FLAG_NONE = 0,
+	P11_TOKEN_FLAG_WRITE_PROTECTED = 1 << 0,
+};
+
 typedef struct _p11_token p11_token;
 
 p11_token *     p11_token_new         (CK_SLOT_ID slot,
                                        const char *path,
-                                       const char *label);
+                                       const char *label,
+                                       int flags);
 
 void            p11_token_free        (p11_token *token);
 


### PR DESCRIPTION
The ```Default Trust``` token is typically mounted on ```$datadir```, which is considered as read-only on modern OSes.

Suggestd by Kai Engert in:
https://bugzilla.redhat.com/show_bug.cgi?id=1523630