### PR TITLE
doc: Replace links to freedesktop.org to github pages

### DIFF
--- a/doc/manual/p11-kit-devel.xml
+++ b/doc/manual/p11-kit-devel.xml
@@ -12,9 +12,9 @@
 		contributing to p11-kit beyond what's in this manual:</para>
 
 		<itemizedlist>
-			<listitem><para><ulink url="http://p11-glue.freedesktop.org/p11-kit.html">Website</ulink></para></listitem>
+			<listitem><para><ulink url="https://p11-glue.github.io/p11-glue/p11-kit.html">Website</ulink></para></listitem>
 			<listitem><para><ulink url="mail:p11-glue@lists.freedesktop.org">Mailing list</ulink></para></listitem>
-			<listitem><para><ulink url="https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue&amp;component=p11-kit">Bugzilla</ulink></para></listitem>
+			<listitem><para><ulink url="https://github.com/p11-glue/p11-kit/issues/">Issue tracker</ulink></para></listitem>
 		</itemizedlist>
 	</section>
 
@@ -89,7 +89,7 @@ $ <command>pkg-config p11-kit-1 --variable p11_module_path</command>
 		contribute to the project or package p11-kit.</para>
 
 		<para>You can download
-		<ulink url="http://p11-glue.freedesktop.org/releases/">tarballs
+		<ulink url="https://github.com/p11-glue/p11-kit/releases">tarballs
 		of the releases</ulink> of p11-kit or
 		<ulink url="https://github.com/p11-glue/p11-kit/">check
 		out the source code from git</ulink>. This documentation will not
@@ -306,7 +306,7 @@ $ make install
 		you've tested the lines changed by a patch.</para>
 
 		<para>A code coverage report is
-			<ulink url="http://p11-glue.freedesktop.org/build/coverage">available online</ulink></para>.
+			<ulink url="https://coveralls.io/github/p11-glue/p11-kit">available online</ulink></para>.
 	</section>
 
 	<section id="devel-debugging">

--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -134,7 +134,7 @@ $ p11-kit remote pkcs11:token1 pkcs11:token2 ...
   <para>
     Please send bug reports to either the distribution bug tracker
     or the upstream bug tracker at
-    <ulink url="https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue&amp;component=p11-kit">https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue&amp;component=p11-kit</ulink>.
+    <ulink url="https://github.com/p11-glue/p11-kit/issues/">https://github.com/p11-glue/p11-kit/issues/</ulink>.
   </para>
 </refsect1>
 
@@ -145,7 +145,7 @@ $ p11-kit remote pkcs11:token1 pkcs11:token2 ...
     </simplelist>
     <para>
     Further details available in the p11-kit online documentation at
-    <ulink url="http://p11-glue.freedesktop.org/doc/p11-kit/">http://p11-glue.freedesktop.org/doc/p11-kit/</ulink>.
+    <ulink url="https://p11-glue.github.io/p11-glue/p11-kit/manual/">https://p11-glue.github.io/p11-glue/p11-kit/manual/</ulink>.
   </para>
 </refsect1>
 

--- a/doc/manual/pkcs11.conf.xml
+++ b/doc/manual/pkcs11.conf.xml
@@ -274,7 +274,7 @@ remote: |ssh user@remote p11-kit remote /path/to/module.so
 		<member><citerefentry><refentrytitle>p11-kit</refentrytitle><manvolnum>8</manvolnum></citerefentry></member>
 	</simplelist>
 	<para>Further details available in the p11-kit online documentation at
-	<ulink url="http://p11-glue.freedesktop.org/doc/p11-kit/">http://p11-glue.freedesktop.org/doc/p11-kit/</ulink>.
+	<ulink url="https://p11-glue.github.io/p11-glue/p11-kit/manual/">https://p11-glue.github.io/p11-glue/p11-kit/manual/</ulink>.
 	</para>
 </refsect1>
 

--- a/doc/manual/trust.xml
+++ b/doc/manual/trust.xml
@@ -391,7 +391,7 @@ $ trust dump
   <para>
     Please send bug reports to either the distribution bug tracker
     or the upstream bug tracker at
-    <ulink url="https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue&amp;component=p11-kit">https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue&amp;component=p11-kit</ulink>.
+    <ulink url="https://github.com/p11-glue/p11-kit/issues/">https://github.com/p11-glue/p11-kit/issues/</ulink>.
   </para>
 </refsect1>
 
@@ -401,10 +401,10 @@ $ trust dump
         <member><citerefentry><refentrytitle>p11-kit</refentrytitle><manvolnum>8</manvolnum></citerefentry></member>
     </simplelist>
     <para>An explanatory document about storing trust policy:
-    <ulink url="http://p11-glue.freedesktop.org/doc/storing-trust-policy/">http://p11-glue.freedesktop.org/doc/storing-trust-policy/</ulink></para>
+    <ulink url="https://p11-glue.github.io/p11-glue/doc/storing-trust-policy/">https://p11-glue.github.io/p11-glue/doc/storing-trust-policy/</ulink></para>
     <para>
     Further details available in the p11-kit online documentation at
-    <ulink url="http://p11-glue.freedesktop.org/doc/p11-kit/">http://p11-glue.freedesktop.org/doc/p11-kit/</ulink>.
+    <ulink url="https://p11-glue.github.io/p11-glue/p11-kit/manual/">https://p11-glue.github.io/p11-glue/p11-kit/manual/</ulink>.
   </para>
 </refsect1>
 


### PR DESCRIPTION
Fixes #130 