### PR TITLE
modules: Add option to control module visibility from proxy

### DIFF
--- a/doc/manual/pkcs11.conf.xml
+++ b/doc/manual/pkcs11.conf.xml
@@ -115,6 +115,7 @@ x-custom : text
 			for other programs using p11-kit. The base name of the process executable
 			should be used here, for example
 			<literal>seahorse, ssh</literal>.</para>
+			<para>This option can also be used to control whether the module will be loaded by <link linkend="sharing">the proxy module</link>.  To enable loading only from the proxy module, specify <literal>p11-kit-proxy</literal> as the value.</para>
 			<para>This is not a security feature. The argument is optional. If
 			not present, then any process will load the module.</para>
 		</listitem>
@@ -127,6 +128,7 @@ x-custom : text
 			other programs using p11-kit. The base name of the process
 			executable should be used here, for example
 			<literal>firefox, thunderbird-bin</literal>.</para>
+			<para>This option can also be used to control whether the module will be loaded by <link linkend="sharing">the proxy module</link>.  To disable loading from the proxy module, specify <literal>p11-kit-proxy</literal> as the value.</para>
 			<para>This is not a security feature. The argument is optional. If
 			not present, then any process will load the module.</para>
 		</listitem>

--- a/p11-kit/p11-kit.h
+++ b/p11-kit/p11-kit.h
@@ -57,6 +57,7 @@ enum {
 	P11_KIT_MODULE_UNMANAGED = 1 << 0,
 	P11_KIT_MODULE_CRITICAL = 1 << 1,
 	P11_KIT_MODULE_TRUSTED = 1 << 2,
+	P11_KIT_MODULE_MASK = (1 << 3) - 1
 };
 
 typedef void        (* p11_kit_destroyer)                   (void *data);

--- a/p11-kit/private.h
+++ b/p11-kit/private.h
@@ -45,6 +45,11 @@ extern const char *p11_config_package_modules;
 extern const char *p11_config_system_modules;
 extern const char *p11_config_user_modules;
 
+/* These are flags used only internally */
+enum {
+	P11_KIT_MODULE_LOADED_FROM_PROXY = 1 << 16
+};
+
 CK_RV       _p11_load_config_files_unlocked                     (const char *system_conf,
                                                                  const char *user_conf,
                                                                  int *user_mode);

--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -1670,7 +1670,7 @@ C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
 
 	if (all_modules == NULL) {
 		/* WARNING: Reentrancy can occur here */
-		rv = p11_modules_load_inlock_reentrant (0, &loaded);
+		rv = p11_modules_load_inlock_reentrant (P11_KIT_MODULE_LOADED_FROM_PROXY, &loaded);
 		if (rv == CKR_OK) {
 			if (all_modules == NULL)
 				all_modules = loaded;


### PR DESCRIPTION
This enables to control the visibility of a module loaded from the proxy module.  The configuration reuses the `enable-in` and `disable-in` options.  To enable/disable a module when loaded from the proxy module, set `p11-kit-proxy` as the value of the option.