### PR TITLE
 trust: Prevent trust module being loaded by proxy module 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,6 @@ x86_64-w64-mingw32
 
 /trust/trust
 /trust/trust-extract-compat
-/trust/test-extract
+/trust/test-init.sh
 
 /p11-kit-?.?

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: required
 language: c
 
 env:
-  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64" SRCDIR=/srcdir BUILDDIR=/builddir
-  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 --enable-coverage" COVERAGE=yes SRCDIR=/coverage BUILDDIR=/coverage
-  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lasan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir PRELOAD_CMD='ls -1 /usr/lib64/libasan.so.* | head -1' LSAN_OPTIONS='suppressions=/srcdir/build/lsan.supp'
-  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lubsan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir
-  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64" SCAN_BUILD="scan-build --status-bugs" SRCDIR=/srcdir BUILDDIR=/builddir
-  - BUILD_OPTS="-host=x86_64-w64-mingw32 --prefix=/usr/x86_64-w64-mingw32 --without-libffi" CHECK_OPTS="LOG_COMPILER=/srcdir/build/wine-wrapper.sh" SRCDIR=/srcdir BUILDDIR=/builddir
+  - BUILD_OPTS="" SRCDIR=/srcdir BUILDDIR=/builddir
+  - BUILD_OPTS="--enable-coverage" COVERAGE=yes SRCDIR=/coverage BUILDDIR=/coverage
+  - BUILD_OPTS="CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lasan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir PRELOAD_CMD='ls -1 /usr/lib64/libasan.so.* | head -1' LSAN_OPTIONS='suppressions=/srcdir/build/lsan.supp'
+  - BUILD_OPTS="CFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lubsan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir
+  - BUILD_OPTS="" SCAN_BUILD="scan-build --status-bugs" SRCDIR=/srcdir BUILDDIR=/builddir
+  - BUILD_OPTS="-host=x86_64-w64-mingw32 --without-libffi" CHECK_OPTS="LOG_COMPILER=/srcdir/build/wine-wrapper.sh" SRCDIR=/srcdir BUILDDIR=/builddir
 
 services:
   - docker
@@ -22,6 +22,7 @@ before_install:
   - docker exec $CONTAINER dnf -y install libasan libubsan
   - docker exec $CONTAINER dnf -y install clang-analyzer
   - docker exec $CONTAINER dnf -y install mingw64-gcc mingw64-libffi mingw64-libtasn1 wine
+  - docker exec $CONTAINER dnf -y install opensc openssl
   - docker exec $CONTAINER useradd user
 
 install:
@@ -29,6 +30,10 @@ install:
   - docker exec $CONTAINER cp -R /srcdir /coverage
   - docker exec $CONTAINER mkdir /builddir
   - docker exec $CONTAINER chown -R user /builddir
+  - docker exec $CONTAINER mkdir /installdir
+  - docker exec $CONTAINER mkdir -p /installdir/etc/pki/ca-trust-source
+  - docker exec $CONTAINER mkdir -p /installdir/share/pki/ca-trust-source
+  - docker exec $CONTAINER chown -R user /installdir
   # FIXME: This is needed because some files are included in distribution
   # and need to be generated in $srcdir rather than $builddir
   - docker exec $CONTAINER chown -R user /srcdir
@@ -36,12 +41,15 @@ install:
 
 script:
   - docker exec $CONTAINER sh -c "cd $SRCDIR && NOCONFIGURE=1 ./autogen.sh"
-  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && $SRCDIR/configure --enable-strict $BUILD_OPTS"
+  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && $SRCDIR/configure --enable-strict --prefix=/installdir --libdir=/installdir/lib --sysconfdir=/installdir/etc --with-trust-paths=/installdir/etc/pki/ca-trust-source:/installdir/share/pki/ca-trust-source $BUILD_OPTS"
   - |
       if test -n "$PRELOAD_CMD"; then
         P11_KIT_TEST_LD_PRELOAD=$(docker exec $CONTAINER su - user sh -c "$PRELOAD_CMD")
       fi
-  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && $SCAN_BUILD make -j$(nproc) V=1 && P11_KIT_DEBUG=all LSAN_OPTIONS="$LSAN_OPTIONS" P11_KIT_TEST_LD_PRELOAD=\"$P11_KIT_TEST_LD_PRELOAD\" make check -j$(nproc) V=1 $CHECK_OPTS"
+  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && $SCAN_BUILD make -j$(nproc) V=1"
+  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && P11_KIT_DEBUG=all LSAN_OPTIONS="$LSAN_OPTIONS" P11_KIT_TEST_LD_PRELOAD=\"$P11_KIT_TEST_LD_PRELOAD\" make check -j$(nproc) V=1 $CHECK_OPTS"
+  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && make install"
+  - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && make installcheck"
 
 after_failure:
   - docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && cat test-suite.log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: required
 language: c
 
 env:
-  - BUILD_OPTS="" SRCDIR=/srcdir BUILDDIR=/builddir
-  - BUILD_OPTS="--enable-coverage" COVERAGE=yes SRCDIR=/coverage BUILDDIR=/coverage
-  - BUILD_OPTS="CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lasan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir PRELOAD_CMD='ls -1 /usr/lib64/libasan.so.* | head -1' LSAN_OPTIONS='suppressions=/srcdir/build/lsan.supp'
-  - BUILD_OPTS="CFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lubsan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir
-  - BUILD_OPTS="" SCAN_BUILD="scan-build --status-bugs" SRCDIR=/srcdir BUILDDIR=/builddir
-  - BUILD_OPTS="-host=x86_64-w64-mingw32 --without-libffi" CHECK_OPTS="LOG_COMPILER=/srcdir/build/wine-wrapper.sh" SRCDIR=/srcdir BUILDDIR=/builddir
+  - BUILD_OPTS="" SRCDIR=/srcdir BUILDDIR=/builddir EXTRA_PKGS=""
+  - BUILD_OPTS="--enable-coverage" COVERAGE=yes SRCDIR=/coverage BUILDDIR=/coverage EXTRA_PKGS="lcov"
+  - BUILD_OPTS="CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lasan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir PRELOAD_CMD='ls -1 /usr/lib64/libasan.so.* | head -1' LSAN_OPTIONS='suppressions=/srcdir/build/lsan.supp' EXTRA_PKGS="libasan"
+  - BUILD_OPTS="CFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LIBS='-lubsan -ldl -lpthread'" SRCDIR=/srcdir BUILDDIR=/builddir EXTRA_PKGS="libubsan"
+  - BUILD_OPTS="" SCAN_BUILD="scan-build --status-bugs" SRCDIR=/srcdir BUILDDIR=/builddir EXTRA_PKGS="clang-analyzer"
+  - BUILD_OPTS="--host=x86_64-w64-mingw32 --without-libffi" CHECK_OPTS="LOG_COMPILER=/srcdir/build/wine-wrapper.sh" SRCDIR=/srcdir BUILDDIR=/builddir EXTRA_PKGS="mingw64-gcc mingw64-libffi mingw64-libtasn1 wine"
 
 services:
   - docker
@@ -18,11 +18,7 @@ before_install:
   - export CONTAINER=$(docker run -d fedora sleep 1800)
   - docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
   - docker exec $CONTAINER dnf -y builddep p11-kit
-  - docker exec $CONTAINER dnf -y install gettext-devel git lcov libtool make
-  - docker exec $CONTAINER dnf -y install libasan libubsan
-  - docker exec $CONTAINER dnf -y install clang-analyzer
-  - docker exec $CONTAINER dnf -y install mingw64-gcc mingw64-libffi mingw64-libtasn1 wine
-  - docker exec $CONTAINER dnf -y install opensc openssl
+  - docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl $EXTRA_PKGS
   - docker exec $CONTAINER useradd user
 
 install:

--- a/configure.ac
+++ b/configure.ac
@@ -532,7 +532,7 @@ AC_CONFIG_FILES([Makefile
 	p11-kit/p11-kit-1.pc
 	p11-kit/pkcs11.conf.example
 	trust/trust-extract-compat
-	trust/test-extract
+	trust/test-init.sh
 ])
 AC_OUTPUT
 

--- a/trust/Makefile.am
+++ b/trust/Makefile.am
@@ -303,12 +303,15 @@ frob_token_SOURCES = trust/frob-token.c
 frob_token_LDADD = $(trust_LIBS)
 frob_token_CFLAGS = $(trust_CFLAGS)
 
-noinst_SCRIPTS += trust/test-extract
+noinst_SCRIPTS += trust/test-extract.sh
 
+if !OS_WIN32
 installcheck-local:
-	sh $(builddir)/trust/test-extract
+	builddir="$(abs_top_builddir)/trust" $(SHELL) $(srcdir)/trust/test-extract.sh
+endif
 
 EXTRA_DIST += \
 	trust/input \
 	trust/fixtures \
+	trust/test-extract.sh \
 	$(NULL)

--- a/trust/Makefile.am
+++ b/trust/Makefile.am
@@ -303,15 +303,17 @@ frob_token_SOURCES = trust/frob-token.c
 frob_token_LDADD = $(trust_LIBS)
 frob_token_CFLAGS = $(trust_CFLAGS)
 
-noinst_SCRIPTS += trust/test-extract.sh
+noinst_SCRIPTS += trust/test-extract.sh trust/test-trust.sh
 
 if !OS_WIN32
 installcheck-local:
 	builddir="$(abs_top_builddir)/trust" $(SHELL) $(srcdir)/trust/test-extract.sh
+	builddir="$(abs_top_builddir)/trust" $(SHELL) $(srcdir)/trust/test-trust.sh
 endif
 
 EXTRA_DIST += \
 	trust/input \
 	trust/fixtures \
 	trust/test-extract.sh \
+	trust/test-trust.sh \
 	$(NULL)

--- a/trust/enumerate.c
+++ b/trust/enumerate.c
@@ -613,6 +613,7 @@ p11_enumerate_opt_filter (p11_enumerate *ex,
 	}
 
 	p11_kit_iter_add_filter (ex->iter, attrs, p11_attrs_count (attrs));
+	p11_attrs_free (attrs);
 	ex->num_filters++;
 	return true;
 }

--- a/trust/p11-kit-trust.module
+++ b/trust/p11-kit-trust.module
@@ -15,3 +15,6 @@ trust-policy: yes
 # projects used this non-standard attribute to denote slots to use to
 # retrieve trust information.
 x-trust-lookup: pkcs11:library-description=PKCS%2311%20Kit%20Trust%20Module
+
+# Prevent this module being loaded by the proxy module
+disable-in: p11-kit-proxy

--- a/trust/test-extract.sh
+++ b/trust/test-extract.sh
@@ -1,48 +1,6 @@
 #!/bin/sh
 
-set -euf
-
-# -----------------------------------------------------------------------------
-# Basic fundamentals
-
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-datarootdir=@datarootdir@
-datadir=@datadir@
-sysconfdir=@sysconfdir@
-libdir=@libdir@
-libexecdir=@libexecdir@
-privatedir=@privatedir@
-with_trust_paths=@with_trust_paths@
-script=$(basename $0)
-
-# -----------------------------------------------------------------------------
-# Testing
-
-warning()
-{
-	echo "$script: $@" >&2
-}
-
-assert_fail()
-{
-	warning $@
-	exit 1
-}
-
-assert_contains()
-{
-	if ! grep -qF $2 $1; then
-		assert_fail "$1 does not contain $2"
-	fi
-}
-
-assert_not_contains()
-{
-	if grep -qF $2 $1; then
-		assert_fail "$1 contains $2"
-	fi
-}
+. "${builddir=.}/test-init.sh"
 
 teardown()
 {
@@ -56,24 +14,12 @@ teardown()
 	TD=""
 }
 
-teardown_dirty()
-{
-	echo "not ok $TEST_NUMBER $TEST_NAME"
-	teardown
-}
-
 openssl_quiet()
 (
 	command='/Generating a|-----|^[.+]+$|writing new private key/d'
 	exec 3>&1
 	openssl $@ 2>&1 >&3 3>&- | sed -r "$command" 3>&-
 )
-
-skip()
-{
-	TEST_SKIP=yes
-	echo "ok $TEST_NUMBER # skip $TEST_NAME: $@"
-}
 
 setup()
 {
@@ -125,42 +71,6 @@ setup()
 
 	TD="$SOURCE_1/anchors/cert_1.pem $SOURCE_2/anchors/cert_2.pem $SOURCE_2/anchors/cert_3.pem $TD"
 }
-
-run()
-{
-	TOTAL=0
-	for TEST_NAME in $@; do
-		TOTAL=$(expr $TOTAL + 1)
-	done
-
-	echo "1..$TOTAL"
-
-	TEST_NUMBER=0
-	for TEST_NAME in $@; do
-		TEST_NUMBER=$(expr $TEST_NUMBER + 1)
-		(
-			trap teardown_dirty EXIT
-			trap "teardown_dirty; exit 127" INT TERM
-			TD=""
-
-			TEST_SKIP=no
-			setup
-
-			if [ $TEST_SKIP != "yes" ]; then
-				$TEST_NAME
-			fi
-			if [ $TEST_SKIP != "yes" ]; then
-				echo "ok $TEST_NUMBER $TEST_NAME"
-			fi
-
-			trap - EXIT
-			teardown
-		)
-	done
-}
-
-# -----------------------------------------------------------------------------
-# Main tests
 
 test_extract()
 {

--- a/trust/test-init.sh.in
+++ b/trust/test-init.sh.in
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+set -euf
+
+# -----------------------------------------------------------------------------
+# Basic fundamentals
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+datarootdir=@datarootdir@
+datadir=@datadir@
+sysconfdir=@sysconfdir@
+libdir=@libdir@
+libexecdir=@libexecdir@
+privatedir=@privatedir@
+with_trust_paths=@with_trust_paths@
+script=$(basename $0)
+
+# -----------------------------------------------------------------------------
+# Testing
+
+warning()
+{
+	echo "$script: $@" >&2
+}
+
+assert_fail()
+{
+	warning $@
+	exit 1
+}
+
+assert_contains()
+{
+	if ! grep -qF $2 $1; then
+		assert_fail "$1 does not contain $2"
+	fi
+}
+
+assert_not_contains()
+{
+	if grep -qF $2 $1; then
+		assert_fail "$1 contains $2"
+	fi
+}
+
+teardown()
+{
+	:
+}
+
+teardown_dirty()
+{
+	echo "not ok $TEST_NUMBER $TEST_NAME"
+	teardown
+}
+
+skip()
+{
+	TEST_SKIP=yes
+	echo "ok $TEST_NUMBER # skip $TEST_NAME: $@"
+}
+
+setup()
+{
+	:
+}
+
+run()
+{
+	TOTAL=0
+	for TEST_NAME in $@; do
+		TOTAL=$(expr $TOTAL + 1)
+	done
+
+	echo "1..$TOTAL"
+
+	TEST_NUMBER=0
+	for TEST_NAME in $@; do
+		TEST_NUMBER=$(expr $TEST_NUMBER + 1)
+		(
+			trap teardown_dirty EXIT
+			trap "teardown_dirty; exit 127" INT TERM
+			TD=""
+
+			PATH="$exec_prefix/bin:$PATH"
+			export PATH
+
+			PKG_CONFIG_PATH="$libdir/pkgconfig:$datadir/pkgconfig"
+			export PKG_CONFIG_PATH
+
+			TEST_SKIP=no
+			setup
+
+			if [ $TEST_SKIP != "yes" ]; then
+				$TEST_NAME
+			fi
+			if [ $TEST_SKIP != "yes" ]; then
+				echo "ok $TEST_NUMBER $TEST_NAME"
+			fi
+
+			trap - EXIT
+			teardown
+		)
+	done
+}

--- a/trust/test-trust.sh
+++ b/trust/test-trust.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. "${builddir=.}/test-init.sh"
+
+test_disable_in_proxy()
+{
+	: ${PKCS11_TOOL=pkcs11-tool}
+	if ! (type ${PKCS11_TOOL}) > /dev/null 2>&1; then
+		skip "pkcs11-tool not found"
+	fi
+	: ${PKG_CONFIG=pkg-config}
+	if ! (type ${PKG_CONFIG}) > /dev/null 2>&1; then
+		skip "pkg-config not found"
+	fi
+	proxy_module=$(${PKG_CONFIG} --variable=proxy_module p11-kit-1)
+	if ${PKCS11_TOOL} --module="$proxy_module" -T | grep '^ *token model *: *p11-kit-trust' > /dev/null 2>&1; then
+		assert_fail "p11-kit-trust is not disabled in proxy module"
+	fi
+}
+
+run test_disable_in_proxy


### PR DESCRIPTION
Otherwise, when the proxy module were registered in NSS database, the
trust module would be loaded twice and affect search performance.