### PR TITLE
build: Check strerror_l() and uselocale() seperately

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -151,7 +151,7 @@ p11_debug_message_err (int flag,
 {
 	va_list args;
 	char strerr[P11_DEBUG_MESSAGE_MAX];
-#ifdef HAVE_STRERROR_L
+#if defined(HAVE_STRERROR_L) && defined(HAVE_USELOCALE)
 	locale_t loc;
 #endif
 
@@ -162,7 +162,12 @@ p11_debug_message_err (int flag,
 		va_end (args);
 
 		snprintf (strerr, sizeof (strerr), "Unknown error %d", errnum);
-#ifdef HAVE_STRERROR_L
+		/* As strerror_r() is being deprecated in POSIX:
+		 * http://austingroupbugs.net/view.php?id=655
+		 * we prefer to use strerror_l() with per-thread locale
+		 * argument as a thread-safe variant of strerror().
+		 */
+#if defined(HAVE_STRERROR_L) && defined(HAVE_USELOCALE)
 		loc = uselocale ((locale_t) 0);
 		if (loc != NULL)
 			strncpy (strerr, strerror_l (errnum, loc), sizeof (strerr));

--- a/common/message.c
+++ b/common/message.c
@@ -104,7 +104,7 @@ p11_message_err (int errnum,
 	char strerr[P11_MESSAGE_MAX];
 	va_list va;
 	size_t length;
-#ifdef HAVE_STRERROR_L
+#if defined(HAVE_STRERROR_L) && defined(HAVE_USELOCALE)
 	locale_t loc;
 #endif
 
@@ -118,7 +118,12 @@ p11_message_err (int errnum,
 	buffer[length] = 0;
 
 	snprintf (strerr, sizeof (strerr), "Unknown error %d", errnum);
-#ifdef HAVE_STRERROR_L
+	/* As strerror_r() is being deprecated in POSIX:
+	 * http://austingroupbugs.net/view.php?id=655
+	 * we prefer to use strerror_l() with per-thread locale
+	 * argument as a thread-safe variant of strerror().
+	 */
+#if defined(HAVE_STRERROR_L) && defined(HAVE_USELOCALE)
 	loc = uselocale ((locale_t) 0);
 	if (loc != NULL)
 		strncpy (strerr, strerror_l (errnum, loc), sizeof (strerr));

--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,7 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_MEMBERS([struct dirent.d_type],,,[#include <dirent.h>])
 	AC_CHECK_FUNCS([getprogname getexecname basename mkstemp mkdtemp])
 	AC_CHECK_FUNCS([getauxval issetugid getresuid secure_getenv])
-	AC_CHECK_FUNCS([strnstr memdup strndup strerror_l strerror_r])
+	AC_CHECK_FUNCS([strnstr memdup strndup strerror_l strerror_r uselocale])
 	AC_CHECK_FUNCS([reallocarray])
 	AC_CHECK_FUNCS([fdwalk])
 	AC_CHECK_FUNCS([setenv])


### PR DESCRIPTION
NetBSD deliberately doesn't support per-thread locale and our thread-safe replacement of `strerror()` using `strerror_l()` cannot be used.  Fallback to `strerror_r()` in that case.

Fixes #143 