### PR TITLE
trust: Provide a drop-in replacement of gnome-keyring user trust storage

### DIFF
--- a/trust/builder.c
+++ b/trust/builder.c
@@ -922,8 +922,10 @@ const static builder_schema trust_schema = {
 	}, common_populate
 };
 
+/* CKO_X_TRUST_ASSERTION objects can be stored through PKCS #11, for
+ * compatibility reasons with gcr */
 const static builder_schema assertion_schema = {
-	GENERATED_CLASS,
+	NORMAL_BUILD,
 	{ COMMON_ATTRS,
 	  { CKA_X_PURPOSE, REQUIRE | CREATE },
 	  { CKA_X_CERTIFICATE_VALUE, CREATE },

--- a/trust/p11-kit-trust.module
+++ b/trust/p11-kit-trust.module
@@ -16,5 +16,10 @@ trust-policy: yes
 # retrieve trust information.
 x-trust-lookup: pkcs11:library-description=PKCS%2311%20Kit%20Trust%20Module
 
+# This is for drop-in compatibility with glib-networking and gcr. Those
+# projects used this non-standard attribute to denote slots to use to
+# store user trust information.
+x-trust-store: pkcs11:library-description=PKCS%2311%20Kit%20Trust%20Module;token=User%20Trust
+
 # Prevent this module being loaded by the proxy module
 disable-in: p11-kit-proxy


### PR DESCRIPTION
GCR has an API to store user certificates on a token:
https://developer.gnome.org/gcr/3.20/gcr-Trust-Storage-and-Lookups.html

The implementation of the API relies on the fact that there is a token backed by per-user storage.

Although previously such token was provided by gnome-keyring, the upstream decided to stop installing the p11-kit configuration for the gnome-keyring's PKCS#11 module in 3.28:
https://bugzilla.gnome.org/show_bug.cgi?id=791401
which leads to a regression in applications such as Geary:
https://bugzilla.gnome.org/show_bug.cgi?id=736640

This patch exposes the "User Trust" token as a drop-in replacement of gnome-keyring's trust storage.