### PR TITLE
uri: Make scheme comparison case-insensitive

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -953,3 +953,19 @@ fdwalk (int (* cb) (void *data, int fd),
 #endif /* HAVE_FDWALK */
 
 #endif /* OS_UNIX */
+
+int
+p11_ascii_tolower (int c)
+{
+	if (c >= 'A' && c <= 'Z')
+		return 'a' + (c - 'A');
+	return c;
+}
+
+int
+p11_ascii_toupper (int c)
+{
+	if (c >= 'a' && c <= 'z')
+		return 'A' + (c - 'a');
+	return c;
+}

--- a/common/compat.h
+++ b/common/compat.h
@@ -340,4 +340,7 @@ int        fdwalk           (int (* cb) (void *data, int fd),
 
 #endif
 
+int        p11_ascii_tolower (int c);
+int        p11_ascii_toupper (int c);
+
 #endif /* __COMPAT_H__ */

--- a/common/mock.c
+++ b/common/mock.c
@@ -2024,7 +2024,7 @@ mock_C_EncryptUpdate (CK_SESSION_HANDLE session,
 	}
 
 	for (i = 0; i < part_len; ++i)
-		encrypted_part[i] = toupper (part[i]);
+		encrypted_part[i] = p11_ascii_toupper (part[i]);
 	*encrypted_part_len = part_len;
 	return CKR_OK;
 }
@@ -2220,7 +2220,7 @@ mock_C_DecryptUpdate (CK_SESSION_HANDLE session,
 	}
 
 	for (i = 0; i < encrypted_part_len; ++i)
-		part[i] = tolower (encrypted_part[i]);
+		part[i] = p11_ascii_tolower (encrypted_part[i]);
 	*part_len = encrypted_part_len;
 	return CKR_OK;
 }

--- a/common/url.c
+++ b/common/url.c
@@ -75,8 +75,8 @@ p11_url_decode (const char *value,
 				free (result);
 				return NULL;
 			}
-			a = strchr (HEX_CHARS, tolower (value[0]));
-			b = strchr (HEX_CHARS, tolower (value[1]));
+			a = strchr (HEX_CHARS, p11_ascii_tolower (value[0]));
+			b = strchr (HEX_CHARS, p11_ascii_tolower (value[1]));
 			if (!a || !b) {
 				free (result);
 				return NULL;

--- a/p11-kit/test-uri.c
+++ b/p11-kit/test-uri.c
@@ -103,6 +103,26 @@ test_uri_parse (void)
 }
 
 static void
+test_uri_parse_case_insensitive (void)
+{
+	P11KitUri *uri;
+	int ret;
+
+	uri = p11_kit_uri_new ();
+	assert_ptr_not_null (uri);
+
+	ret = p11_kit_uri_parse ("PKCS11:", P11_KIT_URI_FOR_MODULE, uri);
+	assert_num_eq (P11_KIT_URI_OK, ret);
+
+	assert (is_module_empty (uri));
+	assert (is_slot_empty (uri));
+	assert (is_token_empty (uri));
+	assert (are_attributes_empty (uri));
+
+	p11_kit_uri_free (uri);
+}
+
+static void
 test_uri_parse_bad_scheme (void)
 {
 	P11KitUri *uri;
@@ -1619,6 +1639,7 @@ main (int argc,
       char *argv[])
 {
 	p11_test (test_uri_parse, "/uri/test_uri_parse");
+	p11_test (test_uri_parse_case_insensitive, "/uri/test_uri_parse_case_insensitive");
 	p11_test (test_uri_parse_bad_scheme, "/uri/test_uri_parse_bad_scheme");
 	p11_test (test_uri_parse_with_label, "/uri/test_uri_parse_with_label");
 	p11_test (test_uri_parse_with_empty_label, "/uri/test_uri_parse_with_empty_label");

--- a/p11-kit/uri.c
+++ b/p11-kit/uri.c
@@ -1628,7 +1628,7 @@ p11_kit_uri_parse (const char *string, P11KitUriType uri_type,
 {
 	const char *spos, *epos;
 	int ret;
-	size_t length;
+	size_t length, i;
 	char *allocated = NULL;
 
 	assert (string);
@@ -1648,8 +1648,14 @@ p11_kit_uri_parse (const char *string, P11KitUriType uri_type,
 		free (allocated);
 		return P11_KIT_URI_BAD_SCHEME;
 	}
-	ret = strncmp (string, P11_KIT_URI_SCHEME, strlen (P11_KIT_URI_SCHEME));
-	if (ret != 0) {
+	if (epos - string != P11_KIT_URI_SCHEME_LEN) {
+		free (allocated);
+		return P11_KIT_URI_BAD_SCHEME;
+	}
+	for (i = 0; i < P11_KIT_URI_SCHEME_LEN; i++)
+		if (p11_ascii_tolower (string[i]) != P11_KIT_URI_SCHEME[i])
+			break;
+	if (i != P11_KIT_URI_SCHEME_LEN) {
 		free (allocated);
 		return P11_KIT_URI_BAD_SCHEME;
 	}

--- a/trust/extract-jks.c
+++ b/trust/extract-jks.c
@@ -159,7 +159,7 @@ convert_alias (const char *input,
 	for (i = 0; i < length; i++) {
 		ch = input[i];
 		if (!isspace (ch) && (ch & 0x80) == 0) {
-			ch = tolower (ch);
+			ch = p11_ascii_tolower (ch);
 			p11_buffer_add (buf, &ch, 1);
 		}
 	}

--- a/trust/extract-openssl.c
+++ b/trust/extract-openssl.c
@@ -395,7 +395,7 @@ p11_openssl_canon_string (char *str,
 			/* If there has been a space, then add one */
 			if (sp)
 				*out++ = ' ';
-			*out++ = (*in & 0x80) ? *in : tolower (*in);
+			*out++ = (*in & 0x80) ? *in : p11_ascii_tolower (*in);
 			sp = false;
 			nsp = true;
 		/* If there has been a non-space, then note we should get one */


### PR DESCRIPTION
RFC 3986 suggests that implementations should accept uppercase letters as equivalent to lowercase in scheme names.