### PR TITLE
build: Don't use locale funcs if locale_t is not defined in locale.h

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -340,6 +340,12 @@ int        fdwalk           (int (* cb) (void *data, int fd),
 
 #endif
 
+/* If either locale_t or newlocale() is not available, strerror_l()
+ * cannot be used */
+#if !defined(HAVE_LOCALE_T) || !defined(HAVE_NEWLOCALE)
+#undef HAVE_STRERROR_L
+#endif
+
 int        p11_ascii_tolower (int c);
 int        p11_ascii_toupper (int c);
 

--- a/common/debug.c
+++ b/common/debug.c
@@ -73,7 +73,7 @@ static bool debug_strict = false;
 /* global variable exported in debug.h */
 int p11_debug_current_flags = ~0;
 
-#ifdef HAVE_LOCALE_H
+#ifdef HAVE_STRERROR_L
 extern locale_t p11_message_locale;
 #endif
 
@@ -163,7 +163,7 @@ p11_debug_message_err (int flag,
 		va_end (args);
 
 		snprintf (strerr, sizeof (strerr), "Unknown error %d", errnum);
-#if defined(HAVE_STRERROR_L) && defined(HAVE_NEWLOCALE)
+#ifdef HAVE_STRERROR_L
 		if (p11_message_locale != (locale_t) 0)
 			strncpy (strerr, strerror_l (errnum, p11_message_locale), sizeof (strerr));
 #else

--- a/common/library.c
+++ b/common/library.c
@@ -70,7 +70,7 @@ pthread_once_t p11_library_once = PTHREAD_ONCE_INIT;
 
 unsigned int p11_forkid = 1;
 
-#ifdef HAVE_LOCALE_H
+#ifdef HAVE_STRERROR_L
 extern locale_t p11_message_locale;
 #endif
 
@@ -130,7 +130,7 @@ p11_library_init_impl (void)
 	p11_mutex_init (&p11_virtual_mutex);
 	pthread_key_create (&thread_local, free);
 	p11_message_storage = thread_local_message;
-#ifdef HAVE_NEWLOCALE
+#ifdef HAVE_STRERROR_L
 	p11_message_locale = newlocale (LC_ALL_MASK, "POSIX", (locale_t) 0);
 #endif
 
@@ -152,7 +152,7 @@ p11_library_uninit (void)
 	free (pthread_getspecific (thread_local));
 	pthread_setspecific (thread_local, NULL);
 
-#ifdef HAVE_NEWLOCALE
+#ifdef HAVE_STRERROR_L
 	freelocale (p11_message_locale);
 #endif
 	p11_message_storage = dont_store_message;

--- a/common/message.c
+++ b/common/message.c
@@ -60,7 +60,7 @@
 
 static bool print_messages = false;
 
-#ifdef HAVE_LOCALE_H
+#ifdef HAVE_STRERROR_L
 locale_t p11_message_locale = (locale_t) 0;
 #endif
 
@@ -119,7 +119,7 @@ p11_message_err (int errnum,
 	buffer[length] = 0;
 
 	snprintf (strerr, sizeof (strerr), "Unknown error %d", errnum);
-#if defined(HAVE_STRERROR_L) && defined(HAVE_NEWLOCALE)
+#ifdef HAVE_STRERROR_L
 	if (p11_message_locale != (locale_t) 0)
 		strncpy (strerr, strerror_l (errnum, p11_message_locale), sizeof (strerr));
 #else

--- a/common/test-message.c
+++ b/common/test-message.c
@@ -44,7 +44,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifdef HAVE_LOCALE_H
+#ifdef HAVE_STRERROR_L
 extern locale_t p11_message_locale;
 #endif
 
@@ -54,7 +54,7 @@ test_with_err (void)
 	const char *last;
 	char *expected;
 
-#ifdef HAVE_NEWLOCALE
+#ifdef HAVE_STRERROR_L
 	p11_message_locale = newlocale (LC_ALL_MASK, "POSIX", (locale_t) 0);
 #endif
 
@@ -67,7 +67,7 @@ test_with_err (void)
 	assert_str_eq (expected, last);
 	free (expected);
 
-#ifdef HAVE_NEWLOCALE
+#ifdef HAVE_STRERROR_L
 	freelocale (p11_message_locale);
 #endif
 }

--- a/configure.ac
+++ b/configure.ac
@@ -96,12 +96,17 @@ if test "$os_unix" = "yes"; then
 		AC_MSG_ERROR([could not find socket])
 	])
 
-	# These are thngs we can work around
-	AC_CHECK_HEADERS([locale.h sys/resource.h ucred.h])
+	AC_CHECK_HEADERS([locale.h], [
+		AC_CHECK_TYPES([locale_t], [], [], [[#include <locale.h>]])
+		AC_CHECK_FUNCS([newlocale strerror_l])
+	])
+
+	# These are things we can work around
+	AC_CHECK_HEADERS([sys/resource.h ucred.h])
 	AC_CHECK_MEMBERS([struct dirent.d_type],,,[#include <dirent.h>])
 	AC_CHECK_FUNCS([getprogname getexecname basename mkstemp mkdtemp])
 	AC_CHECK_FUNCS([getauxval issetugid getresuid secure_getenv])
-	AC_CHECK_FUNCS([strnstr memdup newlocale strndup strerror_l strerror_r])
+	AC_CHECK_FUNCS([strnstr memdup strndup strerror_r])
 	AC_CHECK_FUNCS([reallocarray])
 	AC_CHECK_FUNCS([fdwalk])
 	AC_CHECK_FUNCS([setenv])


### PR DESCRIPTION
On macOS, locale_t is not defined in <locale.h>.  Although it is
defined in <xlocale.h>, we rather not use locales at all for POSIX
compliance.

Fixes #158.