### PR TITLE
common: do not use /proc on MacOS

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -912,6 +912,7 @@ fdwalk (int (* cb) (void *data, int fd),
 	struct rlimit rl;
 #endif
 
+#ifdef __linux__
 	dir = opendir ("/proc/self/fd");
 	if (dir != NULL) {
 		while ((de = readdir (dir)) != NULL) {
@@ -934,6 +935,7 @@ fdwalk (int (* cb) (void *data, int fd),
 		closedir (dir);
 		return res;
 	}
+#endif
 
 	/* No /proc, brute force */
 #ifdef HAVE_SYS_RESOURCE_H


### PR DESCRIPTION
I'm the maintainer for `p11-kit` in MacPorts. I'm submitting a patch we have downstream since 2014, to make it buildable on OS X 10.7 and earlier, and I believe it would be worth it to have it incorporated upstream. The relevant `opendir` call will always fail on macOS due to the absence of `/proc`, so nothing is lost by just `#ifdef`ing the code out.