### PR TITLE
build: Ease issetugid() check when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,15 +115,17 @@ if test "$os_unix" = "yes"; then
 
 	# Check if issetugid() is available and has compatible behavior with OpenBSD
 	AC_CHECK_FUNCS([issetugid], [
-		AC_MSG_CHECKING([whether issetugid() can detect setuid/setgid])
-		issetugid_openbsd=no
-		AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
-			[[return issetugid ();]])],
-			[chmod 02777 ./conftest$EXEEXT; ./conftest$EXEEXT || issetugid_openbsd=yes])
-		if test "$issetugid_openbsd" = yes; then
+		AC_CACHE_CHECK([whether issetugid() can detect setuid/setgid],
+			[ac_cv_issetugid_openbsd],
+			[ac_cv_issetugid_openbsd=no
+			AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
+				[[return issetugid ();]])],
+				[chmod 02777 ./conftest$EXEEXT; ./conftest$EXEEXT || ac_cv_issetugid_openbsd=yes],
+				[ac_cv_issetugid_openbsd=no],
+				[ac_cv_issetugid_openbsd="guessing no"])])
+		if test "$ac_cv_issetugid_openbsd" = yes; then
 			AC_DEFINE([HAVE_ISSETUGID_OPENBSD], [1], [Whether issetugid() has compatible behavior with OpenBSD])
 		fi
-		AC_MSG_RESULT([$issetugid_openbsd])
 	])
 
 	# Required functions


### PR DESCRIPTION
When cross-compiling, the configure check for issetugid() aborts,
because of the pessimistic default of AC_RUN_IFELSE.  This patch
provides the non-pessimistic default to AC_RUN_IFELSE and wrap the
macro invocation with AC_CACHE_CHECK so that the user can override the
check by setting ac_cv_issetugid_openbsd=yes, as suggested in:
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Runtime.html#Runtime