### PR TITLE
 rpc-server: p11_kit_remote_serve_tokens: Allow exporting all modules 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ x86_64-w64-mingw32
 
 /p11-kit-remote
 /p11-kit-server
+/p11-kit-remote-testable
+/p11-kit-server-testable
 /print-messages
 
 /po/POTFILES

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - os: linux
       sudo: required
       services: docker
-      env: BUILD_OPTS="--enable-coverage" COVERAGE=yes SRCDIR=/coverage BUILDDIR=/coverage EXTRA_PKGS="lcov"
+      env: BUILD_OPTS="--enable-coverage" COVERAGE=yes SRCDIR=/coverage BUILDDIR=/coverage EXTRA_PKGS="lcov python-pip"
     - os: linux
       sudo: required
       services: docker

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -22,7 +22,7 @@ COMMON_SRCS = \
 	p11-kit/messages.c \
 	p11-kit/rpc-transport.c p11-kit/rpc.h \
 	p11-kit/rpc-message.c p11-kit/rpc-message.h \
-	p11-kit/rpc-client.c p11-kit/rpc-server.c \
+	p11-kit/rpc-client.c \
 	p11-kit/uri.c \
 	p11-kit/virtual.c p11-kit/virtual.h \
 	p11-kit/virtual-fixed.h \
@@ -90,7 +90,8 @@ libp11_kit_la_LDFLAGS = \
 	-export-symbols-regex '^C_GetFunctionList|^p11_kit_'
 
 libp11_kit_la_SOURCES = \
-	p11-kit/proxy.c p11-kit/proxy.h p11-kit/proxy-init.c
+	p11-kit/proxy.c p11-kit/proxy.h p11-kit/proxy-init.c \
+	p11-kit/rpc-server.c \
 	$(NULL)
 
 libp11_kit_la_LIBADD = \

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -243,6 +243,15 @@ p11_kit_remote_LDADD = \
 	libp11-kit.la \
 	$(NULL)
 
+check_PROGRAMS += p11-kit-remote-testable
+p11_kit_remote_testable_SOURCES = $(p11_kit_remote_SOURCES)
+
+p11_kit_remote_testable_LDADD = \
+	libp11-tool.la \
+	libp11-common.la \
+	libp11-kit-testable.la \
+	$(NULL)
+
 private_PROGRAMS += p11-kit-server
 
 p11_kit_server_SOURCES = \
@@ -257,6 +266,23 @@ p11_kit_server_LDADD = \
 	$(NULL)
 
 p11_kit_server_CFLAGS = \
+	-DP11_KIT_REMOTE=\"p11-kit-remote\" \
+	$(COMMON_CFLAGS) \
+	$(LIBSYSTEMD_CFLAGS) \
+	$(NULL)
+
+check_PROGRAMS += p11-kit-server-testable
+p11_kit_server_testable_SOURCES = $(p11_kit_server_SOURCES)
+
+p11_kit_server_testable_LDADD = \
+	libp11-tool.la \
+	libp11-common.la \
+	libp11-kit-testable.la \
+	$(LIBSYSTEMD_LIBS) \
+	$(NULL)
+
+p11_kit_server_testable_CFLAGS = \
+	-DP11_KIT_REMOTE=\"p11-kit-remote-testable\" \
 	$(COMMON_CFLAGS) \
 	$(LIBSYSTEMD_CFLAGS) \
 	$(NULL)

--- a/p11-kit/proxy.h
+++ b/p11-kit/proxy.h
@@ -39,5 +39,8 @@ bool       p11_proxy_module_check                    (CK_FUNCTION_LIST_PTR modul
 
 void       p11_proxy_module_cleanup                  (void);
 
+CK_RV      p11_proxy_module_create                   (CK_FUNCTION_LIST_PTR *module,
+						      CK_FUNCTION_LIST_PTR *modules);
+
 
 #endif /* __P11_PROXY_H__ */

--- a/p11-kit/remote.h
+++ b/p11-kit/remote.h
@@ -58,7 +58,7 @@ int		       p11_kit_remote_serve_token	    (CK_FUNCTION_LIST *module,
 
 int                    p11_kit_remote_serve_tokens          (const char **tokens,
 							     size_t n_tokens,
-							     CK_FUNCTION_LIST *module,
+							     CK_FUNCTION_LIST *provider,
 							     int in_fd,
 							     int out_fd);
 

--- a/p11-kit/server.c
+++ b/p11-kit/server.c
@@ -496,7 +496,7 @@ server_loop (Server *server,
 				}
 
 				n_args = 0;
-				args[n_args] = "p11-kit-remote";
+				args[n_args] = P11_KIT_REMOTE;
 				n_args++;
 
 				if (server->provider) {

--- a/p11-kit/test-server.c
+++ b/p11-kit/test-server.c
@@ -65,7 +65,7 @@ static void
 setup_server (void *arg)
 {
 	char *argv[] = {
-		"p11-kit-server",
+		"p11-kit-server-testable",
 		"-f",
 		"--provider",
 		BUILDDIR "/.libs/mock-one" SHLEXT,
@@ -110,7 +110,7 @@ setup_server (void *arg)
 	if (test.pid == 0) {
 		close (STDOUT_FILENO);
 		dup2 (fds[0], STDOUT_FILENO);
-		execv (BUILDDIR "/p11-kit-server", argv);
+		execv (BUILDDIR "/p11-kit-server-testable", argv);
 		_exit (0);
 	}
 


### PR DESCRIPTION
This amends #173. Previously, `p11-kit server` and `p11-kit remote` were not capable of serving tokens from across multiple modules, even if the user specify `p11-kit-proxy.so` as the argument (due to the recursive loading check).

This patch removes the limitation and changes the default behavior of those commands to serve tokens from all modules.