### PR TITLE
 proxy: Fail early if there is no slot mapping

### DIFF
--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -123,6 +123,8 @@ map_slot_unlocked (Proxy *px,
 
 	if (slot > px->n_mappings) {
 		return CKR_SLOT_ID_INVALID;
+	} else if (px->n_mappings == 0) {
+		return CKR_SLOT_ID_INVALID;
 	} else {
 		assert (px->mappings);
 		memcpy (mapping, &px->mappings[slot], sizeof (Mapping));


### PR DESCRIPTION
Previously, a rare assertion failure (`px->mappings != NULL`) could happen if the proxy doesn't expose any token and the caller accesses the proxy with slot ID == 0x10.