### PR TITLE
build: Make reallocarray detection robuster

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -258,7 +258,7 @@ char *     strndup          (const char *data,
 
 #endif /* HAVE_STRDUP */
 
-#ifndef HAVE_REALLOCARRAY
+#if defined HAVE_DECL_REALLOCARRAY && !HAVE_DECL_REALLOCARRAY
 
 void *     reallocarray     (void *ptr,
                              size_t nmemb,

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,7 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([getauxval getresuid secure_getenv])
 	AC_CHECK_FUNCS([strnstr memdup strndup strerror_r])
 	AC_CHECK_FUNCS([reallocarray])
+	AC_CHECK_DECLS([reallocarray], [], [], [[#include <stdlib.h>]])
 	AC_CHECK_FUNCS([fdwalk])
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])


### PR DESCRIPTION
On NetBSD, reallocarray is not declared until _OPENBSD_SOURCE is
defined.  Reported by Patrick Welche in:
https://lists.freedesktop.org/archives/p11-glue/2018-July/000691.html