### PR TITLE
build: Link to libpthread, if pthread_atfork() needs to be used

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
  * server: Enable socket activation through systemd [PR#173]
  * rpc-server: p11_kit_remote_serve_tokens: Allow exporting all modules [PR#174]
  * proxy: Fail early if there is no slot mapping [PR#175]
- * Remove hard dependency on libpthread [PR#177]
+ * Remove hard dependency on libpthread on glibc systems [PR#177]
  * Build fixes [PR#170, PR#176]
 
 0.23.12 (stable)

--- a/common/library.c
+++ b/common/library.c
@@ -145,12 +145,14 @@ extern int __register_atfork (void (*prepare) (void), void (*parent) (void),
 
 #ifdef HAVE___REGISTER_ATFORK
 
-#define p11_register_atfork(a,b,c,d) \
-	(__register_atfork((a),(b),(c),(d)))
+extern void *__dso_handle;
+
+#define p11_register_atfork(a,b,c) \
+	(__register_atfork((a),(b),(c),__dso_handle))
 
 #else
 
-#define p11_register_atfork(a,b,c,d) \
+#define p11_register_atfork(a,b,c) \
 	(pthread_atfork((a),(b),(c)))
 
 #endif /* HAVE___REGISTER_ATFORK */
@@ -177,7 +179,7 @@ p11_library_init_impl (void)
 	p11_message_locale = newlocale (LC_ALL_MASK, "POSIX", (locale_t) 0);
 #endif
 
-	p11_register_atfork (NULL, NULL, count_forks, NULL);
+	p11_register_atfork (NULL, NULL, count_forks);
 }
 
 void

--- a/configure.ac
+++ b/configure.ac
@@ -123,7 +123,12 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])
 	AC_CHECK_FUNCS([getpeerucred])
-	AC_CHECK_FUNCS([__register_atfork])
+	# If __register_atfork() is not available, we have to link to
+	# libpthread so that the non-stub version of pthread_atfork() work
+	# FIXME: replace pthread_atfork() uses with manual PID checks
+	AC_CHECK_FUNCS([__register_atfork], , [
+		AC_CHECK_LIB([pthread], [pthread_atfork])
+	])
 	AC_CHECK_DECLS([__register_atfork])
 
 	# Check if issetugid() is available and has compatible behavior with OpenBSD


### PR DESCRIPTION
On non-glibc systems (e.g., FreeBSD), pthread_atfork() stub is
provided as a nop and our fork detection mechanism doesn't work.  Pull
in the actual implementation from libpthread in that case.

This is a follow-up of #177.