### PR TITLE
 proxy: Avoid invalid memory access when unloading proxy module

### DIFF
--- a/.travis/linux/before_install.sh
+++ b/.travis/linux/before_install.sh
@@ -5,5 +5,5 @@ export CONTAINER=$(docker run -d fedora sleep 1800)
 
 docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
 docker exec $CONTAINER dnf -y builddep p11-kit
-docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl $EXTRA_PKGS
+docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind $EXTRA_PKGS
 docker exec $CONTAINER useradd user

--- a/.travis/linux/script.sh
+++ b/.travis/linux/script.sh
@@ -9,3 +9,4 @@ docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && $SCAN_BUILD make -j$(npr
 docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && P11_KIT_DEBUG=all LSAN_OPTIONS="$LSAN_OPTIONS" P11_KIT_TEST_LD_PRELOAD=\"$P11_KIT_TEST_LD_PRELOAD\" make check -j$(nproc) V=1 $CHECK_OPTS"
 docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && make install"
 docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && make installcheck"
+docker exec $CONTAINER su - user sh -c "cd $BUILDDIR && valgrind --error-exitcode=81 pkcs11-tool --module p11-kit-proxy.so -L"


### PR DESCRIPTION
When loading and unloading p11-kit-proxy.so with pkcs11-tool, it
accesses already free'd memory area:
```
$ valgrind pkcs11-tool --module p11-kit-proxy.so -L
==25173== Invalid read of size 8
==25173==    at 0x64BF493: p11_proxy_module_cleanup (proxy.c:1724)
==25173==    by 0x64BD028: _p11_kit_fini (proxy-init.c:65)
==25173==    by 0x401477C: _dl_close_worker (in /usr/lib64/ld-2.27.so)
==25173==    by 0x4014E1D: _dl_close (in /usr/lib64/ld-2.27.so)
==25173==    by 0x5E08C4E: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==25173==    by 0x5E08CDE: _dl_catch_error (in /usr/lib64/libc-2.27.so)
==25173==    by 0x58B1724: _dlerror_run (in /usr/lib64/libdl-2.27.so)
==25173==    by 0x58B1113: dlclose (in /usr/lib64/libdl-2.27.so)
==25173==    by 0x11E5A7: ??? (in /usr/bin/pkcs11-tool)
==25173==    by 0x110023: ??? (in /usr/bin/pkcs11-tool)
==25173==    by 0x5CF624A: (below main) (in /usr/lib64/libc-2.27.so)
==25173==  Address 0x61231c8 is 552 bytes inside a block of size 584 free'd
==25173==    at 0x4C2FDAC: free (vg_replace_malloc.c:530)
==25173==    by 0x6548492: p11_virtual_unwrap (virtual.c:2902)
==25173==    by 0x64BF492: p11_proxy_module_cleanup (proxy.c:1723)
```