### PR TITLE
Update pkcs11 header to allow SoftHSMv2 to compile

### DIFF
--- a/common/pkcs11.h
+++ b/common/pkcs11.h
@@ -193,6 +193,20 @@ extern "C" {
 #define source_data pSourceData
 #define source_data_len ulSourceDataLen
 
+#define counter_bits ulCounterBits
+#define iv_ptr pIv
+#define iv_len ulIvLen
+#define iv_bits ulIvBits
+#define aad_ptr pAAD
+#define aad_len ulAADLen
+#define tag_bits ulTagBits
+#define shared_data_len ulSharedDataLen
+#define shared_data pSharedData
+#define public_data_len ulPublicDataLen
+#define public_data pPublicData
+#define string_data pData
+#define string_data_len ulLen
+#define data_params pData
 #endif	/* CRYPTOKI_COMPAT */
 
 
@@ -371,6 +385,24 @@ typedef unsigned long ck_key_type_t;
 #define CKK_AES			(0x1fUL)
 #define CKK_BLOWFISH		(0x20UL)
 #define CKK_TWOFISH		(0x21UL)
+#define CKK_SECURID		(0x22UL)
+#define CKK_HOTP		(0x23UL)
+#define CKK_ACTI		(0x24UL)
+#define CKK_CAMELLIA		(0x25UL)
+#define CKK_ARIA		(0x26UL)
+#define CKK_MD5_HMAC		(0x27UL)
+#define CKK_SHA_1_HMAC		(0x28UL)
+#define CKK_RIPEMD128_HMAC	(0x29UL)
+#define CKK_RIPEMD160_HMAC	(0x2aUL)
+#define CKK_SHA256_HMAC		(0x2bUL)
+#define CKK_SHA384_HMAC		(0x2cUL)
+#define CKK_SHA512_HMAC		(0x2dUL)
+#define CKK_SHA224_HMAC		(0x2eUL)
+#define CKK_SEED		(0x2fUL)
+#define CKK_GOSTR3410		(0x30UL)
+#define CKK_GOSTR3411		(0x31UL)
+#define CKK_GOST28147		(0x32UL)
+#define CKK_EC_EDWARDS		(0x40UL)
 #define CKK_VENDOR_DEFINED	((unsigned long) (1UL << 31))
 
 
@@ -381,6 +413,7 @@ typedef unsigned long ck_certificate_type_t;
 #define CKC_WTLS		(2UL)
 #define CKC_VENDOR_DEFINED	((unsigned long) (1UL << 31))
 
+#define CKC_OPENPGP		(CKC_VENDOR_DEFINED|0x504750UL)
 
 typedef unsigned long ck_attribute_type_t;
 
@@ -403,6 +436,7 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_URL				(0x89UL)
 #define CKA_HASH_OF_SUBJECT_PUBLIC_KEY	(0x8aUL)
 #define CKA_HASH_OF_ISSUER_PUBLIC_KEY	(0x8bUL)
+#define CKA_NAME_HASH_ALGORITHM         (0x8cUL)
 #define CKA_CHECK_VALUE			(0x90UL)
 #define CKA_KEY_TYPE			(0x100UL)
 #define CKA_SUBJECT			(0x101UL)
@@ -428,6 +462,7 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_EXPONENT_1			(0x126UL)
 #define CKA_EXPONENT_2			(0x127UL)
 #define CKA_COEFFICIENT			(0x128UL)
+#define CKA_PUBLIC_KEY_INFO		(0x129UL)
 #define CKA_PRIME			(0x130UL)
 #define CKA_SUBPRIME			(0x131UL)
 #define CKA_BASE			(0x132UL)
@@ -442,6 +477,7 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_KEY_GEN_MECHANISM		(0x166UL)
 #define CKA_MODIFIABLE			(0x170UL)
 #define CKA_COPYABLE			(0x171UL)
+#define CKA_DESTROYABLE			(0x172UL)
 #define CKA_ECDSA_PARAMS		(0x180UL)
 #define CKA_EC_PARAMS			(0x180UL)
 #define CKA_EC_POINT			(0x181UL)
@@ -485,6 +521,7 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_SUPPORTED_CMS_ATTRIBUTES	(0x503UL)
 #define CKA_WRAP_TEMPLATE		(CKF_ARRAY_ATTRIBUTE | 0x211UL)
 #define CKA_UNWRAP_TEMPLATE		(CKF_ARRAY_ATTRIBUTE | 0x212UL)
+#define CKA_DERIVE_TEMPLATE		(CKF_ARRAY_ATTRIBUTE | 0x213UL)
 #define CKA_ALLOWED_MECHANISMS		(CKF_ARRAY_ATTRIBUTE | 0x600UL)
 #define CKA_VENDOR_DEFINED		((unsigned long) (1UL << 31))
 
@@ -525,6 +562,10 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_DSA_KEY_PAIR_GEN		(0x10UL)
 #define	CKM_DSA				(0x11UL)
 #define CKM_DSA_SHA1			(0x12UL)
+#define CKM_DSA_SHA224			(0x13UL)
+#define CKM_DSA_SHA256			(0x14UL)
+#define CKM_DSA_SHA384			(0x15UL)
+#define CKM_DSA_SHA512			(0x16UL)
 #define CKM_DH_PKCS_KEY_PAIR_GEN	(0x20UL)
 #define CKM_DH_PKCS_DERIVE		(0x21UL)
 #define	CKM_X9_42_DH_KEY_PAIR_GEN	(0x30UL)
@@ -537,6 +578,18 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_SHA256_RSA_PKCS_PSS		(0x43UL)
 #define CKM_SHA384_RSA_PKCS_PSS		(0x44UL)
 #define CKM_SHA512_RSA_PKCS_PSS		(0x45UL)
+#define CKM_SHA512_224			(0x48UL)
+#define CKM_SHA512_224_HMAC		(0x49UL)
+#define CKM_SHA512_224_HMAC_GENERAL	(0x4aUL)
+#define CKM_SHA512_224_KEY_DERIVATION	(0x4bUL)
+#define CKM_SHA512_256			(0x4cUL)
+#define CKM_SHA512_256_HMAC		(0x4dUL)
+#define CKM_SHA512_256_HMAC_GENERAL	(0x4eUL)
+#define CKM_SHA512_256_KEY_DERIVATION	(0x4fUL)
+#define CKM_SHA512_T			(0x50UL)
+#define CKM_SHA512_T_HMAC		(0x51UL)
+#define CKM_SHA512_T_HMAC_GENERAL	(0x52UL)
+#define CKM_SHA512_T_KEY_DERIVATION	(0x53UL)
 #define CKM_RC2_KEY_GEN			(0x100UL)
 #define CKM_RC2_ECB			(0x101UL)
 #define	CKM_RC2_CBC			(0x102UL)
@@ -558,6 +611,8 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_DES3_MAC			(0x134UL)
 #define CKM_DES3_MAC_GENERAL		(0x135UL)
 #define CKM_DES3_CBC_PAD		(0x136UL)
+#define CKM_DES3_CMAC_GENERAL		(0x137UL)
+#define CKM_DES3_CMAC			(0x138UL)
 #define CKM_CDMF_KEY_GEN		(0x140UL)
 #define CKM_CDMF_ECB			(0x141UL)
 #define CKM_CDMF_CBC			(0x142UL)
@@ -679,9 +734,40 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_WTLS_PRF			(0x3d3UL)
 #define CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE (0x3d4UL)
 #define CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE (0x3d5UL)
+#define CKM_TLS10_MAC_SERVER		(0x3d6UL)
+#define CKM_TLS10_MAC_CLIENT		(0x3d7UL)
+#define CKM_TLS12_MAC			(0x3d8UL)
+#define CKM_TLS12_KDF			(0x3d9UL)
+#define CKM_TLS12_MASTER_KEY_DERIVE	(0x3e0UL)
+#define CKM_TLS12_KEY_AND_MAC_DERIVE	(0x3e1UL)
+#define CKM_TLS12_MASTER_KEY_DERIVE_DH	(0x3e2UL)
+#define CKM_TLS12_KEY_SAFE_DERIVE	(0x3e3UL)
+#define CKM_TLS_MAC			(0x3e4UL)
+#define CKM_TLS_KDF			(0x3e5UL)
 #define CKM_KEY_WRAP_LYNKS		(0x400UL)
 #define CKM_KEY_WRAP_SET_OAEP		(0x401UL)
 #define CKM_CMS_SIG			(0x500UL)
+#define CKM_KIP_DERIVE			(0x510UL)
+#define CKM_KIP_WRAP			(0x511UL)
+#define CKM_KIP_MAC			(0x512UL)
+#define CKM_CAMELLIA_KEY_GEN		(0x550UL)
+#define CKM_CAMELLIA_CTR		(0x558UL)
+#define CKM_ARIA_KEY_GEN		(0x560UL)
+#define CKM_ARIA_ECB			(0x561UL)
+#define CKM_ARIA_CBC			(0x562UL)
+#define CKM_ARIA_MAC			(0x563UL)
+#define CKM_ARIA_MAC_GENERAL		(0x564UL)
+#define CKM_ARIA_CBC_PAD		(0x565UL)
+#define CKM_ARIA_ECB_ENCRYPT_DATA	(0x566UL)
+#define CKM_ARIA_CBC_ENCRYPT_DATA	(0x567UL)
+#define CKM_SEED_KEY_GEN		(0x650UL)
+#define CKM_SEED_ECB			(0x651UL)
+#define CKM_SEED_CBC			(0x652UL)
+#define CKM_SEED_MAC			(0x653UL)
+#define CKM_SEED_MAC_GENERAL		(0x654UL)
+#define CKM_SEED_CBC_PAD		(0x655UL)
+#define CKM_SEED_ECB_ENCRYPT_DATA	(0x656UL)
+#define CKM_SEED_CBC_ENCRYPT_DATA	(0x657UL)
 #define CKM_SKIPJACK_KEY_GEN		(0x1000UL)
 #define CKM_SKIPJACK_ECB64		(0x1001UL)
 #define CKM_SKIPJACK_CBC64		(0x1002UL)
@@ -707,9 +793,15 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_EC_KEY_PAIR_GEN		(0x1040UL)
 #define CKM_ECDSA			(0x1041UL)
 #define CKM_ECDSA_SHA1			(0x1042UL)
+#define CKM_ECDSA_SHA224		(0x1043UL)
+#define CKM_ECDSA_SHA256		(0x1044UL)
+#define CKM_ECDSA_SHA384		(0x1045UL)
+#define CKM_ECDSA_SHA512		(0x1046UL)
 #define CKM_ECDH1_DERIVE		(0x1050UL)
 #define CKM_ECDH1_COFACTOR_DERIVE	(0x1051UL)
 #define CKM_ECMQV_DERIVE		(0x1052UL)
+#define CKM_ECDH_AES_KEY_WRAP		(0x1053UL)
+#define CKM_RSA_AES_KEY_WRAP		(0x1054UL)
 #define CKM_JUNIPER_KEY_GEN		(0x1060UL)
 #define CKM_JUNIPER_ECB128		(0x1061UL)
 #define CKM_JUNIPER_CBC128		(0x1062UL)
@@ -723,10 +815,21 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_AES_MAC			(0x1083UL)
 #define CKM_AES_MAC_GENERAL		(0x1084UL)
 #define CKM_AES_CBC_PAD			(0x1085UL)
+#define CKM_AES_CTR			(0x1086UL)
+#define CKM_AES_GCM			(0x1087UL)
+#define CKM_AES_CCM			(0x1088UL)
+#define CKM_AES_CTS			(0x1089UL)
+#define CKM_AES_CMAC			(0x108aUL)
+#define CKM_AES_CMAC_GENERAL		(0x108bUL)
+#define CKM_AES_XCBC_MAC		(0x108cUL)
+#define CKM_AES_XCBC_MAC_96		(0x108dUL)
+#define CKM_AES_GMAC			(0x108eUL)
 #define CKM_BLOWFISH_KEY_GEN		(0x1090UL)
 #define CKM_BLOWFISH_CBC		(0x1091UL)
 #define CKM_TWOFISH_KEY_GEN		(0x1092UL)
 #define CKM_TWOFISH_CBC			(0x1093UL)
+#define CKM_BLOWFISH_CBC_PAD		(0x1094UL)
+#define CKM_TWOFISH_CBC_PAD		(0x1095UL)
 #define CKM_DES_ECB_ENCRYPT_DATA	(0x1100UL)
 #define CKM_DES_CBC_ENCRYPT_DATA	(0x1101UL)
 #define CKM_DES3_ECB_ENCRYPT_DATA	(0x1102UL)
@@ -748,27 +851,42 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_DSA_PARAMETER_GEN		(0x2000UL)
 #define CKM_DH_PKCS_PARAMETER_GEN	(0x2001UL)
 #define CKM_X9_42_DH_PARAMETER_GEN	(0x2002UL)
+#define CKM_DSA_PROBABLISTIC_PARAMETER_GEN	(0x2003UL)
+#define CKM_DSA_SHAWE_TAYLOR_PARAMETER_GEN	(0x2004UL)
+#define CKM_AES_OFB			(0x2104UL)
+#define CKM_AES_CFB64			(0x2105UL)
+#define CKM_AES_CFB8			(0x2106UL)
+#define CKM_AES_CFB128			(0x2107UL)
+#define CKM_AES_CFB1			(0x2108UL)
+
 #define CKM_VENDOR_DEFINED		((unsigned long) (1UL << 31))
 
 /* Ammendments */
-#define CKM_SHA224 (0x255UL)
-#define CKM_SHA224_HMAC (0x256UL)
-#define CKM_SHA224_HMAC_GENERAL (0x257UL)
-#define CKM_SHA224_RSA_PKCS (0x46UL)
-#define CKM_SHA224_RSA_PKCS_PSS (0x47UL)
-#define CKM_SHA224_KEY_DERIVATION (0x396UL)
+#define CKM_SHA224			(0x255UL)
+#define CKM_SHA224_HMAC			(0x256UL)
+#define CKM_SHA224_HMAC_GENERAL		(0x257UL)
+#define CKM_SHA224_RSA_PKCS		(0x46UL)
+#define CKM_SHA224_RSA_PKCS_PSS		(0x47UL)
+#define CKM_SHA224_KEY_DERIVATION	(0x396UL)
 
-#define CKM_CAMELLIA_KEY_GEN (0x550UL)
-#define CKM_CAMELLIA_ECB (0x551UL)
-#define CKM_CAMELLIA_CBC (0x552UL)
-#define CKM_CAMELLIA_MAC (0x553UL)
-#define CKM_CAMELLIA_MAC_GENERAL (0x554UL)
-#define CKM_CAMELLIA_CBC_PAD (0x555UL)
-#define CKM_CAMELLIA_ECB_ENCRYPT_DATA (0x556UL)
-#define CKM_CAMELLIA_CBC_ENCRYPT_DATA (0x557UL)
+#define CKM_CAMELLIA_KEY_GEN		(0x550UL)
+#define CKM_CAMELLIA_ECB		(0x551UL)
+#define CKM_CAMELLIA_CBC		(0x552UL)
+#define CKM_CAMELLIA_MAC		(0x553UL)
+#define CKM_CAMELLIA_MAC_GENERAL	(0x554UL)
+#define CKM_CAMELLIA_CBC_PAD		(0x555UL)
+#define CKM_CAMELLIA_ECB_ENCRYPT_DATA	(0x556UL)
+#define CKM_CAMELLIA_CBC_ENCRYPT_DATA	(0x557UL)
 
-#define CKM_AES_KEY_WRAP (0x2109UL)
-#define CKM_AES_KEY_WRAP_PAD (0x210aUL)
+#define CKM_AES_KEY_WRAP		(0x2109UL)
+#define CKM_AES_KEY_WRAP_PAD		(0x210aUL)
+
+#define CKM_RSA_PKCS_TPM_1_1		(0x4001UL)
+#define CKM_RSA_PKCS_OAEP_TPM_1_1	(0x4002UL)
+
+/* From version 3.0 */
+#define CKM_EC_EDWARDS_KEY_PAIR_GEN	(0x1055UL)
+#define CKM_EDDSA			(0x1057UL)
 
 /* Attribute and other constants related to OTP */
 #define CK_OTP_FORMAT_DECIMAL		(0UL)
@@ -856,6 +974,61 @@ struct ck_rsa_pkcs_oaep_params {
   unsigned long source_data_len;
 };
 
+struct ck_aes_ctr_params {
+  unsigned long counter_bits;
+  unsigned char cb[16];
+};
+
+struct ck_gcm_params {
+  unsigned char *iv_ptr;
+  unsigned long iv_len;
+  unsigned long iv_bits;
+  unsigned char *aad_ptr;
+  unsigned long aad_len;
+  unsigned long tag_bits;
+};
+
+
+/* The following EC Key Derivation Functions are defined */
+#define CKD_NULL			(0x01UL)
+#define CKD_SHA1_KDF			(0x02UL)
+
+/* The following X9.42 DH key derivation functions are defined */
+#define CKD_SHA1_KDF_ASN1		(0x03UL)
+#define CKD_SHA1_KDF_CONCATENATE	(0x04UL)
+#define CKD_SHA224_KDF			(0x05UL)
+#define CKD_SHA256_KDF			(0x06UL)
+#define CKD_SHA384_KDF			(0x07UL)
+#define CKD_SHA512_KDF			(0x08UL)
+#define CKD_CPDIVERSIFY_KDF		(0x09UL)
+
+typedef unsigned long ck_ec_kdf_t;
+
+struct ck_ecdh1_derive_params {
+  ck_ec_kdf_t kdf;
+  unsigned long shared_data_len;
+  unsigned char *shared_data;
+  unsigned long public_data_len;
+  unsigned char *public_data;
+};
+
+struct ck_key_derivation_string_data {
+  unsigned char *string_data;
+  unsigned long string_data_len;
+};
+
+struct ck_des_cbc_encrypt_data_params {
+  unsigned char iv[8];
+  unsigned char *data_params;
+  unsigned long length;
+};
+
+struct ck_aes_cbc_encrypt_data_params {
+  unsigned char iv[16];
+  unsigned char *data_params;
+  unsigned long length;
+};
+
 #define CKF_HW			(1UL << 0)
 #define CKF_ENCRYPT		(1UL << 8)
 #define CKF_DECRYPT		(1UL << 9)
@@ -870,6 +1043,11 @@ struct ck_rsa_pkcs_oaep_params {
 #define CKF_UNWRAP		(1UL << 18)
 #define CKF_DERIVE		(1UL << 19)
 #define CKF_EXTENSION		((unsigned long) (1UL << 31))
+
+#define CKF_EC_F_P		(1UL << 20)
+#define CKF_EC_NAMEDCURVE	(1UL << 23)
+#define CKF_EC_UNCOMPRESS	(1UL << 24)
+#define CKF_EC_COMPRESS		(1UL << 25)
 
 
 /* Flags for C_WaitForSlotEvent.  */
@@ -1274,6 +1452,7 @@ struct ck_c_initialize_args
 #define CKR_ATTRIBUTE_SENSITIVE			(0x11UL)
 #define CKR_ATTRIBUTE_TYPE_INVALID		(0x12UL)
 #define CKR_ATTRIBUTE_VALUE_INVALID		(0x13UL)
+#define CKR_ACTION_PROHIBITED			(0x1BUL)
 #define CKR_DATA_INVALID			(0x20UL)
 #define CKR_DATA_LEN_RANGE			(0x21UL)
 #define CKR_DEVICE_ERROR			(0x30UL)
@@ -1353,6 +1532,9 @@ struct ck_c_initialize_args
 #define CKR_PUBLIC_KEY_INVALID			(0x1c4UL)
 #define CKR_FUNCTION_REJECTED			(0x200UL)
 #define CKR_VENDOR_DEFINED			((unsigned long) (1UL << 31))
+
+
+#define CKZ_DATA_SPECIFIED			(0x01UL)
 
 
 
@@ -1442,7 +1624,27 @@ typedef struct ck_rsa_pkcs_pss_params *CK_RSA_PKCS_PSS_PARAMS_PTR;
 typedef struct ck_rsa_pkcs_oaep_params CK_RSA_PKCS_OAEP_PARAMS;
 typedef struct ck_rsa_pkcs_oaep_params *CK_RSA_PKCS_OAEP_PARAMS_PTR;
 
+typedef struct ck_aes_ctr_params CK_AES_CTR_PARAMS;
+typedef struct ck_aes_ctr_params *CK_AES_CTR_PARAMS_PTR;
+
+typedef struct ck_gcm_params CK_GCM_PARAMS;
+typedef struct ck_gcm_params *CK_GCM_PARAMS_PTR;
+
+typedef struct ck_ecdh1_derive_params CK_ECDH1_DERIVE_PARAMS;
+typedef struct ck_ecdh1_derive_params *CK_ECDH1_DERIVE_PARAMS_PTR;
+
+typedef struct ck_key_derivation_string_data CK_KEY_DERIVATION_STRING_DATA;
+typedef struct ck_key_derivation_string_data *CK_KEY_DERIVATION_STRING_DATA_PTR;
+
+typedef struct ck_des_cbc_encrypt_data_params CK_DES_CBC_ENCRYPT_DATA_PARAMS;
+typedef struct ck_des_cbc_encrypt_data_params *CK_DES_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+typedef struct ck_aes_cbc_encrypt_data_params CK_AES_CBC_ENCRYPT_DATA_PARAMS;
+typedef struct ck_aes_cbc_encrypt_data_params *CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+#ifndef NULL_PTR
 #define NULL_PTR NULL
+#endif
 
 /* Delete the helper macros defined at the top of the file.  */
 #undef ck_flags_t


### PR DESCRIPTION
This patch updates common/pkcs11.h with constants and structure definitions that are required for SoftHSMv2 to be compiled using a copy of this header.

It would be nice to have these changes in p11-kit as well, to avoid maintenance effort.