### PR TITLE
Resolves: rhbz#1615616 crash during __run_exit_handlers

### DIFF
--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -1714,14 +1714,16 @@ void
 p11_proxy_module_cleanup (void)
 {
 	State *state, *next;
+	CK_FUNCTION_LIST **loaded;
 
 	state = all_instances;
 	all_instances = NULL;
 
 	for (; state != NULL; state = next) {
 		next = state->next;
+		loaded = state->loaded;
 		p11_virtual_unwrap (state->wrapped);
-		p11_kit_modules_release (state->loaded);
+		p11_kit_modules_release (loaded);
 	}
 }
 
@@ -1735,9 +1737,10 @@ static void
 proxy_module_free (p11_virtual *virt)
 {
 	State *state = (State *)virt;
+	CK_FUNCTION_LIST **loaded = state->loaded;
 
 	p11_virtual_unwrap (state->wrapped);
-	p11_kit_modules_release (state->loaded);
+	p11_kit_modules_release (loaded);
 	free (state);
 }
 


### PR DESCRIPTION
in p11_proxy_module_cleanup on calling p11_virtual_unwrap state has the same
value as wrapper->virt has in p11_virtual_unwrap when its passed to
wrapper->destroyer, so dereferencing state after callling p11_virtual_unwrap
results in junk