### PR TITLE
build: Restore libpthread dependency

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
  * server: Enable socket activation through systemd [PR#173]
  * rpc-server: p11_kit_remote_serve_tokens: Allow exporting all modules [PR#174]
  * proxy: Fail early if there is no slot mapping [PR#175]
- * Remove hard dependency on libpthread on glibc systems [PR#177]
+ * Remove hard dependency on libpthread [PR#177]
  * Build fixes [PR#170, PR#176]
 
 0.23.12 (stable)

--- a/common/library.c
+++ b/common/library.c
@@ -145,14 +145,12 @@ extern int __register_atfork (void (*prepare) (void), void (*parent) (void),
 
 #ifdef HAVE___REGISTER_ATFORK
 
-extern void *__dso_handle;
-
-#define p11_register_atfork(a,b,c) \
-	(__register_atfork((a),(b),(c),__dso_handle))
+#define p11_register_atfork(a,b,c,d) \
+	(__register_atfork((a),(b),(c),(d)))
 
 #else
 
-#define p11_register_atfork(a,b,c) \
+#define p11_register_atfork(a,b,c,d) \
 	(pthread_atfork((a),(b),(c)))
 
 #endif /* HAVE___REGISTER_ATFORK */
@@ -179,7 +177,7 @@ p11_library_init_impl (void)
 	p11_message_locale = newlocale (LC_ALL_MASK, "POSIX", (locale_t) 0);
 #endif
 
-	p11_register_atfork (NULL, NULL, count_forks);
+	p11_register_atfork (NULL, NULL, count_forks, NULL);
 }
 
 void

--- a/common/library.c
+++ b/common/library.c
@@ -138,23 +138,6 @@ _p11_library_get_thread_local (void)
 }
 #endif
 
-#if defined(HAVE_DECL___REGISTER_ATFORK) && !HAVE_DECL___REGISTER_ATFORK
-extern int __register_atfork (void (*prepare) (void), void (*parent) (void),
-			      void (*child) (void), void *dso_handle);
-#endif /* HAVE_DECL___REGISTER_ATFORK */
-
-#ifdef HAVE___REGISTER_ATFORK
-
-#define p11_register_atfork(a,b,c,d) \
-	(__register_atfork((a),(b),(c),(d)))
-
-#else
-
-#define p11_register_atfork(a,b,c,d) \
-	(pthread_atfork((a),(b),(c)))
-
-#endif /* HAVE___REGISTER_ATFORK */
-
 static void
 count_forks (void)
 {
@@ -177,7 +160,7 @@ p11_library_init_impl (void)
 	p11_message_locale = newlocale (LC_ALL_MASK, "POSIX", (locale_t) 0);
 #endif
 
-	p11_register_atfork (NULL, NULL, count_forks, NULL);
+	pthread_atfork (NULL, NULL, count_forks);
 }
 
 void

--- a/configure.ac
+++ b/configure.ac
@@ -123,8 +123,6 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])
 	AC_CHECK_FUNCS([getpeerucred])
-	AC_CHECK_FUNCS([__register_atfork])
-	AC_CHECK_DECLS([__register_atfork])
 
 	# Check if issetugid() is available and has compatible behavior with OpenBSD
 	AC_CHECK_FUNCS([issetugid], [

--- a/configure.ac
+++ b/configure.ac
@@ -79,16 +79,6 @@ if test "$os_unix" = "yes"; then
 		])
 	])
 
-	SAVE_LIBS="$LIBS"
-	PTHREAD_LIBS=
-	AC_CHECK_FUNC([pthread_create], , [
-		AC_CHECK_LIB([pthread], [pthread_create],
-			[PTHREAD_LIBS=-lpthread],
-			[AC_MSG_ERROR([could not find pthread_create])])
-	])
-	LIBS="$SAVE_LIBS"
-	AC_SUBST(PTHREAD_LIBS)
-
 	AC_CHECK_FUNC([nanosleep], , [
 		AC_SEARCH_LIBS([nanosleep], [rt], , [
 			AC_MSG_ERROR([could not find nanosleep])

--- a/configure.ac
+++ b/configure.ac
@@ -123,12 +123,7 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([setenv])
 	AC_CHECK_FUNCS([getpeereid])
 	AC_CHECK_FUNCS([getpeerucred])
-	# If __register_atfork() is not available, we have to link to
-	# libpthread so that the non-stub version of pthread_atfork() work
-	# FIXME: replace pthread_atfork() uses with manual PID checks
-	AC_CHECK_FUNCS([__register_atfork], , [
-		AC_CHECK_LIB([pthread], [pthread_atfork])
-	])
+	AC_CHECK_FUNCS([__register_atfork])
 	AC_CHECK_DECLS([__register_atfork])
 
 	# Check if issetugid() is available and has compatible behavior with OpenBSD

--- a/configure.ac
+++ b/configure.ac
@@ -73,9 +73,9 @@ AC_HEADER_STDBOOL
 AC_CHECK_SIZEOF([unsigned long])
 
 if test "$os_unix" = "yes"; then
-	AC_CHECK_FUNC([pthread_mutex_lock], , [
-		AC_SEARCH_LIBS([pthread_mutex_lock], [pthread], , [
-			AC_MSG_ERROR([could not find pthread_mutex_lock])
+	AC_CHECK_FUNC([pthread_create], , [
+		AC_CHECK_LIB(pthread, pthread_create, , [
+			AC_MSG_ERROR([could not find pthread_create])
 		])
 	])
 

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -335,10 +335,10 @@ test_conf_SOURCES = p11-kit/test-conf.c
 test_conf_LDADD = $(p11_kit_LIBS)
 
 test_deprecated_SOURCES = p11-kit/test-deprecated.c
-test_deprecated_LDADD = $(p11_kit_LIBS) $(PTHREAD_LIBS)
+test_deprecated_LDADD = $(p11_kit_LIBS)
 
 test_init_SOURCES = p11-kit/test-init.c
-test_init_LDADD = $(p11_kit_LIBS) $(PTHREAD_LIBS)
+test_init_LDADD = $(p11_kit_LIBS)
 
 test_iter_SOURCES = p11-kit/test-iter.c
 test_iter_LDADD = $(p11_kit_LIBS)
@@ -356,7 +356,7 @@ test_proxy_SOURCES = p11-kit/test-proxy.c
 test_proxy_LDADD = $(p11_kit_LIBS)
 
 test_rpc_SOURCES = p11-kit/test-rpc.c
-test_rpc_LDADD = $(p11_kit_LIBS) $(PTHREAD_LIBS)
+test_rpc_LDADD = $(p11_kit_LIBS)
 
 test_server_SOURCES = p11-kit/test-server.c
 test_server_LDADD = $(p11_kit_LIBS)
@@ -397,7 +397,7 @@ test_managed_SOURCES = p11-kit/test-managed.c
 test_managed_LDADD = $(p11_kit_LIBS)
 
 test_transport_SOURCES = p11-kit/test-transport.c
-test_transport_LDADD = $(p11_kit_LIBS) $(PTHREAD_LIBS)
+test_transport_LDADD = $(p11_kit_LIBS)
 
 test_virtual_SOURCES = p11-kit/test-virtual.c
 test_virtual_LDADD = $(p11_kit_LIBS)


### PR DESCRIPTION
This partially reverts #177, as it turned out to be impractical to remove libpthread dependency from p11-kit.  See this bug for the rationale:
https://bugzilla.redhat.com/show_bug.cgi?id=1615038

The following commits are kept as general cleanup:
ebfd7da82d7b9eea81067479861aac2d2c07cc29
f04c2a84ad2a017a778fa2f23719318acb9ca89f
5b18e77e9dbb6a598812427ba07ad6df63eb7a67