### PR TITLE
trust: Improve error handling if backed trust file is corrupted

### DIFF
--- a/common/message.c
+++ b/common/message.c
@@ -58,7 +58,7 @@
 #include <stdio.h>
 #include <string.h>
 
-static bool print_messages = false;
+bool p11_print_messages = false;
 
 #ifdef HAVE_STRERROR_L
 locale_t p11_message_locale = (locale_t) 0;
@@ -148,7 +148,7 @@ p11_message (const char* msg,
 	buffer[length] = 0;
 
 	/* If printing is not disabled, just print out */
-	if (print_messages)
+	if (p11_print_messages)
 		fprintf (stderr, "p11-kit: %s\n", buffer);
 	else
 		p11_debug_message (P11_DEBUG_LIB, "message: %s", buffer);
@@ -158,13 +158,13 @@ p11_message (const char* msg,
 void
 p11_message_quiet (void)
 {
-	print_messages = false;
+	p11_print_messages = false;
 }
 
 void
 p11_message_loud (void)
 {
-	print_messages = true;
+	p11_print_messages = true;
 }
 
 const char *

--- a/p11-kit/modules.c
+++ b/p11-kit/modules.c
@@ -306,6 +306,7 @@ free_module_unlocked (void *data)
 	p11_dict_free (mod->config);
 	free (mod->name);
 	free (mod->filename);
+	free (mod->init_args.pReserved);
 	free (mod);
 }
 
@@ -550,10 +551,12 @@ is_module_enabled_unlocked (const char *name,
 static CK_RV
 take_config_and_load_module_inlock (char **name,
                                     p11_dict **config,
-                                    bool critical)
+                                    bool critical,
+                                    bool verbose)
 {
 	const char *filename = NULL;
 	const char *remote = NULL;
+	char *init_reserved = NULL;
 	CK_RV rv = CKR_OK;
 	Module *mod;
 
@@ -591,7 +594,19 @@ take_config_and_load_module_inlock (char **name,
 	 * 'x-init-reserved' setting in the config. This only works with specific
 	 * PKCS#11 modules, and is non-standard use of that field.
 	 */
-	mod->init_args.pReserved = p11_dict_get (*config, "x-init-reserved");
+	init_reserved = p11_dict_get (*config, "x-init-reserved");
+	if (init_reserved) {
+		if (verbose) {
+			init_reserved = strconcat (init_reserved, " verbose=yes", NULL);
+		} else {
+			init_reserved = strdup (init_reserved);
+		}
+		if (init_reserved == NULL) {
+			rv = CKR_HOST_MEMORY;
+			goto out;
+		}
+	}
+	mod->init_args.pReserved = init_reserved;
 
 	/* Take ownership of thes evariables */
 	p11_dict_free (mod->config);
@@ -607,7 +622,7 @@ out:
 }
 
 static CK_RV
-load_registered_modules_unlocked (void)
+load_registered_modules_unlocked (int flags)
 {
 	p11_dictiter iter;
 	p11_dict *configs;
@@ -617,6 +632,7 @@ load_registered_modules_unlocked (void)
 	int mode;
 	CK_RV rv;
 	bool critical;
+	bool verbose;
 
 	if (gl.config)
 		return CKR_OK;
@@ -652,7 +668,8 @@ load_registered_modules_unlocked (void)
 
 		/* Is this a critical module, should abort loading of others? */
 		critical = _p11_conf_parse_boolean (p11_dict_get (config, "critical"), false);
-		rv = take_config_and_load_module_inlock (&name, &config, critical);
+		verbose = (flags & P11_KIT_MODULE_VERBOSE) != 0;
+		rv = take_config_and_load_module_inlock (&name, &config, critical, verbose);
 
 		/*
 		 * These variables will be cleared if ownership is transeferred
@@ -858,7 +875,7 @@ initialize_registered_inlock_reentrant (void)
 	if (rv != CKR_OK)
 		return rv;
 
-	rv = load_registered_modules_unlocked ();
+	rv = load_registered_modules_unlocked (0);
 	if (rv == CKR_OK) {
 		p11_dict_iterate (gl.unmanaged_by_funcs, &iter);
 		while (rv == CKR_OK && p11_dict_next (&iter, NULL, (void **)&mod)) {
@@ -1955,7 +1972,7 @@ p11_modules_load_inlock_reentrant (int flags,
 	if (rv != CKR_OK)
 		return rv;
 
-	rv = load_registered_modules_unlocked ();
+	rv = load_registered_modules_unlocked (flags);
 	if (rv != CKR_OK)
 		return rv;
 

--- a/p11-kit/p11-kit.h
+++ b/p11-kit/p11-kit.h
@@ -57,7 +57,8 @@ enum {
 	P11_KIT_MODULE_UNMANAGED = 1 << 0,
 	P11_KIT_MODULE_CRITICAL = 1 << 1,
 	P11_KIT_MODULE_TRUSTED = 1 << 2,
-	P11_KIT_MODULE_MASK = (1 << 3) - 1
+	P11_KIT_MODULE_VERBOSE = 1 << 3,
+	P11_KIT_MODULE_MASK = (1 << 4) - 1
 };
 
 typedef void        (* p11_kit_destroyer)                   (void *data);

--- a/trust/enumerate.c
+++ b/trust/enumerate.c
@@ -674,6 +674,8 @@ p11_enumerate_opt_purpose (p11_enumerate *ex,
 	return true;
 }
 
+extern bool p11_print_messages;
+
 bool
 p11_enumerate_ready (p11_enumerate *ex,
                      const char *def_filter)
@@ -687,8 +689,13 @@ p11_enumerate_ready (p11_enumerate *ex,
 	 * We only "believe" the CKA_TRUSTED and CKA_X_DISTRUSTED attributes
 	 * we get from modules explicitly marked as containing trust-policy.
 	 */
-	if (!ex->modules)
-		ex->modules = p11_kit_modules_load_and_initialize (P11_KIT_MODULE_TRUSTED);
+	if (!ex->modules) {
+		int flags = P11_KIT_MODULE_TRUSTED;
+		if (p11_print_messages)
+			flags |= P11_KIT_MODULE_VERBOSE;
+
+		ex->modules = p11_kit_modules_load_and_initialize (flags);
+	}
 	if (!ex->modules)
 		return false;
 	if (ex->modules[0] == NULL)

--- a/trust/module.c
+++ b/trust/module.c
@@ -287,6 +287,11 @@ parse_argument (char *arg,
 		free (gl.paths);
 		gl.paths = value ? strdup (value) : NULL;
 
+	} else if (strcmp (arg, "verbose") == 0) {
+		if (strcmp (value, "yes") == 0)
+			p11_message_loud ();
+		else if (strcmp (value, "no") == 0)
+			p11_message_quiet ();
 	} else {
 		p11_message ("unrecognized module argument: %s", arg);
 	}

--- a/trust/module.c
+++ b/trust/module.c
@@ -1198,11 +1198,16 @@ sys_C_FindObjectsInit (CK_SESSION_HANDLE handle,
 				indices[n++] = session->index;
 			if (want_token_objects) {
 				if (!session->loaded)
-					p11_token_load (session->token);
-				session->loaded = CK_TRUE;
-				indices[n++] = p11_token_index (session->token);
+					if (p11_token_load (session->token) < 0)
+						rv = CKR_FUNCTION_FAILED;
+				if (rv == CKR_OK) {
+					session->loaded = CK_TRUE;
+					indices[n++] = p11_token_index (session->token);
+				}
 			}
+		}
 
+		if (rv == CKR_OK) {
 			find = calloc (1, sizeof (FindObjects));
 			warn_if_fail (find != NULL);
 

--- a/trust/p11-kit-trust.module
+++ b/trust/p11-kit-trust.module
@@ -18,3 +18,7 @@ x-trust-lookup: pkcs11:library-description=PKCS%2311%20Kit%20Trust%20Module
 
 # Prevent this module being loaded by the proxy module
 disable-in: p11-kit-proxy
+
+# This will be overwritten by appending "verbose=yes", if the trust
+# command is called with the -v option.
+x-init-reserved:

--- a/trust/parser.c
+++ b/trust/parser.c
@@ -639,7 +639,7 @@ p11_parser_format_persist (p11_parser *parser,
 	}
 
 	p11_array_free (objects);
-	return ret ? P11_PARSE_SUCCESS : P11_PARSE_FAILURE;
+	return ret ? P11_PARSE_SUCCESS : P11_PARSE_UNRECOGNIZED;
 }
 
 p11_parser *

--- a/trust/token.c
+++ b/trust/token.c
@@ -377,16 +377,19 @@ p11_token_load (p11_token *token)
 	int ret;
 
 	ret = loader_load_path (token, token->path, &is_dir);
-	return_val_if_fail (ret >= 0, -1);
+	if (ret < 0)
+		return -1;
 	total += ret;
 
 	if (is_dir) {
 		ret = loader_load_path (token, token->anchors, &is_dir);
-		return_val_if_fail (ret >= 0, -1);
+		if (ret < 0)
+			return -1;
 		total += ret;
 
 		ret = loader_load_path (token, token->blacklist, &is_dir);
-		return_val_if_fail (ret >= 0, -1);
+		if (ret < 0)
+			return -1;
 		total += ret;
 	}
 

--- a/trust/token.c
+++ b/trust/token.c
@@ -196,14 +196,14 @@ loader_load_file (p11_token *token,
 	default:
 		p11_debug ("failed to parse: %s", filename);
 		loader_gone_file (token, filename);
-		return 0;
+		return -1;
 	}
 
 	/* Update each parsed object with the origin */
 	parsed = p11_parser_parsed (token->parser);
 	for (i = 0; i < parsed->num; i++) {
 		parsed->elem[i] = p11_attrs_build (parsed->elem[i], origin, NULL);
-		return_val_if_fail (parsed->elem[i] != NULL, 0);
+		return_val_if_fail (parsed->elem[i] != NULL, -1);
 	}
 
 	p11_index_load (token->index);
@@ -215,7 +215,7 @@ loader_load_file (p11_token *token,
 
 	if (rv != CKR_OK) {
 		p11_message ("couldn't load file into objects: %s", filename);
-		return 0;
+		return -1;
 	}
 
 	loader_was_loaded (token, filename, sb);


### PR DESCRIPTION
This PR does 3 things: first, tell p11-kit-trust.so the tool's verbosity so it can correctly print messages to stderr; secondly, make C_FindObjectsInit fail early on parse error, and finally, if the trust file is not parsable in the p11-kit persistent format proceed with the next formats (DER and PEM).

Fixes #205 