### PR TITLE
trust: Ignore unreadable content in anchors

### DIFF
--- a/trust/module.c
+++ b/trust/module.c
@@ -1198,8 +1198,7 @@ sys_C_FindObjectsInit (CK_SESSION_HANDLE handle,
 				indices[n++] = session->index;
 			if (want_token_objects) {
 				if (!session->loaded)
-					if (p11_token_load (session->token) < 0)
-						rv = CKR_FUNCTION_FAILED;
+					p11_token_load (session->token);
 				if (rv == CKR_OK) {
 					session->loaded = CK_TRUE;
 					indices[n++] = p11_token_index (session->token);

--- a/trust/token.c
+++ b/trust/token.c
@@ -266,8 +266,8 @@ loader_load_directory (p11_token *token,
 		return_val_if_fail (path != NULL, -1);
 
 		ret = loader_load_if_file (token, path);
-		return_val_if_fail (ret >=0, -1);
-		total += ret;
+		if (ret >= 0)
+			total += ret;
 
 		/* Make note that this file was seen */
 		p11_dict_remove (present, path);
@@ -328,8 +328,8 @@ loader_load_path (p11_token *token,
 			p11_dict_iterate (present, &iter);
 			while (p11_dict_next (&iter, (void **)&filename, NULL)) {
 				ret = loader_load_if_file (token, filename);
-				return_val_if_fail (ret >= 0, ret);
-				total += ret;
+				if (ret >= 0)
+					total += ret;
 			}
 		}
 
@@ -377,20 +377,17 @@ p11_token_load (p11_token *token)
 	int ret;
 
 	ret = loader_load_path (token, token->path, &is_dir);
-	if (ret < 0)
-		return -1;
-	total += ret;
+	if (ret >= 0)
+		total += ret;
 
 	if (is_dir) {
 		ret = loader_load_path (token, token->anchors, &is_dir);
-		if (ret < 0)
-			return -1;
-		total += ret;
+		if (ret >= 0)
+			total += ret;
 
 		ret = loader_load_path (token, token->blacklist, &is_dir);
-		if (ret < 0)
-			return -1;
-		total += ret;
+		if (ret >= 0)
+			total += ret;
 	}
 
 	return total;


### PR DESCRIPTION
This amends eb503f3a1467f21a5ecc9ae84ae23b216afc102f.  Instead of failing `C_FindObjectsInit`, treat any errors internally and accumulates the successfully loaded certificates.

Reported by Andrej Kvasnica in:
https://bugzilla.redhat.com/show_bug.cgi?id=1675441