### PR TITLE
modules: fix a SIGSEGV checking gl.modules before iterates on it when freeing

### DIFF
--- a/p11-kit/modules.c
+++ b/p11-kit/modules.c
@@ -797,14 +797,16 @@ init_globals_unlocked (void)
 static void
 free_modules_when_no_refs_unlocked (void)
 {
-	Module *mod;
-	p11_dictiter iter;
+	if (gl.modules) {
+		Module *mod;
+		p11_dictiter iter;
 
-	/* Check if any modules have a ref count */
-	p11_dict_iterate (gl.modules, &iter);
-	while (p11_dict_next (&iter, (void **)&mod, NULL)) {
-		if (mod->ref_count)
-			return;
+		/* Check if any modules have a ref count */
+		p11_dict_iterate (gl.modules, &iter);
+		while (p11_dict_next (&iter, (void **)&mod, NULL)) {
+			if (mod->ref_count)
+				return;
+		}
 	}
 
 	p11_dict_free (gl.unmanaged_by_funcs);


### PR DESCRIPTION
In some circumstances, as described in the BZ, can happen that
free_modules_when_no_refs_unlocked() is called multiple times
when the module destructor is invoked.
We should check gl.modules before iterates on it in the
free_modules_when_no_refs_unlocked() functions, to avoid
a SIGSEGV.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1680963