### PR TITLE
Fix Win32 p11_dl_error crash

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -270,6 +270,7 @@ p11_dl_error (void)
 {
 	DWORD code = GetLastError();
 	LPVOID msg_buf;
+	char *result;
 
 	FormatMessageA (FORMAT_MESSAGE_ALLOCATE_BUFFER |
 	                FORMAT_MESSAGE_FROM_SYSTEM |
@@ -278,7 +279,9 @@ p11_dl_error (void)
 	                MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT),
 	                (LPSTR)&msg_buf, 0, NULL);
 
-	return msg_buf;
+	result = strdup (msg_buf);
+	LocalFree (msg_buf);
+	return result;
 }
 
 int


### PR DESCRIPTION
Caused by returning a buffer that wasn't allocated with malloc and
needed to be freed with LocalFree() instead. The fix is to strdup
msg_buf so what's returned can be free()d.