### PR TITLE
modules: Fix index used in call to p11_dict_remove()

### DIFF
--- a/p11-kit/modules.c
+++ b/p11-kit/modules.c
@@ -1647,7 +1647,7 @@ managed_steal_sessions_inlock (p11_dict *sessions,
 	/* Only removed some, go through and remove those */
 	} else {
 		for (i = 0; i < at; i++) {
-			if (!p11_dict_remove (sessions, stolen + at))
+			if (!p11_dict_remove (sessions, stolen + i))
 				assert_not_reached ();
 		}
 	}


### PR DESCRIPTION
This fixes a call to p11_dict_remove() in managed_steal_sessions_inlock() to use
the correct index in the stolen array (i, rather than at). This avoids an
assert, which was encountered on a host serving a PKCS#11 module to a remote
Linux client.

Signed-off-by: Simon Haggett <simon.haggett@gmail.com>