### PR TITLE
proxy: Refresh slot list on every C_GetSlotList call

### DIFF
--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -408,7 +408,8 @@ check_LTLIBRARIES += \
 	mock-three.la \
 	mock-four.la \
 	mock-five.la \
-	mock-seven.la
+	mock-seven.la \
+	mock-eight.la
 
 mock_one_la_SOURCES = p11-kit/mock-module-ep.c
 mock_one_la_LIBADD = libp11-test.la libp11-common.la
@@ -442,6 +443,10 @@ endif
 mock_seven_la_SOURCES = p11-kit/mock-module-ep5.c
 mock_seven_la_LDFLAGS = $(mock_one_la_LDFLAGS)
 mock_seven_la_LIBADD = $(mock_one_la_LIBADD)
+
+mock_eight_la_SOURCES = p11-kit/mock-module-ep6.c
+mock_eight_la_LDFLAGS = $(mock_one_la_LDFLAGS)
+mock_eight_la_LIBADD = $(mock_one_la_LIBADD)
 
 EXTRA_DIST += \
 	p11-kit/fixtures \

--- a/p11-kit/mock-module-ep6.c
+++ b/p11-kit/mock-module-ep6.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012 Stefan Walter
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Stef Walter <stef@thewalter.net>, Daiki Ueno
+ */
+
+#include "config.h"
+
+#define CRYPTOKI_EXPORTS 1
+#include "pkcs11.h"
+
+#include "mock.h"
+#include "test.h"
+
+static size_t called = 0;
+
+static CK_RV
+override_get_slot_list (CK_BBOOL token_present,
+			CK_SLOT_ID_PTR slot_list,
+			CK_ULONG_PTR count)
+{
+	/* Return 0 on the first attempt to retrieve slot list.  Note
+	 * that this function is typically called twice: first to get
+	 * the number of slots, and then to retrieve the slot list.
+	 */
+	if (called++ < 2) {
+		*count = 0;
+		return CKR_OK;
+	}
+
+	return mock_C_GetSlotList (token_present, slot_list, count);
+}
+
+#ifdef OS_WIN32
+__declspec(dllexport)
+#endif
+CK_RV
+C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
+{
+	mock_module_init ();
+	mock_module.C_GetFunctionList = C_GetFunctionList;
+	if (list == NULL)
+		return CKR_ARGUMENTS_BAD;
+	mock_module.C_GetSlotList = override_get_slot_list;
+	*list = &mock_module;
+	return CKR_OK;
+}


### PR DESCRIPTION
Previously, the proxy module calculated the slot list only once at the `C_Initialize()` call.  That was causing a usability limitation when the user attaches HSM after starting an application.

Suggested by David Ward.

Fixes #221.