### PR TITLE
proxy: Support C_WaitForSlotEvent() if CKF_DONT_BLOCK is specified

### DIFF
--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -409,7 +409,8 @@ check_LTLIBRARIES += \
 	mock-four.la \
 	mock-five.la \
 	mock-seven.la \
-	mock-eight.la
+	mock-eight.la \
+	mock-nine.la
 
 mock_one_la_SOURCES = p11-kit/mock-module-ep.c
 mock_one_la_LIBADD = libp11-test.la libp11-common.la
@@ -447,6 +448,10 @@ mock_seven_la_LIBADD = $(mock_one_la_LIBADD)
 mock_eight_la_SOURCES = p11-kit/mock-module-ep6.c
 mock_eight_la_LDFLAGS = $(mock_one_la_LDFLAGS)
 mock_eight_la_LIBADD = $(mock_one_la_LIBADD)
+
+mock_nine_la_SOURCES = p11-kit/mock-module-ep7.c
+mock_nine_la_LDFLAGS = $(mock_one_la_LDFLAGS)
+mock_nine_la_LIBADD = $(mock_one_la_LIBADD)
 
 EXTRA_DIST += \
 	p11-kit/fixtures \

--- a/p11-kit/mock-module-ep7.c
+++ b/p11-kit/mock-module-ep7.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2012 Stefan Walter
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Stef Walter <stef@thewalter.net>, Daiki Ueno
+ */
+
+#include "config.h"
+
+#define CRYPTOKI_EXPORTS 1
+#include "pkcs11.h"
+
+#include "mock.h"
+#include "test.h"
+
+static CK_RV
+override_wait_for_slot_event (CK_FLAGS flags,
+			      CK_SLOT_ID_PTR slot,
+			      CK_VOID_PTR reserved)
+{
+	if (flags & CKF_DONT_BLOCK) {
+		*slot = MOCK_SLOT_ONE_ID;
+		return CKR_OK;
+	}
+
+	return mock_C_WaitForSlotEvent(flags, slot, reserved);
+}
+
+#ifdef OS_WIN32
+__declspec(dllexport)
+#endif
+CK_RV
+C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
+{
+	mock_module_init ();
+	mock_module.C_GetFunctionList = C_GetFunctionList;
+	if (list == NULL)
+		return CKR_ARGUMENTS_BAD;
+	mock_module.C_WaitForSlotEvent = override_wait_for_slot_event;
+	*list = &mock_module;
+	return CKR_OK;
+}


### PR DESCRIPTION
While fully implementing `C_WaitForSlotEvent()` would require a separate thread to monitor events, it is straightforward to implement the function if the `CKF_DONT_BLOCK` flag is given.

Suggested by David Ward.

Fixes #222 