### PR TITLE
tests: Avoid uninitialized value in test-proxy.c

### DIFF
--- a/p11-kit/test-proxy.c
+++ b/p11-kit/test-proxy.c
@@ -363,6 +363,10 @@ test_slot_event (void)
 	rv = proxy->C_Initialize (NULL);
 	assert (rv == CKR_OK);
 
+	rv = proxy->C_GetSlotList (CK_FALSE, NULL, &count);
+	assert (rv == CKR_OK);
+	assert (count == 2);
+
 	rv = proxy->C_GetSlotList (CK_FALSE, slots, &count);
 	assert (rv == CKR_OK);
 	assert (count == 2);


### PR DESCRIPTION
This should fix the `make check` error on some platforms. I'm sorry about that.