### PR TITLE
common: Fix uClibc-ng compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,9 +135,9 @@ if test "$os_unix" = "yes"; then
 		[AC_MSG_ERROR([could not find required gmtime_r() function])])
 
 	# Check if these are declared and/or available to link against
-	AC_CHECK_DECLS([program_invocation_short_name])
+	AC_CHECK_DECLS([program_invocation_short_name]), [], [], [#include <error.h>])
 	AC_MSG_CHECKING([whether program_invocation_short_name is available])
-	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <argp.h>]],
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <errno.h>]],
 	                                [[program_invocation_short_name = "test";]])],
 	               [AC_DEFINE([HAVE_PROGRAM_INVOCATION_SHORT_NAME], [1],
 	                          [Whether program_invocation_short_name available])


### PR DESCRIPTION
program_invocation_short_name is const under uClibc-ng.

```
common/compat.c:100:14: error: conflicting types for 'program_invocation_short_name'
 extern char *program_invocation_short_name;
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from common/compat.c:52:
/opt/buildbot/slaves/lede-slave-tah/arc_arc700/build/sdk/staging_dir/toolchain-arc_arc700_gcc-8.3.0_uClibc/include/errno.h:54:46: note: previous declaration of 'program_invocation_short_name' was here
 extern const char *program_invocation_name, *program_invocation_short_name;
                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Makefile:3501: recipe for target 'common/compat.lo' failed
```