### PR TITLE
autotools: adjust feature parity after meson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ frob-*
 /x86_64_w64-mingw32/
 
 /build/m4/*.m4
+!/build/m4/ld-version-script.m4
 /build/common
 /build/coverage
 /build/coverage.info

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ BUILT_SOURCES =
 
 CLEANFILES =
 
-EXTRA_DIST = HACKING
+EXTRA_DIST = HACKING meson.build meson_options.txt po/meson.build
 
 incdir = $(includedir)/p11-kit-1/p11-kit
 inc_HEADERS =

--- a/build/m4/ld-version-script.m4
+++ b/build/m4/ld-version-script.m4
@@ -1,0 +1,48 @@
+# ld-version-script.m4 serial 4
+dnl Copyright (C) 2008-2018 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    [AS_HELP_STRING([--enable-ld-version-script],
+       [enable linker version script (default is enabled when possible)])],
+    [have_ld_version_script=$enableval],
+    [AC_CACHE_CHECK([if LD -Wl,--version-script works],
+       [gl_cv_sys_ld_version_script],
+       [gl_cv_sys_ld_version_script=no
+        save_LDFLAGS=$LDFLAGS
+        LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+        echo foo >conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [],
+          [cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+             [gl_cv_sys_ld_version_script=yes])])
+        rm -f conftest.map
+        LDFLAGS=$save_LDFLAGS])
+     have_ld_version_script=$gl_cv_sys_ld_version_script])
+  AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT],
+    [test "$have_ld_version_script" = yes])
+])

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -128,3 +128,5 @@ common_frob_getauxval_LDADD = $(common_LIBS)
 
 common_frob_getenv_SOURCES = common/frob-getenv.c
 common_frob_getenv_LDADD = $(common_LIBS)
+
+EXTRA_DIST += common/meson.build

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,9 @@ AC_USE_SYSTEM_EXTENSIONS
 LT_PREREQ([2.2.6])
 LT_INIT([dlopen disable-static])
 
+dnl Check if -Wl,--version-script is supported by the linker
+gl_LD_VERSION_SCRIPT
+
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CPP

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -170,4 +170,5 @@ CLEANFILES += \
 
 EXTRA_DIST += \
 	$(MAN_IN_FILES) \
+	doc/manual/meson.build \
 	$(NULL)

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -86,8 +86,13 @@ libp11_kit_la_CFLAGS = $(COMMON_CFLAGS)
 
 libp11_kit_la_LDFLAGS = \
 	-no-undefined \
-	-version-info $(P11KIT_LT_RELEASE) \
-	-export-symbols-regex '^C_GetFunctionList|^p11_kit_'
+	-version-info $(P11KIT_LT_RELEASE)
+
+if HAVE_LD_VERSION_SCRIPT
+libp11_kit_la_LDFLAGS += -Wl,--version-script=$(srcdir)/p11-kit/libp11-kit.map
+else
+libp11_kit_la_LDFLAGS += -export-symbols-regex '^C_GetFunctionList|^p11_kit_'
+endif
 
 libp11_kit_la_SOURCES = \
 	p11-kit/proxy.c p11-kit/proxy.h p11-kit/proxy-init.c \

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -216,6 +216,7 @@ example_DATA = p11-kit/pkcs11.conf.example
 
 EXTRA_DIST += \
 	p11-kit/docs.h \
+	p11-kit/meson.build \
 	$(NULL)
 
 bin_PROGRAMS += p11-kit/p11-kit

--- a/trust/Makefile.am
+++ b/trust/Makefile.am
@@ -120,7 +120,8 @@ external_SCRIPTS = \
 	trust/trust-extract-compat
 
 EXTRA_DIST += \
-	trust/p11-kit-trust.module
+	trust/p11-kit-trust.module \
+	trust/meson.build
 
 asn:
 	asn1Parser -o $(srcdir)/trust/pkix.asn.h $(srcdir)/trust/pkix.asn


### PR DESCRIPTION
This adds symbol versioning and also include meson files in autotools distribution.