### PR TITLE
Add simple bash completion for provided commands

### DIFF
--- a/.travis/autotools/before_install.sh
+++ b/.travis/autotools/before_install.sh
@@ -5,5 +5,5 @@ export CONTAINER=$(docker run -d fedora sleep 1800)
 
 docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
 docker exec $CONTAINER dnf -y builddep p11-kit
-docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind $EXTRA_PKGS
+docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind bash-completion $EXTRA_PKGS
 docker exec $CONTAINER useradd user

--- a/.travis/cppcheck/before_install.sh
+++ b/.travis/cppcheck/before_install.sh
@@ -5,5 +5,5 @@ export CONTAINER=$(docker run -d fedora sleep 1800)
 
 docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
 docker exec $CONTAINER dnf -y builddep p11-kit
-docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind $EXTRA_PKGS
+docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind bash-completion $EXTRA_PKGS
 docker exec $CONTAINER useradd user

--- a/.travis/linux/before_install.sh
+++ b/.travis/linux/before_install.sh
@@ -7,5 +7,5 @@ export CONTAINER=$(docker run -d fedora sleep 1800)
 
 docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
 docker exec $CONTAINER dnf -y builddep p11-kit
-docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind meson ninja-build $EXTRA_PKGS
+docker exec $CONTAINER dnf -y install gettext-devel git libtool make opensc openssl valgrind meson ninja-build bash-completion $EXTRA_PKGS
 docker exec $CONTAINER useradd user

--- a/.travis/osx/before_install.sh
+++ b/.travis/osx/before_install.sh
@@ -1,5 +1,5 @@
 brew update
-brew install libffi
+brew install libffi bash-completion
 
 export PATH=${PATH}:/usr/local/opt/gettext/bin
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/libffi/lib/pkgconfig

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,14 @@ if WITH_TRUST_MODULE
 include trust/Makefile.am
 endif
 
+if WITH_BASH_COMPLETION
+bashcompdir = $(datadir)/bash-completion/completions
+dist_bashcomp_DATA = bash-completion/p11-kit
+if WITH_TRUST_MODULE
+dist_bashcomp_DATA += bash-completion/trust
+endif
+endif
+
 SUBDIRS = . doc po
 
 ACLOCAL_AMFLAGS = -I build/m4

--- a/bash-completion/meson.build
+++ b/bash-completion/meson.build
@@ -1,0 +1,11 @@
+bashcomp = dependency('bash-completion', required: false)
+
+if bashcomp.found()
+  bashcompdir = bashcomp.get_pkgconfig_variable('completionsdir')
+  install_data('p11-kit', install_dir: bashcompdir)
+  if with_trust_module
+    install_data('trust', install_dir: bashcompdir)
+  endif
+else
+  warning('Will not install bash completion due to missing dependencies!')
+endif

--- a/bash-completion/p11-kit
+++ b/bash-completion/p11-kit
@@ -1,0 +1,19 @@
+# p11-kit(8) completion                                       -*- shell-script -*-
+
+_p11-kit()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    if [[ $cur == -* ]]; then
+        local opts="--help --verbose -q --quiet"
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return
+    elif [[ $cword -eq 1 ]]; then
+        local commands='list-modules extract server remote'
+        COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+    fi
+} &&
+complete -F _p11-kit p11-kit
+
+# ex: filetype=sh

--- a/bash-completion/trust
+++ b/bash-completion/trust
@@ -1,0 +1,67 @@
+# trust(1) completion                                       -*- shell-script -*-
+
+_trust()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    local commands command
+
+    commands='list extract extract-compat anchor dump'
+
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+    else
+        command=${words[1]}
+        case $prev in
+            --filter)
+                list=""
+                case $command in
+                    extract|list)
+                        list="ca-anchors trust-policy blacklist certificates pkcs11:"
+                        ;;
+                    dump)
+                        list="all pkcs11:"
+                        ;;
+                esac
+                COMPREPLY=( $(compgen -W "$list" -- "$cur") )
+                return
+                ;;
+            --purpose)
+                COMPREPLY=( $(compgen -W "server-auth client-auth email code-signing" -- "$cur") )
+                return
+                ;;
+            --format)
+                options='x509-file x509-directory pem-bundle pem-directory
+                    pem-directory-hash openssl-bundle openssl-directory
+                    java-cacarts'
+                COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+                return
+                ;;
+        esac
+
+        if [[ "$cur" == -* ]]; then
+            # possible options for the command
+            case $command in
+                list)
+                    options='--filter --purpose'
+                    ;;
+                extract)
+                    options='--comment --filter --format --overwrite --purpose'
+                    ;;
+                anchor)
+                    options='--remove --store'
+                    ;;
+                dump)
+                    options='--filter'
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "$options --verbose --help --quiet" -- "$cur") )
+        else
+            _filedir
+        fi
+    fi
+} &&
+complete -F _trust trust
+
+# ex: filetype=sh

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ if test "$os_unix" = "yes"; then
 		[AC_MSG_ERROR([could not find required gmtime_r() function])])
 
 	# Check if these are declared and/or available to link against
-	AC_CHECK_DECLS([program_invocation_short_name]), [], [], [#include <errno.h>])
+	AC_CHECK_DECLS([program_invocation_short_name], [], [], [#include <errno.h>])
 	AC_MSG_CHECKING([whether program_invocation_short_name is available])
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <errno.h>]],
 	                                [[program_invocation_short_name = "test";]])],

--- a/configure.ac
+++ b/configure.ac
@@ -571,6 +571,13 @@ AS_IF([test "$with_systemd" != "no"], [
 
 AM_CONDITIONAL(WITH_SYSTEMD, [test "$with_systemd" = "yes"])
 
+# --------------------------------------------------------------------
+# bash completion
+
+PKG_CHECK_VAR([bashcompdir], [bash-completion], [with_bash_completion=yes])
+AM_CONDITIONAL(WITH_BASH_COMPLETION, [test "$with_bash_completion" = "yes"])
+
+
 AC_CONFIG_FILES([Makefile
 	doc/Makefile
 	doc/manual/Makefile

--- a/meson.build
+++ b/meson.build
@@ -361,3 +361,4 @@ if with_trust_module
 endif
 subdir('doc/manual')
 subdir('po')
+subdir('bash-completion')


### PR DESCRIPTION
It already bogged me that the p11-kit did not provide bash completion and I had to search help or man pages for the accurate wording of the sub-commands so I wrote one, also for the trust command.

I tried to follow the recommendation of the [bash_completion](https://github.com/scop/bash-completion) how to integrate the completion to upstream project, but I am really not sure whether it will work through the installation step nor whether there is some more magic needed for meson builds so any comments or suggestions will be welcomed.