### PR TITLE
Unbreak list matching in enable-in and disable-in

### DIFF
--- a/p11-kit/modules.c
+++ b/p11-kit/modules.c
@@ -496,17 +496,27 @@ is_string_in_list (const char *list,
                    const char *string)
 {
 	const char *where;
+	const char *start = list;
 
-	where = strstr (list, string);
-	if (where == NULL)
-		return false;
+	while (*start != '\0') {
+		where = strstr (start, string);
+		if (where == NULL)
+			return false;
 
-	/* Has to be at beginning/end of string, and delimiter before/after */
-	if (where != list && !is_list_delimiter (*(where - 1)))
-		return false;
+		/* Has to be at beginning/end of string, and delimiter before/after */
+		if (where != list && !is_list_delimiter (*(where - 1))) {
+			start += strlen (string);
+			continue;
+		}
 
-	where += strlen (string);
-	return (*where == '\0' || is_list_delimiter (*where));
+		where += strlen (string);
+		if (*where == '\0' || is_list_delimiter (*where)) {
+			return true;
+		}
+		start = where;
+	}
+
+	return false;
 }
 
 static bool

--- a/p11-kit/test-proxy.c
+++ b/p11-kit/test-proxy.c
@@ -233,6 +233,7 @@ teardown (void *unused)
 #define TWO_MODULE "module: mock-two" SHLEXT "\n"
 #define ENABLED "enable-in: test-proxy, p11-kit-proxy\n"
 #define DISABLED "disable-in: p11-kit-proxy\n"
+#define ENABLED_PREFIX "enable-in: test-proxy-suffix, p11-kit-proxy-suffix, test-proxy, p11-kit-proxy\n"
 #define EIGHT_MODULE "module: mock-eight" SHLEXT "\n"
 #define NINE_MODULE "module: mock-nine" SHLEXT "\n"
 
@@ -311,6 +312,12 @@ test_disable (void)
 	p11_test_file_write (test.directory, "two.module", TWO_MODULE DISABLED, strlen (TWO_MODULE DISABLED));
 	disabled = load_modules_and_count_slots ();
 	assert_num_cmp (disabled, <, count);
+
+	p11_test_file_write (test.directory, "one.module", ONE_MODULE ENABLED_PREFIX, strlen (ONE_MODULE ENABLED_PREFIX));
+	p11_test_file_write (test.directory, "two.module", TWO_MODULE, strlen (TWO_MODULE));
+	enabled = load_modules_and_count_slots ();
+	assert_num_eq (enabled, count);
+
 }
 
 static void


### PR DESCRIPTION
The enable-in and disable-in options of the module were failing to match in case of there was a match before with substring of the searched name, for example if the running program was `p11-kit` and the `enable-in` rule looked like `p11-kit-proxy,p11-kit`, it was falsely not matched.

The attached patch is trying to fix that by implementing more robust search in list as well as attaching reproducer to the testsuite.