### PR TITLE
trust: Support CKA_NSS_{SERVER,EMAIL}_DISTRUST_AFTER

### DIFF
--- a/common/constants.c
+++ b/common/constants.c
@@ -155,6 +155,8 @@ const p11_constant p11_constant_types[] = {
 	CT (CKA_NSS_PQG_SEED_BITS, "nss-pqg-seed-bits")
 	CT (CKA_NSS_MODULE_SPEC, "nss-module-spec")
 	CT (CKA_NSS_MOZILLA_CA_POLICY, "nss-mozilla-ca-policy")
+	CT (CKA_NSS_SERVER_DISTRUST_AFTER, "nss-server-distrust-after")
+	CT (CKA_NSS_EMAIL_DISTRUST_AFTER, "nss-email-distrust-after")
 	CT (CKA_TRUST_DIGITAL_SIGNATURE, "trust-digital-signature")
 	CT (CKA_TRUST_NON_REPUDIATION, "trust-non-repudiation")
 	CT (CKA_TRUST_KEY_ENCIPHERMENT, "trust-key-encipherment")

--- a/common/pkcs11x.h
+++ b/common/pkcs11x.h
@@ -75,6 +75,8 @@ extern "C" {
 #define CKA_NSS_PQG_SEED_BITS           0xce534367UL
 #define CKA_NSS_MODULE_SPEC             0xce534368UL
 #define CKA_NSS_MOZILLA_CA_POLICY       0xce534372UL
+#define CKA_NSS_SERVER_DISTRUST_AFTER   0xce534373UL
+#define CKA_NSS_EMAIL_DISTRUST_AFTER    0xce534374UL
 
 /* NSS trust attributes */
 #define CKA_TRUST_DIGITAL_SIGNATURE     0xce536351UL

--- a/trust/test-builder.c
+++ b/trust/test-builder.c
@@ -864,6 +864,79 @@ test_invalid_dates (void)
 }
 
 static void
+test_valid_false_or_time (void)
+{
+	CK_ATTRIBUTE *attrs = NULL;
+	CK_ATTRIBUTE *extra = NULL;
+	CK_RV rv;
+
+	CK_ATTRIBUTE input[] = {
+		{ CKA_NSS_SERVER_DISTRUST_AFTER, NULL, 0 },
+		{ CKA_CLASS, &certificate, sizeof (certificate) },
+		{ CKA_CERTIFICATE_TYPE, &x509, sizeof (x509) },
+		{ CKA_INVALID },
+	};
+
+	input[0].pValue = "\x00";
+	input[0].ulValueLen = 1;
+	rv = p11_builder_build (test.builder, test.index, attrs, input, &extra);
+	assert_num_eq (CKR_OK, rv);
+
+	p11_attrs_free (extra);
+	p11_attrs_free (attrs);
+	attrs = NULL;
+
+	input[0].pValue = "190701000000Z";
+	input[0].ulValueLen = 13;
+	rv = p11_builder_build (test.builder, test.index, attrs, input, &extra);
+	assert_num_eq (CKR_OK, rv);
+
+	p11_attrs_free (extra);
+	p11_attrs_free (attrs);
+
+	input[0].pValue = "20190701000000Z";
+	input[0].ulValueLen = 15;
+	rv = p11_builder_build (test.builder, test.index, attrs, input, &extra);
+	assert_num_eq (CKR_OK, rv);
+
+	p11_attrs_free (extra);
+	p11_attrs_free (attrs);
+}
+
+static void
+test_invalid_false_or_time (void)
+{
+	CK_ATTRIBUTE *attrs = NULL;
+	CK_ATTRIBUTE *extra = NULL;
+	CK_RV rv;
+
+	CK_ATTRIBUTE input[] = {
+		{ CKA_NSS_SERVER_DISTRUST_AFTER, NULL, 0 },
+		{ CKA_CLASS, &certificate, sizeof (certificate) },
+		{ CKA_CERTIFICATE_TYPE, &x509, sizeof (x509) },
+		{ CKA_INVALID },
+	};
+
+	p11_message_quiet ();
+
+	input[0].pValue = "\x01";
+	input[0].ulValueLen = 1;
+	rv = p11_builder_build (test.builder, test.index, attrs, input, &extra);
+	assert_num_eq (CKR_ATTRIBUTE_VALUE_INVALID, rv);
+
+	input[0].pValue = "\x01\x02\x03";
+	input[0].ulValueLen = 3;
+	rv = p11_builder_build (test.builder, test.index, attrs, input, &extra);
+	assert_num_eq (CKR_ATTRIBUTE_VALUE_INVALID, rv);
+
+	input[0].pValue = NULL;
+	rv = p11_builder_build (test.builder, test.index, attrs, input, &extra);
+	assert_num_eq (CKR_ATTRIBUTE_VALUE_INVALID, rv);
+
+	p11_message_loud ();
+}
+
+static void
 test_valid_name (void)
 {
 	CK_ATTRIBUTE *attrs = NULL;
@@ -2204,6 +2277,7 @@ main (int argc,
 	p11_test (test_valid_name, "/builder/valid-name");
 	p11_test (test_valid_serial, "/builder/valid-serial");
 	p11_test (test_valid_cert, "/builder/valid-cert");
+	p11_test (test_valid_false_or_time, "/builder/valid-false-or-time");
 	p11_test (test_invalid_bool, "/builder/invalid-bool");
 	p11_test (test_invalid_ulong, "/builder/invalid-ulong");
 	p11_test (test_invalid_utf8, "/builder/invalid-utf8");
@@ -2211,6 +2285,7 @@ main (int argc,
 	p11_test (test_invalid_name, "/builder/invalid-name");
 	p11_test (test_invalid_serial, "/builder/invalid-serial");
 	p11_test (test_invalid_cert, "/builder/invalid-cert");
+	p11_test (test_invalid_false_or_time, "/builder/invalid-false-or-time");
 	p11_test (test_invalid_schema, "/builder/invalid-schema");
 
 	p11_test (test_create_not_settable, "/builder/create_not_settable");


### PR DESCRIPTION
These new attributes are introduced in:
https://bugzilla.mozilla.org/show_bug.cgi?id=1465613

The value of the attribute can be either false (represented as a single octed "\x00"), or a UTCTime in a restricted form (i.e., "YYMMDDHHMMSSZ").  For future proof, we also support GeneralizedTime in the form "YYYYMMDDHHMMSSZ".