### PR TITLE
rpc: Add vsock transport support

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -30,6 +30,7 @@ libp11_common_la_SOURCES = \
 	common/pkcs11.h common/pkcs11x.h common/pkcs11i.h \
 	common/runtime.c common/runtime.h \
 	common/url.c common/url.h \
+	common/vsock.c common/vsock.h \
 	common/init.h \
 	$(NULL)
 

--- a/common/meson.build
+++ b/common/meson.build
@@ -14,7 +14,8 @@ libp11_common_sources = [
   'message.c',
   'path.c',
   'runtime.c',
-  'url.c'
+  'url.c',
+  'vsock.c'
 ]
 
 libp11_common = static_library('p11-common', libp11_common_sources,

--- a/common/vsock.c
+++ b/common/vsock.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: David Woodhouse <dwmw2@infradead.org>
+ */
+
+#include "config.h"
+
+#include "vsock.h"
+
+#include <limits.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#ifdef HAVE_VSOCK
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
+#include <sys/ioctl.h>
+#endif
+
+/* This generic parsing utility doesn't actually require the
+ * vm_sockets.h header and thus doesn't require conditional
+ * compiliation... except for this one definition. */
+#ifndef VMADDR_CID_ANY
+#define VMADDR_CID_ANY -1U
+#endif
+
+bool
+p11_vsock_parse_addr (const char *target,
+		      unsigned int *cid,
+		      unsigned int *port)
+{
+	bool cid_found = false;
+	bool port_found = false;
+	unsigned long val;
+	char *endptr;
+
+	while (*target) {
+		if (strncmp (target, "cid=", 4) == 0) {
+			val = strtoul(target + 4, &endptr, 0);
+			if (val > UINT_MAX || endptr == target + 4)
+				return false;
+			*cid = val;
+			cid_found = true;
+		} else if (strncmp (target, "port=", 5) == 0) {
+			val = strtoul (target + 5, &endptr, 0);
+			if (val > UINT_MAX || endptr == target + 5)
+				return false;
+			*port = val;
+			port_found = true;
+		} else {
+			return false;
+		}
+
+		target = endptr;
+		if (*target == ';')
+			target++;
+		else if (*target)
+			return false;
+	}
+
+	/* Port is mandatory */
+	if (!port_found)
+		return false;
+
+	/* CID is optional, defaulting to VMADDR_CID_ANY */
+	if (!cid_found)
+		*cid = VMADDR_CID_ANY;
+
+	return true;
+}
+
+bool
+p11_vsock_get_local_cid (unsigned int *cid)
+{
+#ifndef HAVE_VSOCK
+	return false;
+#else
+	int fd = open ("/dev/vsock", O_RDONLY);
+	int rc;
+
+	if (fd == -1)
+		return false;
+
+	rc = ioctl (fd, IOCTL_VM_SOCKETS_GET_LOCAL_CID, cid, sizeof(*cid));
+	close (fd);
+
+	return (rc == 0);
+#endif
+}

--- a/common/vsock.h
+++ b/common/vsock.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: David Woodhouse <dwmw2@infradead.org>
+ */
+
+#ifndef P11_VSOCK_H
+#define P11_VSOCK_H
+
+#include "compat.h"
+
+bool                  p11_vsock_parse_addr    (const char *target,
+                                               unsigned int *cid,
+                                               unsigned int *port);
+
+bool                  p11_vsock_get_local_cid (unsigned int *cid);
+
+#endif /* P11_VSOCK_H */

--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,21 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_TYPES([sighandler_t, sig_t, __sighandler_t], [], [],
 		[[#include <sys/types.h>
 		  #include <signal.h>]])
+
+	AC_MSG_CHECKING([whether vsock support is available])
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>
+					  #include <linux/vm_sockets.h>]],
+	                                [[struct sockaddr_vm sa = {
+					  .svm_family = AF_VSOCK,
+					  .svm_cid = VMADDR_CID_ANY,
+					  };
+					  (void)&sa;
+					  return 0;]])],
+	               [AC_DEFINE([HAVE_VSOCK], [1],
+	                          [Whether vsock support available])
+	                AC_MSG_RESULT([yes])],
+	               [AC_MSG_RESULT([no])])
+
 fi
 
 # These are thngs we can work around

--- a/meson.build
+++ b/meson.build
@@ -221,6 +221,15 @@ int main (void) { __libc_enable_secure = 0; return 0; }
     conf.set('HAVE___LIBC_ENABLE_SECURE', 1)
   endif
 
+  vsock_availability_test_code = '''
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
+struct sockaddr_vm sa = { .svm_family = AF_VSOCK, .svm_cid = VMADDR_CID_ANY };
+'''
+  if cc.compiles(vsock_availability_test_code, name: 'vsock_test')
+    conf.set('HAVE_VSOCK', 1)
+  endif
+
   foreach h : ['sys/types.h', 'signal.h']
     foreach t : ['sighandler_t', 'sig_t', '__sighandler_t']
       if cc.has_header_symbol(h, t)

--- a/p11-kit/rpc-transport.c
+++ b/p11-kit/rpc-transport.c
@@ -1175,6 +1175,8 @@ p11_rpc_transport_new (p11_virtual *virt,
 		return NULL;
 	}
 
+	return_val_if_fail (rpc != NULL, NULL);
+
 	if (!p11_rpc_client_init (virt, &rpc->vtable))
 		return_val_if_reached (NULL);
 


### PR DESCRIPTION
This adds support for AF_VSOCK as a transport for the remoting protocol.

With this, software tokens can be isolated into a microVM of their own and the communication happens over the vsock from the host/parent.

In addition to the barrier that virtualisation traditionally provides, technologies like AMD SEV and AWS Nitro Enclaves can turn this into something which approximates the security of a true hardware token.

There is no transport-level access control (yet). We could potentially filter on the client CID, and/or restrict it to root-owned ports. Using a PIN on the software token obviously does work.

I also haven't updated the documentation in p11-kit-remoting.xml. Mostly because I don't really follow it as-is. My current test is just a module file containing:
```
remote:vsock:cid=3;port=9999
```

If I were to touch the existing doc, I'd probably start by ripping out the latter half of it. NSS should be using p11-kit-proxy.so by *default* these days, shouldn't it? It shouldn't require anything special.