### PR TITLE
build: Fix realloc usage

### DIFF
--- a/common/attrs.c
+++ b/common/attrs.c
@@ -102,6 +102,7 @@ attrs_build (CK_ATTRIBUTE *attrs,
 	CK_ULONG j;
 	CK_ULONG i;
 	size_t length;
+	void **new_memory;
 
 	/* How many attributes we already have */
 	current = p11_attrs_count (attrs);
@@ -109,8 +110,9 @@ attrs_build (CK_ATTRIBUTE *attrs,
 	/* Reallocate for how many we need */
 	length = current + count_to_add;
 	return_val_if_fail (current <= length && length < SIZE_MAX, NULL);
-	attrs = reallocarray (attrs, length + 1, sizeof (CK_ATTRIBUTE));
-	return_val_if_fail (attrs != NULL, NULL);
+	new_memory = reallocarray (attrs, length + 1, sizeof (CK_ATTRIBUTE));
+	return_val_if_fail (new_memory != NULL, NULL);
+	attrs = new_memory;
 
 	at = current;
 	for (i = 0; i < count_to_add; i++) {

--- a/p11-kit/filter.c
+++ b/p11-kit/filter.c
@@ -96,11 +96,12 @@ static bool
 filter_add_slot (FilterData *filter, CK_SLOT_ID slot, const CK_TOKEN_INFO *token)
 {
 	if (filter->n_slots >= filter->max_slots) {
+		FilterSlot *slots;
 		filter->max_slots = filter->max_slots * 2 + 1;
-		filter->slots = realloc (filter->slots,
-					 filter->max_slots * sizeof (FilterSlot));
-		if (filter->slots == NULL)
-			return false;
+		slots = realloc (filter->slots,
+				 filter->max_slots * sizeof (FilterSlot));
+		return_val_if_fail (slots != NULL, false);
+		filter->slots = slots;
 	}
 	filter->slots[filter->n_slots].slot = slot;
 	filter->slots[filter->n_slots].token = token;

--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -278,8 +278,11 @@ proxy_list_slots (Proxy *py, Mapping *mappings, unsigned int n_mappings)
 		return_val_if_fail (count == 0 || slots != NULL, CKR_GENERAL_ERROR);
 
 		if (count > 0) {
-			py->mappings = realloc (py->mappings, sizeof (Mapping) * (py->n_mappings + count));
-			return_val_if_fail (py->mappings != NULL, CKR_HOST_MEMORY);
+			Mapping *new_mappings;
+
+			new_mappings = realloc (py->mappings, sizeof (Mapping) * (py->n_mappings + count));
+			return_val_if_fail (new_mappings != NULL, CKR_HOST_MEMORY);
+			py->mappings = new_mappings;
 
 			/* And now add a mapping for each of those slots */
 			for (i = 0; i < count; ++i) {

--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -288,6 +288,8 @@ proxy_list_slots (Proxy *py, Mapping *mappings, unsigned int n_mappings)
 			for (i = 0; i < count; ++i) {
 				/* Reuse the existing mapping if any */
 				for (j = 0; j < n_mappings; ++j) {
+					/* cppcheck-suppress nullPointer symbolName=mappings */
+					/* false-positive: https://trac.cppcheck.net/ticket/9573 */
 					if (mappings[j].funcs == funcs &&
 					    mappings[j].real_slot == slots[i])
 						break;

--- a/trust/index.c
+++ b/trust/index.c
@@ -269,9 +269,13 @@ bucket_insert (index_bucket *bucket,
 
 	alloc = alloc_size (bucket->num);
 	if (bucket->num + 1 > alloc) {
+		CK_OBJECT_HANDLE *elem;
+
 		alloc = alloc ? alloc * 2 : 1;
 		return_if_fail (alloc != 0);
-		bucket->elem = realloc (bucket->elem, alloc * sizeof (CK_OBJECT_HANDLE));
+		elem = realloc (bucket->elem, alloc * sizeof (CK_OBJECT_HANDLE));
+		return_if_fail (elem != NULL);
+		bucket->elem = elem;
 	}
 
 	return_if_fail (bucket->elem != NULL);
@@ -289,9 +293,13 @@ bucket_push (index_bucket *bucket,
 
 	alloc = alloc_size (bucket->num);
 	if (bucket->num + 1 > alloc) {
+		CK_OBJECT_HANDLE *elem;
+
 		alloc = alloc ? alloc * 2 : 1;
 		return_val_if_fail (alloc != 0, false);
-		bucket->elem = realloc (bucket->elem, alloc * sizeof (CK_OBJECT_HANDLE));
+		elem = realloc (bucket->elem, alloc * sizeof (CK_OBJECT_HANDLE));
+		return_val_if_fail (elem != NULL, false);
+		bucket->elem = elem;
 	}
 
 	return_val_if_fail (bucket->elem != NULL, false);


### PR DESCRIPTION
As realloc() doesn't touch the original memory block, we need to use a local variable to avoid potential memory leak in failure cases.

Pointed by David Woodhouse in #270.