### PR TITLE
build: Meson fixes for building on s390x

### DIFF
--- a/common/attrs.c
+++ b/common/attrs.c
@@ -102,7 +102,7 @@ attrs_build (CK_ATTRIBUTE *attrs,
 	CK_ULONG j;
 	CK_ULONG i;
 	size_t length;
-	void **new_memory;
+	void *new_memory;
 
 	/* How many attributes we already have */
 	current = p11_attrs_count (attrs);

--- a/common/mock.c
+++ b/common/mock.c
@@ -431,6 +431,10 @@ mock_C_Initialize (CK_VOID_PTR init_args)
 		the_sessions = p11_dict_new (p11_dict_direct_hash,
 		                             p11_dict_direct_equal,
 		                             NULL, free_session);
+		if (!the_sessions) {
+			ret = CKR_HOST_MEMORY;
+			goto done;
+		}
 
 		module_reset_objects (MOCK_SLOT_ONE_ID);
 

--- a/meson.build
+++ b/meson.build
@@ -244,6 +244,16 @@ struct sockaddr_vm sa = { .svm_family = AF_VSOCK, .svm_cid = VMADDR_CID_ANY };
   endforeach
 endif
 
+headers = [
+  'stdbool.h',
+]
+
+foreach h : headers
+  if cc.has_header(h)
+    conf.set('HAVE_' + h.underscorify().to_upper(), 1)
+  endif
+endforeach
+
 functions = [
   'asprintf',
   'basename',

--- a/meson.build
+++ b/meson.build
@@ -129,7 +129,7 @@ if host_system != 'windows'
 
   if cc.has_header('locale.h')
     conf.set('HAVE_LOCALE_H', 1)
-    if cc.has_header_symbol('locale.h', 'locale_t')
+    if cc.has_type('locale_t', prefix: '#include <locale.h>')
       conf.set('HAVE_LOCALE_T', 1)
       if cc.has_function('newlocale', prefix: '#include <locale.h>')
         conf.set('HAVE_NEWLOCALE', 1)
@@ -236,7 +236,7 @@ struct sockaddr_vm sa = { .svm_family = AF_VSOCK, .svm_cid = VMADDR_CID_ANY };
 
   foreach h : ['sys/types.h', 'signal.h']
     foreach t : ['sighandler_t', 'sig_t', '__sighandler_t']
-      if cc.has_header_symbol(h, t)
+      if cc.has_type(t, prefix: '#include <@0@>'.format(h))
         define = 'HAVE_' + t.underscorify().to_upper()
         conf.set(define, 1)
       endif

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,10 @@ endif
 conf.set_quoted('SHLEXT', shlext)
 conf.set_quoted('EXEEXT', exeext)
 
+if host_machine.endian() == 'big'
+  conf.set('WORDS_BIGENDIAN', 1)
+endif
+
 if get_option('debug')
   conf.set('WITH_DEBUG', 1)
   conf.set('_DEBUG', 1)

--- a/meson.build
+++ b/meson.build
@@ -262,6 +262,11 @@ foreach f : functions
   endif
 endforeach
 
+conf.set10('HAVE_DECL_PROGRAM_INVOCATION_SHORT_NAME',
+           cc.has_header_symbol('errno.h',
+                                'program_invocation_short_name',
+                                prefix: '#define _GNU_SOURCE'))
+
 conf.set10('HAVE_DECL_ASPRINTF',
            cc.has_header_symbol('stdio.h', 'asprintf',
                                 prefix: '#define _GNU_SOURCE'))

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -286,6 +286,10 @@ foreach name, sources : mock_sources
   shared_module(name,
                 sources,
                 name_prefix: '',
+                link_args: p11_module_ldflags,
+                link_depends: [p11_module_symbol_map,
+                               p11_module_symbol_def],
+                vs_module_defs: p11_module_symbol_def,
                 dependencies: [libp11_test_dep])
 endforeach
 


### PR DESCRIPTION
This is mainly meant to fix build failures on s390 when using Meson:
- add missing check for endianness
- explicitly export `C_GetFunctionList` from mock modules