### PR TITLE
Revert #259

### DIFF
--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -570,7 +570,7 @@ proto_read_sesssion_info (p11_rpc_message *msg,
 #define IN_BYTE_BUFFER(arr, len) \
 	if (len == NULL) \
 		{ _ret = CKR_ARGUMENTS_BAD; goto _cleanup; } \
-	if (!p11_rpc_message_write_byte_buffer (&_msg, arr, len)) \
+	if (!p11_rpc_message_write_byte_buffer (&_msg, arr ? *len : 0)) \
 		{ _ret = CKR_HOST_MEMORY; goto _cleanup; }
 
 #define IN_BYTE_ARRAY(arr, len) \

--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -582,7 +582,7 @@ proto_read_sesssion_info (p11_rpc_message *msg,
 #define IN_ULONG_BUFFER(arr, len) \
 	if (len == NULL) \
 		{ _ret = CKR_ARGUMENTS_BAD; goto _cleanup; } \
-	if (!p11_rpc_message_write_ulong_buffer (&_msg, arr, len)) \
+	if (!p11_rpc_message_write_ulong_buffer (&_msg, arr ? *len : 0)) \
 		{ _ret = CKR_HOST_MEMORY; goto _cleanup; }
 
 #define IN_ULONG_ARRAY(arr, len) \

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -380,16 +380,14 @@ p11_rpc_message_write_byte_array (p11_rpc_message *msg,
 
 bool
 p11_rpc_message_write_ulong_buffer (p11_rpc_message *msg,
-                                    CK_ULONG_PTR array,
-                                    CK_ULONG_PTR n_array)
+                                    CK_ULONG count)
 {
 	assert (msg != NULL);
 	assert (msg->output != NULL);
 
 	/* Make sure this is in the right order */
 	assert (!msg->signature || p11_rpc_message_verify_part (msg, "fu"));
-	p11_rpc_buffer_add_byte (msg->output, array ? 0 : 1);
-	p11_rpc_buffer_add_uint32 (msg->output, *n_array);
+	p11_rpc_buffer_add_uint32 (msg->output, count);
 	return !p11_buffer_failed (msg->output);
 }
 

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -241,20 +241,14 @@ p11_rpc_message_write_attribute_buffer (p11_rpc_message *msg,
 	/* Write the number of items */
 	p11_rpc_buffer_add_uint32 (msg->output, num);
 
-	/* Is arr not null ? */
-	p11_rpc_buffer_add_byte (msg->output, arr ? 0 : 1);
-
 	for (i = 0; i < num; ++i) {
 		attr = &(arr[i]);
 
 		/* The attribute type */
 		p11_rpc_buffer_add_uint32 (msg->output, attr->type);
 
-		/* rpc_server.c:value_is_null, is the value buffer not NULL ? */
-		p11_rpc_buffer_add_byte (msg->output, attr->pValue ? 0 : 1);
-
 		/* And the attribute buffer length */
-		p11_rpc_buffer_add_uint32 (msg->output, attr->ulValueLen);
+		p11_rpc_buffer_add_uint32 (msg->output, attr->pValue ? attr->ulValueLen : 0);
 	}
 
 	return !p11_buffer_failed (msg->output);

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -342,16 +342,14 @@ p11_rpc_message_write_ulong (p11_rpc_message *msg,
 
 bool
 p11_rpc_message_write_byte_buffer (p11_rpc_message *msg,
-                                   CK_BYTE_PTR array,
-                                   CK_ULONG_PTR n_array)
+                                   CK_ULONG count)
 {
 	assert (msg != NULL);
 	assert (msg->output != NULL);
 
 	/* Make sure this is in the right order */
 	assert (!msg->signature || p11_rpc_message_verify_part (msg, "fy"));
-	p11_rpc_buffer_add_byte (msg->output, array ? 0 : 1);
-	p11_rpc_buffer_add_uint32 (msg->output, *n_array);
+	p11_rpc_buffer_add_uint32 (msg->output, count);
 	return !p11_buffer_failed (msg->output);
 }
 

--- a/p11-kit/rpc-message.h
+++ b/p11-kit/rpc-message.h
@@ -287,8 +287,7 @@ bool             p11_rpc_message_write_byte_array        (p11_rpc_message *msg,
                                                           CK_ULONG num);
 
 bool             p11_rpc_message_write_ulong_buffer      (p11_rpc_message *msg,
-                                                          CK_ULONG_PTR array,
-                                                          CK_ULONG_PTR n_array);
+                                                          CK_ULONG count);
 
 bool             p11_rpc_message_write_ulong_array       (p11_rpc_message *msg,
                                                           CK_ULONG_PTR arr,

--- a/p11-kit/rpc-message.h
+++ b/p11-kit/rpc-message.h
@@ -279,8 +279,7 @@ bool             p11_rpc_message_write_space_string      (p11_rpc_message *msg,
                                                                    CK_ULONG length);
 
 bool             p11_rpc_message_write_byte_buffer       (p11_rpc_message *msg,
-                                                          CK_BYTE_PTR array,
-                                                          CK_ULONG_PTR n_array);
+                                                          CK_ULONG count);
 
 bool             p11_rpc_message_write_byte_array        (p11_rpc_message *msg,
                                                           CK_BYTE_PTR arr,

--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -68,7 +68,6 @@ proto_read_byte_buffer (p11_rpc_message *msg,
                         CK_ULONG *n_buffer)
 {
 	uint32_t length;
-	uint8_t buffer_is_null;
 
 	assert (msg != NULL);
 	assert (buffer != NULL);
@@ -78,8 +77,6 @@ proto_read_byte_buffer (p11_rpc_message *msg,
 	/* Check that we're supposed to be reading this at this point */
 	assert (!msg->signature || p11_rpc_message_verify_part (msg, "fy"));
 
-	if (!p11_rpc_buffer_get_byte (msg->input, &msg->parsed, &buffer_is_null))
-		return PARSE_ERROR;
 	/* The number of ulongs there's room for on the other end */
 	if (!p11_rpc_buffer_get_uint32 (msg->input, &msg->parsed, &length))
 		return PARSE_ERROR;
@@ -87,8 +84,8 @@ proto_read_byte_buffer (p11_rpc_message *msg,
 	*n_buffer = length;
 	*buffer = NULL;
 
-	/* If buffer is NULL, the caller just wants the length */
-	if (buffer_is_null)
+	/* If set to zero, then they just want the length */
+	if (length == 0)
 		return CKR_OK;
 
 	*buffer = p11_rpc_message_alloc_extra (msg, length * sizeof (CK_BYTE));

--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -169,7 +169,6 @@ proto_read_ulong_buffer (p11_rpc_message *msg,
                          CK_ULONG *n_buffer)
 {
 	uint32_t length;
-	uint8_t buffer_is_null;
 
 	assert (msg != NULL);
 	assert (buffer != NULL);
@@ -179,8 +178,6 @@ proto_read_ulong_buffer (p11_rpc_message *msg,
 	/* Check that we're supposed to be reading this at this point */
 	assert (!msg->signature || p11_rpc_message_verify_part (msg, "fu"));
 
-	if (!p11_rpc_buffer_get_byte (msg->input, &msg->parsed, &buffer_is_null))
-		return PARSE_ERROR;
 	/* The number of ulongs there's room for on the other end */
 	if (!p11_rpc_buffer_get_uint32 (msg->input, &msg->parsed, &length))
 		return PARSE_ERROR;
@@ -188,8 +185,8 @@ proto_read_ulong_buffer (p11_rpc_message *msg,
 	*n_buffer = length;
 	*buffer = NULL;
 
-	/* If buffer is NULL, the caller just wants the length */
-	if (buffer_is_null)
+	/* If set to zero, then they just want the length */
+	if (length == 0)
 		return CKR_OK;
 
 	*buffer = p11_rpc_message_alloc_extra (msg, length * sizeof (CK_ULONG));

--- a/p11-kit/test-server.c
+++ b/p11-kit/test-server.c
@@ -264,36 +264,6 @@ test_open_session_write_protected (void *unused)
 	p11_kit_module_release (module);
 }
 
-static void
-test_no_slots (void *unused)
-{
-	CK_FUNCTION_LIST_PTR module;
-	CK_SLOT_ID slots[32];
-	CK_ULONG count;
-	CK_RV rv;
-
-	module = p11_kit_module_load (P11_MODULE_PATH "/p11-kit-client" SHLEXT, 0);
-	assert (module != NULL);
-
-	rv = p11_kit_module_initialize (module);
-	assert (rv == CKR_OK);
-
-	count = 0;
-	rv = module->C_GetSlotList (CK_TRUE, NULL, &count);
-	assert (rv == CKR_OK);
-	assert_num_eq (0, count);
-
-	count = 0;
-	rv = module->C_GetSlotList (CK_TRUE, slots, &count);
-	assert (rv == CKR_OK);
-	assert_num_eq (0, count);
-
-	rv = p11_kit_module_finalize (module);
-	assert (rv == CKR_OK);
-
-	p11_kit_module_release (module);
-}
-
 int
 main (int argc,
       char *argv[])
@@ -313,11 +283,6 @@ main (int argc,
 		"pkcs11:?write-protected=yes",
 		1
 	};
-	struct fixture with_no_slots = {
-		P11_MODULE_PATH "/mock-eight" SHLEXT,
-		"pkcs11:",
-		0
-	};
 
 	p11_library_init ();
 	mock_module_init ();
@@ -331,7 +296,6 @@ main (int argc,
 	p11_testx (test_initialize, (void *)&without_provider, "/server/all/initialize");
 	p11_testx (test_initialize_no_address, (void *)&without_provider, "/server/all/initialize-no-address");
 	p11_testx (test_open_session, (void *)&without_provider, "/server/all/open-session");
-	p11_testx (test_no_slots, (void *)&with_no_slots, "/server/no-slots");
 
 	return p11_test_run (argc, argv);
 }


### PR DESCRIPTION
It turned out that this breaks compatibility of the RPC protocol.  The right fix to the original issue would be to add a new call ID associated with a different signature and add a fallback mechanism in both client and server.

Fixes #275 