### PR TITLE
rpc: Add missing null checks in attribute value serializers

### DIFF
--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -953,9 +953,7 @@ p11_rpc_buffer_add_mechanism_type_array_value (p11_buffer *buffer,
 					       const void *value,
 					       CK_ULONG value_length)
 {
-	const CK_MECHANISM_TYPE *mechs = value;
 	size_t count = value_length / sizeof (CK_MECHANISM_TYPE);
-	size_t i;
 
 	/* Check if count can be converted to uint32_t. */
 	if (count > UINT32_MAX) {
@@ -966,12 +964,17 @@ p11_rpc_buffer_add_mechanism_type_array_value (p11_buffer *buffer,
 	/* Write the number of items */
 	p11_rpc_buffer_add_uint32 (buffer, count);
 
-	for (i = 0; i < count; i++) {
-		if (mechs[i] > UINT64_MAX) {
-			p11_buffer_fail (buffer);
-			return;
+	if (value) {
+		const CK_MECHANISM_TYPE *mechs = value;
+		size_t i;
+
+		for (i = 0; i < count; i++) {
+			if (mechs[i] > UINT64_MAX) {
+				p11_buffer_fail (buffer);
+				return;
+			}
+			p11_rpc_buffer_add_uint64 (buffer, mechs[i]);
 		}
-		p11_rpc_buffer_add_uint64 (buffer, mechs[i]);
 	}
 }
 
@@ -982,6 +985,7 @@ p11_rpc_buffer_add_date_value (p11_buffer *buffer,
 {
 	CK_DATE date_value;
 	unsigned char array[8];
+	unsigned char *ptr = NULL;
 
 	/* Check if value is empty or can be converted to CK_DATE. */
 	if (value_length != 0 && value_length != sizeof (CK_DATE)) {
@@ -989,14 +993,15 @@ p11_rpc_buffer_add_date_value (p11_buffer *buffer,
 		return;
 	}
 
-	if (value_length == sizeof (CK_DATE)) {
+	if (value && value_length == sizeof (CK_DATE)) {
 		memcpy (&date_value, value, value_length);
 		memcpy (array, date_value.year, 4);
 		memcpy (array + 4, date_value.month, 2);
 		memcpy (array + 6, date_value.day, 2);
+		ptr = array;
 	}
 
-	p11_rpc_buffer_add_byte_array (buffer, array, value_length);
+	p11_rpc_buffer_add_byte_array (buffer, ptr, value_length);
 }
 
 void


### PR DESCRIPTION
To get the length of an attribute value, the client calls `C_GetAttributeValue` with `attr->pValue` set to `NULL` and `attr->ulValueLen` set to -1.  In the RPC level, this is already indicated with a
'validity' flag, but there were a couple of places that assume `attr->pValue` is non-NULL.

This was uncovered by:
https://bugzilla.redhat.com/show_bug.cgi?id=1766340