### PR TITLE
WIP: proxy: Add option to use deterministic slot IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       sudo: required
       services: docker
       env: PROFILE=cppcheck SRCDIR=/srcdir BUILDDIR=/builddir EXTRA_PKGS="cppcheck"
+    - os: linux
+      sudo: required
+      services: docker
+      env: MESON_BUILD_OPTS="-Ddeterministic_slots=true" SRCDIR=/srcdir BUILDDIR=/builddir
     - os: osx
 
 language: c

--- a/configure.ac
+++ b/configure.ac
@@ -538,6 +538,24 @@ AC_SUBST(LCOV)
 AC_SUBST(GCOV)
 AC_SUBST(GENHTML)
 
+# --------------------------------------------------------------------
+# Deterministic slots
+
+AC_MSG_CHECKING([whether to use deterministic slot IDs])
+AC_ARG_ENABLE([deterministic-slots],
+		[AS_HELP_STRING([--enable-deterministic_slots],
+		[Whether to use deterministic slots])],
+		[],
+		[enable_deterministic_slots=no])
+
+AC_MSG_RESULT([$enable_deterministic_slots])
+
+AS_IF([test "x$enable_deterministic_slots" = "xyes"], [
+	AC_DEFINE_UNQUOTED(WITH_DETERMINISTIC_SLOTS, 1, [Use deterministic slots])
+])
+
+AM_CONDITIONAL(WITH_DETERMINISTIC_SLOTS, [test "x$enable_deterministic_slots" = "xyes"])
+
 # ---------------------------------------------------------------------
 
 P11KIT_LT_RELEASE=$P11KIT_CURRENT:$P11KIT_REVISION:$P11KIT_AGE
@@ -633,6 +651,7 @@ AC_MSG_NOTICE([build options:
     User global config:              $p11_user_config_file
     User module config directory:    $p11_user_config_modules
     Load relative module paths from: $p11_module_path
+    Use deterministic slots:         $enable_deterministic_slots
 
     With libtasn1 dependency:        $with_libtasn1
     With libffi:                     $with_libffi

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ if get_option('debug')
 endif
 
 conf.set10('WITH_STRICT', get_option('strict'))
+conf.set10('WITH_DETERMINISTIC_SLOTS', get_option('deterministic_slots'))
 
 prefix = get_option('prefix')
 datadir = get_option('datadir')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -49,3 +49,7 @@ option('gtk_doc', type : 'boolean',
 option('man', type : 'boolean',
        value : false,
        description : 'Build manpages using xsltproc')
+
+option('deterministic_slots', type : 'boolean',
+       value : false,
+       description : 'Whether to use deterministic slot IDs')

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -432,7 +432,8 @@ check_LTLIBRARIES += \
 	mock-five.la \
 	mock-seven.la \
 	mock-eight.la \
-	mock-nine.la
+	mock-nine.la \
+	mock-ten.la
 
 mock_one_la_SOURCES = p11-kit/mock-module-ep.c
 mock_one_la_LIBADD = libp11-test.la libp11-common.la
@@ -474,6 +475,10 @@ mock_eight_la_LIBADD = $(mock_one_la_LIBADD)
 mock_nine_la_SOURCES = p11-kit/mock-module-ep7.c
 mock_nine_la_LDFLAGS = $(mock_one_la_LDFLAGS)
 mock_nine_la_LIBADD = $(mock_one_la_LIBADD)
+
+mock_ten_la_SOURCES = p11-kit/mock-module-ep8.c
+mock_ten_la_LDFLAGS = $(mock_one_la_LDFLAGS)
+mock_ten_la_LIBADD = $(mock_one_la_LIBADD)
 
 EXTRA_DIST += \
 	p11-kit/fixtures \

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -275,7 +275,8 @@ mock_sources = {
   'mock-five': ['mock-module-ep3.c'],
   'mock-seven': ['mock-module-ep5.c'],
   'mock-eight': ['mock-module-ep6.c'],
-  'mock-nine': ['mock-module-ep7.c']
+  'mock-nine': ['mock-module-ep7.c'],
+  'mock-ten': ['mock-module-ep8.c']
 }
 
 if host_system != 'windows'

--- a/p11-kit/mock-module-ep8.c
+++ b/p11-kit/mock-module-ep8.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2012 Stefan Walter
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Stef Walter <stef@thewalter.net>, Daiki Ueno, Anderson Sasaki
+ */
+
+#include "config.h"
+
+#define CRYPTOKI_EXPORTS 1
+#include "pkcs11.h"
+
+#include "mock.h"
+#include "test.h"
+
+#define MOCK_SLOT_THREE_ID 792
+
+static const CK_SLOT_INFO MOCK_INFO_ONE = {
+	"TEST SLOT                                                       ",
+	"TEST MANUFACTURER               ",
+	CKF_TOKEN_PRESENT | CKF_REMOVABLE_DEVICE,
+	{ 55, 155 },
+	{ 65, 165 },
+};
+
+/* Update mock-module.h URIs when updating this */
+
+static const CK_SLOT_INFO MOCK_INFO_TWO = {
+	"TEST SLOT                                                       ",
+	"TEST MANUFACTURER               ",
+	CKF_REMOVABLE_DEVICE,
+	{ 55, 155 },
+	{ 65, 165 },
+};
+
+static const CK_SLOT_INFO MOCK_INFO_THREE = {
+	"TEST SLOT                                                       ",
+	"TEST MANUFACTURER               ",
+	CKF_TOKEN_PRESENT,
+	{ 55, 155 },
+	{ 65, 165 },
+};
+
+static const CK_TOKEN_INFO MOCK_TOKEN_ONE = {
+	"TEST LABEL                      ",
+	"TEST MANUFACTURER               ",
+	"TEST MODEL      ",
+	"TEST SERIAL     ",
+	CKF_LOGIN_REQUIRED | CKF_USER_PIN_INITIALIZED | CKF_CLOCK_ON_TOKEN | CKF_TOKEN_INITIALIZED,
+	1,
+	2,
+	3,
+	4,
+	5,
+	6,
+	7,
+	8,
+	9,
+	10,
+	{ 75, 175 },
+	{ 85, 185 },
+	{ '1', '9', '9', '9', '0', '5', '2', '5', '0', '9', '1', '9', '5', '9', '0', '0' }
+};
+
+static const CK_TOKEN_INFO MOCK_TOKEN_THREE = {
+	"TEST LABEL                      ", // label[32]
+	"TEST MANUFACTURER               ", // manufacturer_id[32]
+	"TEST MODEL      ",                 // model[16]
+	"1234567812345678",                 // serial[16]
+	CKF_LOGIN_REQUIRED | CKF_USER_PIN_INITIALIZED | CKF_CLOCK_ON_TOKEN | CKF_TOKEN_INITIALIZED,
+	1,                                  // max_session_count
+	0,                                  // session_count
+	1,                                  // max_rw_session_count
+	0,                                  // rw_session_count
+	16,                                  // max_pin_len
+	4,                                  // min_pin_len
+	4096,                               // total_public_memory
+	0,                                  // free_public_memory
+	4096,                               // total_private_memory
+	0,                                  // free_private_memory
+	{ 55, 155 },                        // hardware_version
+	{ 65, 165 },                        // firmware_version
+	{'1', '9', '9', '1', '0', '8', '2', '5', '2', '2', '5', '7', '0', '8', '0', '0'}
+};
+
+static CK_RV
+override_get_slot_list (CK_BBOOL token_present,
+                    CK_SLOT_ID_PTR slot_list,
+                    CK_ULONG_PTR count)
+{
+	CK_ULONG num;
+
+	if (count == NULL)
+		return CKR_ARGUMENTS_BAD;
+
+	num = token_present ? 2 : 3;
+
+	/* Application only wants to know the number of slots. */
+	if (slot_list == NULL) {
+		*count = num;
+		return CKR_OK;
+	}
+
+	if (*count < num)
+		return CKR_BUFFER_TOO_SMALL;
+
+	*count = num;
+	slot_list[0] = MOCK_SLOT_ONE_ID;
+	if (token_present) {
+		slot_list[1] = MOCK_SLOT_THREE_ID;
+	} else {
+		slot_list[1] = MOCK_SLOT_TWO_ID;
+		slot_list[2] = MOCK_SLOT_THREE_ID;
+	}
+
+	return CKR_OK;
+
+}
+
+static CK_RV
+override_get_slot_info (CK_SLOT_ID slot_id,
+                    CK_SLOT_INFO_PTR info)
+{
+	if (info == NULL)
+		return CKR_ARGUMENTS_BAD;
+
+	if (slot_id == MOCK_SLOT_ONE_ID) {
+		memcpy (info, &MOCK_INFO_ONE, sizeof (*info));
+		return CKR_OK;
+	} else if (slot_id == MOCK_SLOT_TWO_ID) {
+		memcpy (info, &MOCK_INFO_TWO, sizeof (*info));
+		return CKR_OK;
+	} else if (slot_id == MOCK_SLOT_THREE_ID) {
+		memcpy (info, &MOCK_INFO_THREE, sizeof (*info));
+		return CKR_OK;
+	} else {
+		return CKR_SLOT_ID_INVALID;
+	}
+}
+
+static CK_RV
+override_get_token_info (CK_SLOT_ID slot_id,
+                     CK_TOKEN_INFO_PTR info)
+{
+	if (info == NULL)
+		return CKR_ARGUMENTS_BAD;
+
+	if (slot_id == MOCK_SLOT_ONE_ID) {
+		memcpy (info, &MOCK_TOKEN_ONE, sizeof (*info));
+		return CKR_OK;
+	} else if (slot_id == MOCK_SLOT_TWO_ID) {
+		return CKR_TOKEN_NOT_PRESENT;
+	} else if (slot_id == MOCK_SLOT_THREE_ID) {
+		memcpy (info, &MOCK_TOKEN_THREE, sizeof (*info));
+		return CKR_OK;
+	} else {
+		return CKR_SLOT_ID_INVALID;
+	}
+}
+
+#ifdef OS_WIN32
+__declspec(dllexport)
+#endif
+CK_RV
+C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
+{
+	mock_module_init ();
+	mock_module.C_GetFunctionList = C_GetFunctionList;
+	if (list == NULL)
+		return CKR_ARGUMENTS_BAD;
+	mock_module.C_GetSlotList= override_get_slot_list;
+	mock_module.C_GetSlotInfo= override_get_slot_info;
+	mock_module.C_GetTokenInfo= override_get_token_info;
+	*list = &mock_module;
+	return CKR_OK;
+}
+


### PR DESCRIPTION
The added option makes the p11-kit-proxy module to provide slot IDs
derived from the information retrieved from the devices.  This way,
devices will get a deterministic ID regardless of the order the devices are found.

Fixes:  #266