### PR TITLE
anchor: Exit with non-zero code, if any error occurs

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -67,7 +67,6 @@ static struct DebugKey debug_keys[] = {
 	{ 0, }
 };
 
-static bool debug_inited = false;
 static bool debug_strict = false;
 
 /* global variable exported in debug.h */
@@ -130,7 +129,6 @@ void
 p11_debug_init (void)
 {
 	p11_debug_current_flags = parse_environ_flags ();
-	debug_inited = true;
 }
 
 void

--- a/common/tool.c
+++ b/common/tool.c
@@ -182,14 +182,14 @@ command_usage (const p11_tool_command *commands)
 static void
 verbose_arg (void)
 {
-	putenv ("P11_KIT_DEBUG=tool");
+	setenv ("P11_KIT_DEBUG", "tool", 0);
 	p11_message_loud ();
 }
 
 static void
 quiet_arg (void)
 {
-	putenv ("P11_KIT_DEBUG=");
+	unsetenv ("P11_KIT_DEBUG");
 	p11_message_quiet ();
 }
 

--- a/common/tool.c
+++ b/common/tool.c
@@ -184,7 +184,6 @@ verbose_arg (void)
 {
 	putenv ("P11_KIT_DEBUG=tool");
 	p11_message_loud ();
-	p11_debug_init ();
 }
 
 static void
@@ -192,7 +191,6 @@ quiet_arg (void)
 {
 	putenv ("P11_KIT_DEBUG=");
 	p11_message_quiet ();
-	p11_debug_init ();
 }
 
 int
@@ -206,6 +204,9 @@ p11_tool_main (int argc,
 	bool skip;
 	int in, out;
 	int i;
+
+	/* Print messages by default. */
+	p11_message_loud ();
 
 	/*
 	 * Parse the global options. We rearrange the options as


### PR DESCRIPTION
This makes `trust anchor --store` or `trust anchor --remove` exit with non-zero if any error happens.

Also it makes the tools print error messages by default.

Fixes #300.