### PR TITLE
Avoid using setenv() for MinGW users.

### DIFF
--- a/common/tool.c
+++ b/common/tool.c
@@ -189,7 +189,7 @@ verbose_arg (void)
 static void
 quiet_arg (void)
 {
-	unsetenv ("P11_KIT_DEBUG");
+	setenv ("P11_KIT_DEBUG", "", 1);
 	p11_message_quiet ();
 }
 


### PR DESCRIPTION
In MinGW (Minimalist GNU for Windows), unsetenv() is undefined...
I propose to use setenv() instead.

Signed-off-by: Kai Takahashi <www.carrotsoft@gmail.com>