### PR TITLE
common: Get program name based on executable path if possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ x86_64-w64-mingw32
 
 /test-*
 frob-*
+!frob-*.c
 
 /x86_64_w64-mingw32/
 

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -130,4 +130,11 @@ common_frob_getauxval_LDADD = $(common_LIBS)
 common_frob_getenv_SOURCES = common/frob-getenv.c
 common_frob_getenv_LDADD = $(common_LIBS)
 
+if !OS_WIN32
+check_PROGRAMS += common/frob-getprogname
+
+common_frob_getprogname_SOURCES = common/frob-getprogname.c
+common_frob_getprogname_LDADD = $(common_LIBS)
+endif
+
 EXTRA_DIST += common/meson.build

--- a/common/frob-getprogname.c
+++ b/common/frob-getprogname.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020 Red Hat Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Daiki Ueno
+ */
+
+#include "config.h"
+#include "compat.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int
+main (int argc,
+      char *argv[])
+{
+	if (argc == 1) {
+		pid_t pid;
+		int pfds[2];
+
+		if (pipe (pfds) < 0) {
+			perror ("pipe");
+			exit (EXIT_FAILURE);
+		}
+
+		pid = fork ();
+		if (pid < 0) {
+			perror ("fork");
+			exit (EXIT_FAILURE);
+		}
+
+		if (pid == 0) {
+			char * const argv[] = {
+				BUILDDIR "/common/frob-getprogname" EXEEXT " foo bar",
+				"foo",
+				"bar",
+				NULL,
+			};
+
+			dup2 (pfds[1], STDOUT_FILENO);
+			close (pfds[0]);
+			close (pfds[1]);
+			execv (BUILDDIR "/common/frob-getprogname" EXEEXT, argv);
+		} else {
+			int status;
+			char buffer[1024];
+			size_t offset = 0;
+			ssize_t nread;
+			char *p;
+
+			close (pfds[1]);
+			while (1) {
+				nread = read (pfds[0], buffer + offset, sizeof(buffer) - offset);
+				if (nread < 0) {
+					perror ("read");
+					exit (EXIT_FAILURE);
+				}
+				if (nread == 0)
+					break;
+				offset += nread;
+			}
+
+			if (waitpid (pid, &status, 0) < 0) {
+				perror ("waitpid");
+				exit (EXIT_FAILURE);
+			}
+
+			assert (!WIFSIGNALED (status));
+			assert (WIFEXITED (status));
+			assert (WEXITSTATUS (status) == 0);
+
+			p = memchr (buffer, '\n', sizeof(buffer));
+			if (!p) {
+				fprintf (stderr, "missing newline: %s\n", buffer);
+				exit (EXIT_FAILURE);
+			}
+			*p = '\0';
+
+			return strcmp ("frob-getprogname", buffer) == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+		}
+	} else {
+		printf ("%s\n", getprogname ());
+		exit (EXIT_SUCCESS);
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/common/meson.build
+++ b/common/meson.build
@@ -92,8 +92,13 @@ if get_option('test')
     'frob-getenv'
   ]
 
+  if host_system != 'windows'
+    common_progs += ['frob-getprogname']
+  endif
+
   foreach name : common_progs
     executable(name, '@0@.c'.format(name),
+               c_args: tests_c_args,
                include_directories: configinc,
                dependencies: dlopen_deps,
                link_with: [libp11_common])

--- a/common/test-compat.c
+++ b/common/test-compat.c
@@ -125,6 +125,20 @@ test_mmap (void)
 	p11_mmap_close (map);
 }
 
+static void
+test_getprogname (void)
+{
+#if defined(__linux__) && defined(HAVE_PROGRAM_INVOCATION_SHORT_NAME)
+	const char *args[] = { BUILDDIR "/common/frob-getprogname", NULL };
+	int ret;
+
+	ret = p11_test_run_child (args, false);
+	assert_num_eq (ret, 0);
+#else
+	assert_skip ("cannot perform getprogname test", NULL);
+#endif
+}
+
 #endif /* OS_UNIX */
 
 int
@@ -140,6 +154,7 @@ main (int argc,
 		p11_test (test_secure_getenv, "/compat/secure_getenv");
 	}
 	p11_test (test_mmap, "/compat/mmap");
+	p11_test (test_getprogname, "/compat/getprogname");
 #endif
 	return p11_test_run (argc, argv);
 }


### PR DESCRIPTION
Some programs (e.g., Chromium) pack command line arguments into `argv[0]`. Check if it is the case by reading `/proc/self/exe` and extract the program name.

Logic borrowed from:
<https://github.com/mesa3d/mesa/commit/759b94038987bb983398cd4b1d2cb1c8f79817a9>.

Fixes #263.