### PR TITLE
conf: Add internal option to forcibly enable user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # p11-kit
 
-[![Build Status](https://travis-ci.org/p11-glue/p11-kit.svg?branch=master)](https://travis-ci.org/p11-glue/p11-kit) [![Coverage Status](https://img.shields.io/coveralls/p11-glue/p11-kit.svg)](https://coveralls.io/r/p11-glue/p11-kit) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1627/badge)](https://bestpractices.coreinfrastructure.org/en/projects/1627)[![Total alerts](https://img.shields.io/lgtm/alerts/g/p11-glue/p11-kit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/p11-glue/p11-kit/alerts/)[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/p11-glue/p11-kit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/p11-glue/p11-kit/context:cpp)
+[![Build Status](https://travis-ci.org/p11-glue/p11-kit.svg?branch=master)](https://travis-ci.org/p11-glue/p11-kit) [![Coverage Status](https://img.shields.io/coveralls/p11-glue/p11-kit.svg)](https://coveralls.io/r/p11-glue/p11-kit) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1627/badge)](https://bestpractices.coreinfrastructure.org/en/projects/1627) [![Total alerts](https://img.shields.io/lgtm/alerts/g/p11-glue/p11-kit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/p11-glue/p11-kit/alerts/) [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/p11-glue/p11-kit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/p11-glue/p11-kit/context:cpp)
 
 p11-kit aims to solve problems with coordinating the use of [PKCS #11]
 by different components or libraries living in the same process, by

--- a/p11-kit/conf.c
+++ b/p11-kit/conf.c
@@ -57,6 +57,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* For testing, when the tests assuming user config are run as root. */
+bool p11_conf_force_user_config = false;
+
 static int
 strequal (const char *one, const char *two)
 {
@@ -228,7 +231,7 @@ _p11_conf_load_globals (const char *system_conf, const char *user_conf,
 		goto finished;
 	}
 
-	if (mode != CONF_USER_NONE) {
+	if (mode != CONF_USER_NONE && !p11_conf_force_user_config) {
 		if (getauxval (AT_SECURE)) {
 			p11_debug ("skipping user config in setuid or setgid program");
 			mode = CONF_USER_NONE;

--- a/p11-kit/test-conf.c
+++ b/p11-kit/test-conf.c
@@ -406,6 +406,9 @@ test_setuid (void)
 	char *path;
 	int ret;
 
+	if (getuid () == 0)
+		assert_skip ("cannot perform setuid test as root", NULL);
+
 	/* This is the 'number' setting set in one.module user configuration. */
 	ret = p11_test_run_child (args, true);
 	assert_num_eq (ret, 33);
@@ -427,10 +430,14 @@ test_setuid (void)
 
 #endif /* OS_UNIX */
 
+extern bool p11_conf_force_user_config;
+
 int
 main (int argc,
       char *argv[])
 {
+	p11_conf_force_user_config = true;
+
 	p11_test (test_parse_conf_1, "/conf/test_parse_conf_1");
 	p11_test (test_parse_ignore_missing, "/conf/test_parse_ignore_missing");
 	p11_test (test_parse_fail_missing, "/conf/test_parse_fail_missing");

--- a/p11-kit/test-deprecated.c
+++ b/p11-kit/test-deprecated.c
@@ -486,10 +486,14 @@ test_load_and_initialize (void)
 	assert_num_eq (rv, CKR_OK);
 }
 
+extern bool p11_conf_force_user_config;
+
 int
 main (int argc,
       char *argv[])
 {
+	p11_conf_force_user_config = true;
+
 	p11_mutex_init (&race_mutex);
 	mock_module_init ();
 	p11_library_init ();

--- a/p11-kit/test-modules.c
+++ b/p11-kit/test-modules.c
@@ -486,10 +486,14 @@ test_already_initialized (void)
 	finalize_and_free_modules (modules);
 }
 
+extern bool p11_conf_force_user_config;
+
 int
 main (int argc,
       char *argv[])
 {
+	p11_conf_force_user_config = true;
+
 	p11_library_init ();
 
 	p11_test (test_filename, "/modules/test_filename");

--- a/p11-kit/test-transport.c
+++ b/p11-kit/test-transport.c
@@ -405,6 +405,8 @@ test_fork_and_reinitialize (void)
 
 #include "test-mock.c"
 
+extern bool p11_conf_force_user_config;
+
 int
 main (int argc,
       char *argv[])
@@ -420,6 +422,8 @@ main (int argc,
 	};
 
 	p11_library_init ();
+
+	p11_conf_force_user_config = true;
 
 	/* Override the mechanisms that the RPC mechanism will handle */
 	p11_rpc_mechanisms_override_supported = mechanisms;


### PR DESCRIPTION
Some tests need user config enabled, though it is disabled under certain conditions (e.g., running as root) and makes those tests fail.

Fixes #256.