### PR TITLE
autotools: Fix SUFFIXES usage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,8 @@ check_PROGRAMS = $(c_tests)
 check_SCRIPTS = $(sh_tests)
 check_LTLIBRARIES =
 
+SUFFIXES =
+
 BUILT_SOURCES =
 
 CLEANFILES =

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -137,7 +137,7 @@ p11-kit/uri.gnu.c: p11-kit/uri.h
 p11-kit/iter.gnu.c: p11-kit/iter.h
 p11-kit/pin.gnu.c: p11-kit/pin.h
 
-SUFFIXES = .h .gnu.c
+SUFFIXES += .h .gnu.c
 .h.gnu.c:
 	$(AM_V_GEN) src=$<; dst=$@; rm -f $@-t $@ && \
 	{ echo '/* DO NOT EDIT! GENERATED AUTOMATICALLY! */'; \

--- a/trust/Makefile.am
+++ b/trust/Makefile.am
@@ -125,7 +125,7 @@ EXTRA_DIST += \
 	trust/p11-kit-trust.module \
 	trust/meson.build
 
-SUFFIXES = .asn .asn.h
+SUFFIXES += .asn .asn.h
 .asn.asn.h:
 	$(AM_V_GEN)$(ASN1PARSER) -o $@ $<
 


### PR DESCRIPTION
SUFFIXES must be defined in the top-level Makefile.am, when non-recursive make is used.