### PR TITLE
unix-peer: replace incorrect include1

### DIFF
--- a/common/unix-peer.c
+++ b/common/unix-peer.c
@@ -41,7 +41,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/uio.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #ifdef HAVE_UCRED_H
 #  include <ucred.h>


### PR DESCRIPTION
Fixes musl warning:

warning: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Wcpp]