### PR TITLE
common: Check for a NULL locale before freeing it

### DIFF
--- a/common/library.c
+++ b/common/library.c
@@ -181,7 +181,8 @@ p11_library_uninit (void)
 #endif
 
 #ifdef HAVE_STRERROR_L
-	freelocale (p11_message_locale);
+	if (p11_message_locale != (locale_t) 0)
+		freelocale (p11_message_locale);
 #endif
 	p11_message_storage = dont_store_message;
 #ifndef P11_TLS_KEYWORD


### PR DESCRIPTION
If newlocale() fails, (locale_t) 0 ends up being passed to freelocale(),
resulting in a segfault when the library is unloaded.