### PR TITLE
meson: Allow override of default bashcompdir.

### DIFF
--- a/bash-completion/meson.build
+++ b/bash-completion/meson.build
@@ -1,11 +1,15 @@
-bashcomp = dependency('bash-completion', required: get_option('bash_completion'))
-
-if bashcomp.found()
-  bashcompdir = bashcomp.get_pkgconfig_variable('completionsdir')
+bashcompdir = get_option('bashcompdir')
+if bashcompdir == ''
+  bashcomp = dependency('bash-completion', required: get_option('bash_completion'))
+  if bashcomp.found()
+    bashcompdir = bashcomp.get_pkgconfig_variable('completionsdir')
+  else
+    warning('Will not install bash completion due to missing dependencies!')
+  endif
+endif
+if bashcompdir != ''
   install_data('p11-kit', install_dir: bashcompdir)
   if with_trust_module
     install_data('trust', install_dir: bashcompdir)
   endif
-else
-  warning('Will not install bash completion due to missing dependencies!')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,6 +42,10 @@ option('systemd', type : 'feature',
        value : 'auto',
        description : 'Use systemd socket activation')
 
+option('bashcompdir', type : 'string',
+       value : '',
+       description : 'Override default location for bash completion files')
+
 option('bash_completion', type : 'feature',
        value : 'auto',
        description : 'Install bash completion files')


### PR DESCRIPTION
Fixes meson regression (issue #322).  Pass -Dbashcompdir=/xxx to meson.