### PR TITLE
proxy: C_CloseAllSessions: Make sure that calloc args are non-zero

### DIFF
--- a/common/dict.c
+++ b/common/dict.c
@@ -122,7 +122,7 @@ lookup_or_create_bucket (p11_dict *dict,
 		return bucketp;
 
 	/* add a new entry for non-NULL val */
-	(*bucketp) = calloc (sizeof (dictbucket), 1);
+	(*bucketp) = calloc (1, sizeof (dictbucket));
 
 	if (*bucketp != NULL) {
 		(*bucketp)->key = (void*)key;
@@ -175,7 +175,7 @@ p11_dict_set (p11_dict *dict,
 		/* check that the collision rate isn't too high */
 		if (dict->num_items > dict->num_buckets) {
 			num_buckets = dict->num_buckets * 2 + 1;
-			new_buckets = (dictbucket **)calloc (sizeof (dictbucket *), num_buckets);
+			new_buckets = (dictbucket **)calloc (num_buckets, sizeof (dictbucket *));
 
 			/* Ignore failures, maybe we can expand later */
 			if(new_buckets) {
@@ -283,7 +283,7 @@ p11_dict_new (p11_dict_hasher hash_func,
 		dict->value_destroy_func = value_destroy_func;
 
 		dict->num_buckets = 9;
-		dict->buckets = (dictbucket **)calloc (sizeof (dictbucket *), dict->num_buckets);
+		dict->buckets = (dictbucket **)calloc (dict->num_buckets, sizeof (dictbucket *));
 		if (!dict->buckets) {
 			free (dict);
 			return NULL;

--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -265,7 +265,7 @@ proxy_list_slots (Proxy *py, Mapping *mappings, unsigned int n_mappings)
 		/* Ask module for its slots */
 		rv = (funcs->C_GetSlotList) (FALSE, NULL, &count);
 		if (rv == CKR_OK && count) {
-			slots = calloc (sizeof (CK_SLOT_ID), count);
+			slots = calloc (count, sizeof (CK_SLOT_ID));
 			rv = (funcs->C_GetSlotList) (FALSE, slots, &count);
 		}
 
@@ -756,7 +756,7 @@ proxy_C_CloseAllSessions (CK_X_FUNCTION_LIST *self,
 			rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 		} else {
 			assert (state->px->sessions != NULL);
-			to_close = calloc (sizeof (CK_SESSION_HANDLE), p11_dict_size (state->px->sessions));
+			to_close = calloc (p11_dict_size (state->px->sessions), sizeof (CK_SESSION_HANDLE));
 			if (!to_close) {
 				rv = CKR_HOST_MEMORY;
 			} else {

--- a/p11-kit/proxy.c
+++ b/p11-kit/proxy.c
@@ -744,7 +744,7 @@ proxy_C_CloseAllSessions (CK_X_FUNCTION_LIST *self,
                           CK_SLOT_ID id)
 {
 	State *state = (State *)self;
-	CK_SESSION_HANDLE_PTR to_close;
+	CK_SESSION_HANDLE_PTR to_close = NULL;
 	CK_RV rv = CKR_OK;
 	Session *sess;
 	CK_ULONG i, count = 0;
@@ -756,7 +756,7 @@ proxy_C_CloseAllSessions (CK_X_FUNCTION_LIST *self,
 			rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 		} else {
 			assert (state->px->sessions != NULL);
-			to_close = calloc (p11_dict_size (state->px->sessions), sizeof (CK_SESSION_HANDLE));
+			to_close = calloc (p11_dict_size (state->px->sessions) + 1, sizeof (CK_SESSION_HANDLE));
 			if (!to_close) {
 				rv = CKR_HOST_MEMORY;
 			} else {


### PR DESCRIPTION
This prevents efence warning if either of the calloc arguments is zero.  While it is is safe on glibc systems, POSIX says the behavior is implementation-defined.
    
Reported by Paul Wouters.