### PR TITLE
common: Fix infloop in p11_path_build

### DIFF
--- a/common/path.c
+++ b/common/path.c
@@ -241,8 +241,10 @@ p11_path_build (const char *path,
 			num--;
 
 		if (at != 0) {
-			if (num == 0)
+			if (num == 0) {
+				path = va_arg (va, const char *);
 				continue;
+			}
 			built[at++] = delim;
 		}
 

--- a/common/test-path.c
+++ b/common/test-path.c
@@ -88,6 +88,8 @@ static void
 test_build (void)
 {
 #ifdef OS_UNIX
+	assert_str_eq_free ("/root",
+	                    p11_path_build ("/root", "", NULL));
 	assert_str_eq_free ("/root/second",
 	                    p11_path_build ("/root", "second", NULL));
 	assert_str_eq_free ("/root/second",
@@ -99,6 +101,8 @@ test_build (void)
 	assert_str_eq_free ("/root/second/third",
 	                    p11_path_build ("/root", "/second/third", NULL));
 #else /* OS_WIN32 */
+	assert_str_eq_free ("C:\\root",
+	                    p11_path_build ("C:\\root", "", NULL));
 	assert_str_eq_free ("C:\\root\\second",
 	                    p11_path_build ("C:\\root", "second", NULL));
 	assert_str_eq_free ("C:\\root\\second",


### PR DESCRIPTION
If `p11_path_build` is called with 2 or more arguments and the non-first argument is an empty string (""), it previously fell into an infloop.

Reported by Karel Srot.