### PR TITLE
Follow-up improvements to p11_path_build

### DIFF
--- a/common/path.c
+++ b/common/path.c
@@ -119,7 +119,7 @@ expand_homedir (const char *remainder)
 		return NULL;
 	}
 
-	while (remainder[0] && is_path_component_or_null (remainder[0]))
+	while (is_path_component (remainder[0]))
 		remainder++;
 	if (remainder[0] == '\0')
 		remainder = NULL;

--- a/common/path.c
+++ b/common/path.c
@@ -241,8 +241,10 @@ p11_path_build (const char *path,
 			num--;
 
 		if (at != 0) {
-			if (num == 0)
+			if (num == 0) {
+				path = va_arg (va, const char *);
 				continue;
+			}
 			built[at++] = delim;
 		}
 

--- a/common/path.c
+++ b/common/path.c
@@ -94,7 +94,7 @@ p11_path_base (const char *path)
 }
 
 static inline bool
-is_path_component (char ch)
+is_path_separator (char ch)
 {
 	return (ch == '/'
 #ifdef OS_WIN32
@@ -104,9 +104,9 @@ is_path_component (char ch)
 }
 
 static inline bool
-is_path_component_or_null (char ch)
+is_path_separator_or_null (char ch)
 {
-	return is_path_component (ch) || ch == '\0';
+	return is_path_separator (ch) || ch == '\0';
 }
 
 static char *
@@ -119,7 +119,7 @@ expand_homedir (const char *remainder)
 		return NULL;
 	}
 
-	while (is_path_component (remainder[0]))
+	while (is_path_separator (remainder[0]))
 		remainder++;
 	if (remainder[0] == '\0')
 		remainder = NULL;
@@ -127,7 +127,7 @@ expand_homedir (const char *remainder)
 	/* Expand $XDG_CONFIG_HOME */
 	if (remainder != NULL &&
 	    strncmp (remainder, ".config", 7) == 0 &&
-	    is_path_component_or_null (remainder[7])) {
+	    is_path_separator_or_null (remainder[7])) {
 		env = getenv ("XDG_CONFIG_HOME");
 		if (env && env[0])
 			return p11_path_build (env, remainder + 8, NULL);
@@ -180,7 +180,7 @@ p11_path_expand (const char *path)
 	return_val_if_fail (path != NULL, NULL);
 
 	if (strncmp (path, "~", 1) == 0 &&
-	    is_path_component_or_null (path[1])) {
+	    is_path_separator_or_null (path[1])) {
 		return expand_homedir (path + 1);
 
 	} else {
@@ -242,9 +242,9 @@ p11_path_build (const char *path,
 		num = strlen (path);
 
 		/* Trim beginning of path */
-		while (is_path_component (path[0])) {
+		while (is_path_separator (path[0])) {
 			/* But preserve the leading path component */
-			if (!at && !is_path_component (path[1]))
+			if (!at && !is_path_separator (path[1]))
 				break;
 			path++;
 			num--;
@@ -252,7 +252,7 @@ p11_path_build (const char *path,
 
 		/* Trim end of the path */
 		until = (at > 0) ? 0 : 1;
-		while (num > until && is_path_component_or_null (path[num - 1]))
+		while (num > until && is_path_separator_or_null (path[num - 1]))
 			num--;
 
 		if (at != 0) {
@@ -288,17 +288,17 @@ p11_path_parent (const char *path)
 
 	/* Find the end of the last component */
 	e = path + strlen (path);
-	while (e != path && is_path_component_or_null (*e))
+	while (e != path && is_path_separator_or_null (*e))
 		e--;
 
 	/* Find the beginning of the last component */
-	while (e != path && !is_path_component_or_null (*e)) {
+	while (e != path && !is_path_separator_or_null (*e)) {
 		had = true;
 		e--;
 	}
 
 	/* Find the end of the last component */
-	while (e != path && is_path_component_or_null (*e))
+	while (e != path && is_path_separator_or_null (*e))
 		e--;
 
 	if (e == path) {
@@ -327,7 +327,7 @@ p11_path_prefix (const char *string,
 
 	return a > b &&
 	       strncmp (string, prefix, b) == 0 &&
-	       is_path_component_or_null (string[b]);
+	       is_path_separator_or_null (string[b]);
 }
 
 void

--- a/common/test-path.c
+++ b/common/test-path.c
@@ -88,6 +88,16 @@ static void
 test_build (void)
 {
 #ifdef OS_UNIX
+	assert_str_eq_free ("/",
+	                    p11_path_build ("/", NULL));
+	assert_str_eq_free ("/",
+	                    p11_path_build ("", "//", NULL));
+	assert_str_eq_free ("/root",
+	                    p11_path_build ("///root///", NULL));
+	assert_str_eq_free ("/root",
+	                    p11_path_build ("/", "root", NULL));
+	assert_str_eq_free ("/root",
+	                    p11_path_build ("", "/root", NULL));
 	assert_str_eq_free ("/root",
 	                    p11_path_build ("/root", "", NULL));
 	assert_str_eq_free ("/root/second",
@@ -96,11 +106,19 @@ test_build (void)
 	                    p11_path_build ("/root", "/second", NULL));
 	assert_str_eq_free ("/root/second",
 	                    p11_path_build ("/root/", "second", NULL));
+	assert_str_eq_free ("/root/second",
+	                    p11_path_build ("/root//", "//second/", NULL));
+	assert_str_eq_free ("/root/second",
+	                    p11_path_build ("/root//", "", "//second/", NULL));
 	assert_str_eq_free ("/root/second/third",
 	                    p11_path_build ("/root", "second", "third", NULL));
 	assert_str_eq_free ("/root/second/third",
 	                    p11_path_build ("/root", "/second/third", NULL));
 #else /* OS_WIN32 */
+	assert_str_eq_free ("C:\\root",
+	                    p11_path_build ("C:\\", "root", NULL));
+	assert_str_eq_free ("C:\\root",
+	                    p11_path_build ("", "C:\\root", NULL));
 	assert_str_eq_free ("C:\\root",
 	                    p11_path_build ("C:\\root", "", NULL));
 	assert_str_eq_free ("C:\\root\\second",
@@ -109,6 +127,10 @@ test_build (void)
 	                    p11_path_build ("C:\\root", "\\second", NULL));
 	assert_str_eq_free ("C:\\root\\second",
 	                    p11_path_build ("C:\\root\\", "second", NULL));
+	assert_str_eq_free ("C:\\root\\second",
+	                    p11_path_build ("C:\\root\\\\", "\\\\second", NULL));
+	assert_str_eq_free ("C:\\root\\second",
+	                    p11_path_build ("C:\\root\\\\", "", "\\\\second", NULL));
 	assert_str_eq_free ("C:\\root\\second\\third",
 	                    p11_path_build ("C:\\root", "second", "third", NULL));
 	assert_str_eq_free ("C:\\root\\second/third",

--- a/common/test-path.c
+++ b/common/test-path.c
@@ -88,6 +88,8 @@ static void
 test_build (void)
 {
 #ifdef OS_UNIX
+	assert_str_eq_free ("/root",
+	                    p11_path_build ("/root", "", NULL));
 	assert_str_eq_free ("/root/second",
 	                    p11_path_build ("/root", "second", NULL));
 	assert_str_eq_free ("/root/second",
@@ -99,6 +101,8 @@ test_build (void)
 	assert_str_eq_free ("/root/second/third",
 	                    p11_path_build ("/root", "/second/third", NULL));
 #else /* OS_WIN32 */
+	assert_str_eq_free ("C:\\root",
+	                    p11_path_build ("C:\\root", "", NULL));
 	assert_str_eq_free ("C:\\root\\second",
 	                    p11_path_build ("C:\\root", "second", NULL));
 	assert_str_eq_free ("C:\\root\\second",


### PR DESCRIPTION
This PR builds upon @ueno's #326 that fixes handling of empty string components in `p11_path_build`.
It incorporates the following improvements on top of that:
* components following empty strings get their leading path separators stripped
* multiple leading path separators of the first component are now stripped as well
* `(".../", "", "/...")` situation also won't result in duplicate separators

Note that:
* `is_path_component` has been extracted from `is_path_component_or_null`, hope it's OK
* I haven't actually executed the windows tests