### PR TITLE
anchor: Prefer persistent format when storing anchor

### DIFF
--- a/trust/anchor.c
+++ b/trust/anchor.c
@@ -64,9 +64,10 @@ create_arg_file_parser (void)
 	return_val_if_fail (parser != NULL, NULL);
 
 	p11_parser_formats (parser,
-	                    p11_parser_format_x509,
-	                    p11_parser_format_pem,
-	                    NULL);
+			    p11_parser_format_persist,
+			    p11_parser_format_x509,
+			    p11_parser_format_pem,
+			    NULL);
 
 	return parser;
 }

--- a/trust/test-extract.sh
+++ b/trust/test-extract.sh
@@ -8,7 +8,7 @@ teardown()
 		if [ -d $x ]; then
 			rmdir $x
 		elif [ -f $x ]; then
-			rm $x
+			rm -f $x
 		fi
 	done
 	TD=""
@@ -51,6 +51,7 @@ setup()
 	CERT_1_CN=test_$(dd if=/dev/urandom count=40 bs=1 status=none | base64 | tr -d '+/=')
 	CERT_2_CN=test_$(dd if=/dev/urandom count=40 bs=1 status=none | base64 | tr -d '+/=')
 	CERT_3_CN=test_$(dd if=/dev/urandom count=40 bs=1 status=none | base64 | tr -d '+/=')
+	CERT_4_CN=test_$(dd if=/dev/urandom count=40 bs=1 status=none | base64 | tr -d '+/=')
 
 	# Generate relevant certificates
 	openssl_quiet req -x509 -newkey rsa:512 -keyout /dev/null -days 3 -nodes \
@@ -59,8 +60,10 @@ setup()
 		-out cert_2.pem -subj /CN=$CERT_2_CN
 	openssl_quiet req -x509 -newkey rsa:512 -keyout /dev/null -days 3 -nodes \
 		-out cert_3.pem -subj /CN=$CERT_3_CN
+	openssl_quiet req -x509 -newkey rsa:512 -keyout /dev/null -days 3 -nodes \
+		-out cert_4.pem -subj /CN=$CERT_4_CN
 
-	TD="cert_1.pem cert_2.pem cert_3.pem $TD"
+	TD="cert_1.pem cert_2.pem cert_3.pem cert_4.pem $TD"
 
 	mkdir -p $SOURCE_1/anchors
 	cp cert_1.pem $SOURCE_1/anchors/
@@ -70,6 +73,15 @@ setup()
 	cp cert_3.pem $SOURCE_2/anchors/
 
 	TD="$SOURCE_1/anchors/cert_1.pem $SOURCE_2/anchors/cert_2.pem $SOURCE_2/anchors/cert_3.pem $TD"
+
+	cat > cert_4.p11-kit <<EOF
+[p11-kit-object-v1]
+nss-server-distrust-after: "191228000000Z"
+nss-email-distrust-after: "%00"
+EOF
+	cat cert_4.pem >> cert_4.p11-kit
+	trust anchor --store cert_4.p11-kit
+	TD="cert_4.p11-kit $SOURCE_1/$CERT_4_CN.p11-kit $TD"
 }
 
 test_extract()
@@ -81,6 +93,7 @@ test_extract()
 	assert_contains extract-test.pem $CERT_1_CN
 	assert_contains extract-test.pem $CERT_2_CN
 	assert_contains extract-test.pem $CERT_3_CN
+	assert_contains extract-test.pem $CERT_4_CN
 }
 
 test_blocklist()
@@ -97,4 +110,12 @@ test_blocklist()
 	assert_not_contains blocklist-test.pem $CERT_3_CN
 }
 
-run test_extract test_blocklist
+test_persist()
+{
+	if ! (trust dump --filter "pkcs11:object=$CERT_4_CN" | \
+		  grep '^nss-server-distrust-after: "191228000000Z"$') 2>&1 >/dev/null; then
+		assert_fail "nss-server-distrust-after is not preserved"
+	fi
+}
+
+run test_extract test_blocklist test_persist


### PR DESCRIPTION
When a new certificate is stored with "trust anchor --store" from a .p11-kit file, the command treated it as a PEM file, while it should
preserve extra fields in the file.