### PR TITLE
meson: expand ternary operator in function call for compatibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,11 @@ conf.set('PACKAGE_MAJOR', major_version)
 conf.set('PACKAGE_MINOR', minor_version)
 
 host_system = host_machine.system()
-conf.set(host_system == 'windows' ? 'OS_WIN32' : 'OS_UNIX', 1)
+if host_system == 'windows'
+  conf.set('OS_WIN32', 1)
+else
+  conf.set('OS_UNIX', 1)
+endif
 
 if host_system == 'windows'
   shlext = '.dll'


### PR DESCRIPTION
While the minimum version requirement of meson is [0.49](https://github.com/p11-glue/p11-kit/blob/master/meson.build#L3), the current meson.build causes the parser to crash, because of the use of the ternary operator inside a function call:
https://github.com/mesonbuild/meson/issues/5003