### PR TITLE
travis: Add freebsd build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
       services: docker
       env: PROFILE=cppcheck SRCDIR=/srcdir BUILDDIR=/builddir EXTRA_PKGS="cppcheck"
     - os: osx
+    - os: freebsd
 
 language: c
 

--- a/.travis/freebsd/after_failure.sh
+++ b/.travis/freebsd/after_failure.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat meson-logs/testlog.txt

--- a/.travis/freebsd/before_install.sh
+++ b/.travis/freebsd/before_install.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+sudo pkg install -y gettext gtk-doc libffi libtasn1 meson

--- a/.travis/freebsd/script.sh
+++ b/.travis/freebsd/script.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+meson _build -Dsystemd=disabled -Dbash_completion=disabled
+meson test -C _build

--- a/common/compat.c
+++ b/common/compat.c
@@ -845,7 +845,7 @@ getauxval (unsigned long type)
 		secure = __libc_enable_secure;
 
 #elif defined(HAVE_ISSETUGID) && \
-	!((defined __APPLE__ && defined __MACH__) || (defined __FREEBSD__))
+	!((defined __APPLE__ && defined __MACH__) || (defined __FreeBSD__))
 		secure = issetugid ();
 
 #elif defined(OS_UNIX)

--- a/common/compat.c
+++ b/common/compat.c
@@ -938,9 +938,6 @@ int
 fdwalk (int (* cb) (void *data, int fd),
         void *data)
 {
-	struct dirent *de;
-	char *end;
-	DIR *dir;
 	int open_max;
 	long num;
 	int res = 0;
@@ -951,6 +948,10 @@ fdwalk (int (* cb) (void *data, int fd),
 #endif
 
 #ifdef __linux__
+	struct dirent *de;
+	char *end;
+	DIR *dir;
+
 	dir = opendir ("/proc/self/fd");
 	if (dir != NULL) {
 		while ((de = readdir (dir)) != NULL) {

--- a/trust/meson.build
+++ b/trust/meson.build
@@ -149,7 +149,7 @@ if get_option('test')
                    dependencies: [asn_h_dep,
                                   libp11_kit_dep,
                                   libp11_library_dep,
-                                  libp11_test_dep] + dlopen_deps,
+                                  libp11_test_dep] + libtasn1_deps + dlopen_deps,
                    link_with: [libtrust_testable, libtrust_data, libtrust_test])
     test(name, t)
   endforeach


### PR DESCRIPTION
This adds a new CI job that makes use of the FreeBSD support in Travis CI.