### PR TITLE
p11-kit/lists.c: Add stdint.h to fix compilation

### DIFF
--- a/p11-kit/lists.c
+++ b/p11-kit/lists.c
@@ -39,6 +39,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Add stdint.h otherwise compilation fails on FreeBSD 13-CURRENT with "use of undeclared identifier 'SIZE_MAX'"

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>