### PR TITLE
Supress warnings in FreeBSD build

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -939,7 +939,6 @@ fdwalk (int (* cb) (void *data, int fd),
         void *data)
 {
 	int open_max;
-	long num;
 	int res = 0;
 	int fd;
 
@@ -948,13 +947,16 @@ fdwalk (int (* cb) (void *data, int fd),
 #endif
 
 #ifdef __linux__
-	struct dirent *de;
-	char *end;
 	DIR *dir;
 
 	dir = opendir ("/proc/self/fd");
 	if (dir != NULL) {
+		struct dirent *de;
+
 		while ((de = readdir (dir)) != NULL) {
+			char *end;
+			long num;
+
 			end = NULL;
 			num = (int) strtol (de->d_name, &end, 10);
 

--- a/common/compat.c
+++ b/common/compat.c
@@ -40,6 +40,15 @@
  */
 #define _XOPEN_SOURCE 700
 
+/*
+ * This is needed to expose issetugid, getresuid, and getresgid, which are
+ * hidden with the _XOPEN_SOURCE setting above
+ */
+#ifdef __FreeBSD__
+#undef __BSD_VISIBLE
+#define __BSD_VISIBLE 1
+#endif
+
 #include "compat.h"
 #include "debug.h"
 

--- a/common/compat.c
+++ b/common/compat.c
@@ -49,6 +49,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 /*-
  * Portions of this file are covered by the following copyright:
@@ -89,8 +92,6 @@
 #ifndef HAVE_GETPROGNAME
 
 #ifdef OS_UNIX
-
-#include <unistd.h>
 
 #if defined (HAVE_PROGRAM_INVOCATION_SHORT_NAME) && !HAVE_DECL_PROGRAM_INVOCATION_SHORT_NAME
 extern char *program_invocation_short_name;

--- a/common/compat.h
+++ b/common/compat.h
@@ -185,7 +185,6 @@ void        p11_mmap_close  (p11_mmap *map);
 #include <pthread.h>
 #include <dlfcn.h>
 #include <time.h>
-#include <unistd.h>
 
 typedef pthread_mutex_t p11_mutex_t;
 

--- a/common/test-compat.c
+++ b/common/test-compat.c
@@ -40,6 +40,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 #include "compat.h"
 

--- a/common/vsock.c
+++ b/common/vsock.c
@@ -43,6 +43,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 #ifdef HAVE_VSOCK
 #include <sys/socket.h>

--- a/p11-kit/conf.c
+++ b/p11-kit/conf.c
@@ -48,6 +48,9 @@
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 #include <assert.h>
 #include <ctype.h>

--- a/p11-kit/test-managed.c
+++ b/p11-kit/test-managed.c
@@ -46,6 +46,7 @@
 #include <sys/types.h>
 #ifdef OS_UNIX
 #include <sys/wait.h>
+#include <unistd.h>
 #endif
 #include <errno.h>
 #include <stdlib.h>

--- a/p11-kit/test-rpc.c
+++ b/p11-kit/test-rpc.c
@@ -55,6 +55,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 #define ELEMS(x) (sizeof (x) / sizeof (x[0]))
 

--- a/p11-kit/test-transport.c
+++ b/p11-kit/test-transport.c
@@ -51,6 +51,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #endif
 #include <stdlib.h>
 #include <stdio.h>

--- a/trust/test-token.c
+++ b/trust/test-token.c
@@ -43,6 +43,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 #include "attrs.h"
 #include "debug.h"

--- a/trust/token.c
+++ b/trust/token.c
@@ -54,6 +54,9 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef OS_UNIX
+#include <unistd.h>
+#endif
 
 #include <assert.h>
 #include <dirent.h>


### PR DESCRIPTION
This should fix the following warnings we are currently seeing:
```console
[5/280] Compiling C object common/libp11-common.a.p/compat.c.o
../common/compat.c:856:7: warning: implicit declaration of function 'getresuid' is invalid in C99 [-Wimplicit-function-declaration]
                if (getresuid (&ruid, &euid, &suid) != 0 ||
                    ^
../common/compat.c:857:7: warning: implicit declaration of function 'getresgid' is invalid in C99 [-Wimplicit-function-declaration]
                    getresgid (&rgid, &egid, &sgid) != 0)
                    ^
../common/compat.c:942:7: warning: unused variable 'num' [-Wunused-variable]
        long num;
             ^
3 warnings generated.
```