### PR TITLE
autotools: Fix for VPATH build

### DIFF
--- a/trust/Makefile.am
+++ b/trust/Makefile.am
@@ -18,6 +18,7 @@ libtrust_data_la_SOURCES = \
 	$(NULL)
 
 libtrust_data_la_CFLAGS = \
+	-I$(builddir)/trust \
 	$(LIBTASN1_CFLAGS)
 
 libtrust_data_la_LIBADD = \
@@ -46,6 +47,7 @@ module_LTLIBRARIES += \
 p11_kit_trust_la_CFLAGS = \
 	-DP11_DEFAULT_TRUST_PREFIX=DATA_DIR \
 	-DP11_SYSTEM_TRUST_PREFIX=SYSCONFDIR \
+	-I$(builddir)/trust \
 	$(LIBTASN1_CFLAGS)
 
 p11_kit_trust_la_LIBADD = \
@@ -72,6 +74,7 @@ libtrust_testable_la_SOURCES = $(TRUST_SRCS)
 libtrust_testable_la_CFLAGS = \
 	-DP11_DEFAULT_TRUST_PREFIX=\"$(builddir)/trust/default\" \
 	-DP11_SYSTEM_TRUST_PREFIX=\"$(builddir)/trust/system\" \
+	-I$(builddir)/trust \
 	$(LIBTASN1_CFLAGS)
 
 libtrust_testable_la_LIBADD = \
@@ -91,6 +94,7 @@ trust_trust_LDADD = \
 
 trust_trust_CFLAGS = \
 	-DP11_KIT_FUTURE_UNSTABLE_API \
+	-I$(builddir)/trust \
 	$(LIBTASN1_CFLAGS) \
 	$(NULL)
 


### PR DESCRIPTION
Since adbb94ea3ec3c39b71c05eff8ef86cc85a075955, we always generate *.asn.h file at build time.  This caused a build problem if
p11-kit is built with an out-of-tree build directory.

Reported by Pavel Heimlich in:
https://github.com/p11-glue/p11-kit/issues/348