### PR TITLE
p11-kit: Add missing <limits.h> include for SIZE_MAX

### DIFF
--- a/p11-kit/lists.c
+++ b/p11-kit/lists.c
@@ -39,6 +39,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
Spotted by Jeffrey Walton in:
https://github.com/p11-glue/p11-kit/issues/361