### PR TITLE
rpc-server: Disable parsing CKF_ARRAY_ATTRIBUTE

### DIFF
--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -241,6 +241,11 @@ proto_read_attribute_array (p11_rpc_message *msg,
 			return PARSE_ERROR;
 		}
 
+		if (temp.type & CKF_ARRAY_ATTRIBUTE) {
+			p11_debug("recursive attribute array is not supported");
+			return PARSE_ERROR;
+		}
+
 		/* Try and stuff it in the output data */
 		if (arr) {
 			CK_ATTRIBUTE *attr = &(arr[i]);

--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -323,6 +323,11 @@ proto_read_attribute_array (p11_rpc_message *msg,
 			return PARSE_ERROR;
 		}
 
+		if (temp.type & CKF_ARRAY_ATTRIBUTE) {
+			p11_debug("recursive attribute array is not supported");
+			return PARSE_ERROR;
+		}
+
 		attrs[i].type = temp.type;
 
 		/* Whether this one is valid or not */


### PR DESCRIPTION
This is a temporary measure to avoid oss-fuzz failure.  When the attribute array is nested, the current internal API cannot determine the actual size of data that need to be stored, because `ulValueLen` is set to the attribute count times `sizeof(CK_ATTRIBUTE)`.