### PR TITLE
Support recursive attributes indicated with CKF_ARRAY_ATTRIBUTE

### DIFF
--- a/common/attrs.c
+++ b/common/attrs.c
@@ -82,8 +82,9 @@ p11_attrs_free (void *attrs)
 	if (!attrs)
 		return;
 
-	for (i = 0; !p11_attrs_terminator (ats + i); i++)
-		free (ats[i].pValue);
+	for (i = 0; !p11_attrs_terminator (ats + i); i++) {
+		p11_attr_clear (&ats[i]);
+	}
 	free (ats);
 }
 
@@ -143,18 +144,17 @@ attrs_build (CK_ATTRIBUTE *attrs,
 				free (add->pValue);
 			continue;
 
-		/* The attribute exitss, and we're overriding */
+		/* The attribute exists but we're overriding */
 		} else {
 			free (attr->pValue);
 		}
 
-		memcpy (attr, add, sizeof (CK_ATTRIBUTE));
-		if (!take_values && attr->pValue != NULL) {
-			if (attr->ulValueLen == 0)
-				attr->pValue = malloc (1);
-			else
-				attr->pValue = memdup (attr->pValue, attr->ulValueLen);
-			return_val_if_fail (attr->pValue != NULL, NULL);
+		if (take_values) {
+			memcpy (attr, add, sizeof (CK_ATTRIBUTE));
+		} else {
+			if (!p11_attr_copy (attr, add)) {
+				return_val_if_reached (NULL);
+			}
 		}
 	}
 
@@ -416,8 +416,9 @@ p11_attrs_remove (CK_ATTRIBUTE *attrs,
 	if (i == count)
 		return false;
 
-	if (attrs[i].pValue)
-		free (attrs[i].pValue);
+	if (attrs[i].pValue) {
+		p11_attr_clear (&attrs[i]);
+	}
 
 	memmove (attrs + i, attrs + i + 1, (count - (i + 1)) * sizeof (CK_ATTRIBUTE));
 	attrs[count - 1].type = CKA_INVALID;
@@ -524,6 +525,61 @@ p11_attr_hash (const void *data)
 	}
 
 	return hash;
+}
+
+bool
+p11_attr_copy (CK_ATTRIBUTE *dst, const CK_ATTRIBUTE *src)
+{
+	memcpy (dst, src, sizeof (CK_ATTRIBUTE));
+
+	if (!src->pValue) {
+		return true;
+	}
+
+	if (src->ulValueLen == 0) {
+		dst->pValue = malloc (1);
+	} else {
+		dst->pValue = malloc (src->ulValueLen);
+	}
+	if (!dst->pValue) {
+		return_val_if_reached (false);
+	}
+
+	assert (dst->ulValueLen >= src->ulValueLen);
+
+	if (!IS_ARRAY_ATTRIBUTE (src)) {
+		memcpy (dst->pValue, src->pValue, src->ulValueLen);
+	} else {
+		CK_ATTRIBUTE *child_dst;
+		const CK_ATTRIBUTE *child_src;
+		size_t i;
+
+		for (i = 0, child_dst = dst->pValue, child_src = src->pValue;
+		     i < src->ulValueLen / sizeof (CK_ATTRIBUTE);
+		     i++, child_dst++, child_src++) {
+			if (!p11_attr_copy (child_dst, child_src)) {
+				return_val_if_reached (false);
+			}
+		}
+	}
+
+	return true;
+}
+
+void
+p11_attr_clear (CK_ATTRIBUTE *attr)
+{
+	if (IS_ARRAY_ATTRIBUTE (attr) && attr->pValue) {
+		CK_ATTRIBUTE *child;
+		size_t i;
+
+		for (i = 0, child = attr->pValue;
+		     i < attr->ulValueLen / sizeof (CK_ATTRIBUTE);
+		     i++, child++) {
+			p11_attr_clear (child);
+		}
+	}
+	free (attr->pValue);
 }
 
 static void

--- a/common/attrs.h
+++ b/common/attrs.h
@@ -42,6 +42,12 @@
 
 #define CKA_INVALID ((CK_ULONG)-1)
 
+/* CKA_VENDOR_DEFINED needs to be checked as well, because our vendor
+ * prefix 0x58444700 indicates CKF_ARRAY_ATTRIBUTE. */
+#define IS_ARRAY_ATTRIBUTE(attr) \
+	(((attr)->type & CKF_ARRAY_ATTRIBUTE) && \
+	 !((attr)->type & CKA_VENDOR_DEFINED))
+
 CK_ATTRIBUTE *      p11_attrs_dup           (const CK_ATTRIBUTE *attrs);
 
 CK_ATTRIBUTE *      p11_attrs_build         (CK_ATTRIBUTE *attrs,
@@ -132,5 +138,8 @@ unsigned int        p11_attr_hash           (const void *data);
 bool                p11_attr_match_value    (const CK_ATTRIBUTE *attr,
                                              const void *value,
                                              ssize_t length);
+bool                p11_attr_copy           (CK_ATTRIBUTE *dst,
+					     const CK_ATTRIBUTE *src);
+void                p11_attr_clear          (CK_ATTRIBUTE *attr);
 
 #endif /* P11_ATTRS_H_ */

--- a/common/test-attrs.c
+++ b/common/test-attrs.c
@@ -41,6 +41,7 @@
 
 #include "attrs.h"
 #include "debug.h"
+#include "pkcs11x.h"
 
 static void
 test_terminator (void)
@@ -240,6 +241,48 @@ test_build_null (void)
 	assert (attrs->ulValueLen == (CK_ULONG)-1);
 	assert_ptr_eq (NULL, attrs->pValue);
 
+	p11_attrs_free (attrs);
+}
+
+static void
+test_build_recursive (void)
+{
+	CK_BBOOL vtrue = CK_TRUE;
+	CK_BYTE vpoint[1];
+	CK_ATTRIBUTE template[] = {
+		{ CKA_LOCAL, &vtrue, sizeof (vtrue) },
+		{ CKA_EC_POINT, vpoint, 0 },
+		{ CKA_X_DISTRUSTED, &vtrue, sizeof (vtrue) }
+	};
+	CK_ATTRIBUTE add = { CKA_WRAP_TEMPLATE, template, sizeof (template) };
+	CK_ATTRIBUTE *attrs;
+	CK_ATTRIBUTE *array;
+
+	attrs = p11_attrs_build (NULL, &add, NULL);
+
+	/* Test the first attribute */
+	assert_ptr_not_null (attrs);
+	assert_num_eq (attrs->type, CKA_WRAP_TEMPLATE);
+	assert_num_eq (attrs->ulValueLen, sizeof (template));
+	array = attrs->pValue;
+	/* Check that the CKA_LOCAL attribute has been copied, but
+	 * still has the same value */
+	assert_num_eq (array[0].type, CKA_LOCAL);
+	assert_num_eq (array[0].ulValueLen, sizeof (vtrue));
+	assert_ptr_cmp (array[0].pValue, !=, &vtrue);
+	assert_num_eq (*(CK_BBOOL *)array[0].pValue, vtrue);
+	/* Check that the CKA_EC_POINT attribute has been allocated,
+	 * even if the length is zero */
+	assert_num_eq (array[1].type, CKA_EC_POINT);
+	assert_num_eq (array[1].ulValueLen, 0);
+	assert_ptr_not_null (array[1].pValue);
+	assert_ptr_cmp (array[1].pValue, !=, vpoint);
+	/* Check that the CKA_X_DISTRUSTED attribute is not treated as
+	 * an array of attribute */
+	assert_num_eq (array[2].type, CKA_X_DISTRUSTED);
+	assert_num_eq (array[2].ulValueLen, sizeof (vtrue));
+	assert_ptr_cmp (array[2].pValue, !=, &vtrue);
+	assert_num_eq (*(CK_BBOOL *)array[2].pValue, vtrue);
 	p11_attrs_free (attrs);
 }
 
@@ -766,6 +809,7 @@ main (int argc,
 	p11_test (test_buildn_two, "/attrs/buildn-two");
 	p11_test (test_build_add, "/attrs/build-add");
 	p11_test (test_build_null, "/attrs/build-null");
+	p11_test (test_build_recursive, "/attrs/build-recursive");
 	p11_test (test_dup, "/attrs/dup");
 	p11_test (test_take, "/attrs/take");
 	p11_test (test_merge_replace, "/attrs/merge-replace");

--- a/common/test.h
+++ b/common/test.h
@@ -97,13 +97,15 @@
 	} while (0)
 #define assert_str_eq(a1, a2) \
 	assert_str_cmp(a1, ==, a2)
-#define assert_ptr_eq(a1, a2) \
+#define assert_ptr_cmp(a1, cmp, a2)    \
 	do { const void *__p1 = (a1); \
 	     const void *__p2 = (a2); \
-	     if (__p1 == __p2) ; else \
+	     if (__p1 cmp __p2) ; else \
 	         p11_test_fail (__FILE__, __LINE__, __FUNCTION__, "assertion failed (%s == %s): (0x%08lx == 0x%08lx)", \
 	                        #a1, #a2, (unsigned long)(size_t)__p1, (unsigned long)(size_t)__p2); \
 	} while (0)
+#define assert_ptr_eq(a1, a2) \
+	assert_ptr_cmp(a1, ==, a2)
 
 #define assert_str_contains(expr, needle) \
 	do { const char *__str = (expr); \


### PR DESCRIPTION
This adds support for getting and setting attributes with array type, e.g., `CKA_WRAP_TEMPLATE`.