### PR TITLE
rpc: Tighten attribute array check with manual enumeration

### DIFF
--- a/common/attrs.h
+++ b/common/attrs.h
@@ -42,6 +42,16 @@
 
 #define CKA_INVALID ((CK_ULONG)-1)
 
+/* CKF_ARRAY_ATTRIBUTE is not sufficient to tell if the attribute is
+ * an array of attributes, because the flag is also set for
+ * CKA_ALLOWED_MECHANISMS, which is an array of CK_MECHANISM_TYPE
+ * (unsigned long).  Moreover, our vendor prefix 0x58444700UL masks
+ * the bit. */
+#define IS_ATTRIBUTE_ARRAY(attr) \
+	((attr)->type == CKA_WRAP_TEMPLATE ||	\
+	 (attr)->type == CKA_UNWRAP_TEMPLATE ||	\
+	 (attr)->type == CKA_DERIVE_TEMPLATE)
+
 CK_ATTRIBUTE *      p11_attrs_dup           (const CK_ATTRIBUTE *attrs);
 
 CK_ATTRIBUTE *      p11_attrs_build         (CK_ATTRIBUTE *attrs,

--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -35,6 +35,7 @@
 
 #include "config.h"
 
+#include "attrs.h"
 #define P11_DEBUG_FLAG P11_DEBUG_RPC
 #include "debug.h"
 #include "pkcs11.h"
@@ -241,7 +242,7 @@ proto_read_attribute_array (p11_rpc_message *msg,
 			return PARSE_ERROR;
 		}
 
-		if (temp.type & CKF_ARRAY_ATTRIBUTE) {
+		if (IS_ATTRIBUTE_ARRAY (&temp)) {
 			p11_debug("recursive attribute array is not supported");
 			return PARSE_ERROR;
 		}

--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -35,6 +35,7 @@
 
 #include "config.h"
 
+#include "attrs.h"
 #include "conf.h"
 #define P11_DEBUG_FLAG P11_DEBUG_RPC
 #include "debug.h"
@@ -323,7 +324,7 @@ proto_read_attribute_array (p11_rpc_message *msg,
 			return PARSE_ERROR;
 		}
 
-		if (temp.type & CKF_ARRAY_ATTRIBUTE) {
+		if (IS_ATTRIBUTE_ARRAY (&temp)) {
 			p11_debug("recursive attribute array is not supported");
 			return PARSE_ERROR;
 		}


### PR DESCRIPTION
CKF_ARRAY_ATTRIBUTE is not sufficient to tell if the attribute is
an array of attributes, because the flag is also set for
CKA_ALLOWED_MECHANISMS, which is an array of CK_MECHANISM_TYPE
(unsigned long).  Moreover, our vendor prefix 0x58444700UL masks
the bit.

Signed-off-by: Daiki Ueno <ueno@gnu.org>