### PR TITLE
proxy: Support copying array of attributes

### DIFF
--- a/common/attrs.h
+++ b/common/attrs.h
@@ -142,5 +142,8 @@ unsigned int        p11_attr_hash           (const void *data);
 bool                p11_attr_match_value    (const CK_ATTRIBUTE *attr,
                                              const void *value,
                                              ssize_t length);
+bool                p11_attr_copy           (CK_ATTRIBUTE *dst,
+					     const CK_ATTRIBUTE *src);
+void                p11_attr_clear          (CK_ATTRIBUTE *attr);
 
 #endif /* P11_ATTRS_H_ */

--- a/common/test.h
+++ b/common/test.h
@@ -97,13 +97,15 @@
 	} while (0)
 #define assert_str_eq(a1, a2) \
 	assert_str_cmp(a1, ==, a2)
-#define assert_ptr_eq(a1, a2) \
+#define assert_ptr_cmp(a1, cmp, a2)    \
 	do { const void *__p1 = (a1); \
 	     const void *__p2 = (a2); \
-	     if (__p1 == __p2) ; else \
+	     if (__p1 cmp __p2) ; else \
 	         p11_test_fail (__FILE__, __LINE__, __FUNCTION__, "assertion failed (%s == %s): (0x%08lx == 0x%08lx)", \
 	                        #a1, #a2, (unsigned long)(size_t)__p1, (unsigned long)(size_t)__p2); \
 	} while (0)
+#define assert_ptr_eq(a1, a2) \
+	assert_ptr_cmp(a1, ==, a2)
 
 #define assert_str_contains(expr, needle) \
 	do { const char *__str = (expr); \


### PR DESCRIPTION
Previously C_SetAttributeValue implementation in the proxy didn't copy array of attributes recursively and caused the subsequent C_GetAttributeValue receive the same memory address for the leaf attributes. This changes the behavior so the copying is always deep copy.