### PR TITLE
rpc: Support protocol version negotiation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,11 @@ P11KIT_REVISION=0
 P11KIT_AGE=3
 
 # ------------------------------------------------------------------------------
+# p11-kit RPC protocol versions
+P11KIT_RPC_MIN=0
+P11KIT_RPC_MAX=0
+
+# ------------------------------------------------------------------------------
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([build/m4])
@@ -377,6 +382,35 @@ AC_DEFINE_UNQUOTED(TRUST_PATHS, ["$with_trust_paths"], [The trust module input p
 AC_SUBST(with_trust_paths)
 
 # --------------------------------------------------------------------
+# RPC
+
+AC_ARG_WITH([rpc-min],
+            [AS_HELP_STRING([--with-rpc-min], [Minimum RPC protocol version we support])],
+            [rpc_min=$withval],
+            [rpc_min=$P11KIT_RPC_MIN])
+
+AC_ARG_WITH([rpc-max],
+            [AS_HELP_STRING([--with-rpc-max], [Maximum RPC protocol version we support])],
+            [rpc_max=$withval],
+            [rpc_max=$P11KIT_RPC_MAX])
+
+AS_IF([test $rpc_min -lt $P11KIT_RPC_MIN || test $rpc_min -gt $P11KIT_RPC_MAX], [
+	AC_MSG_ERROR([Out of range version specified with --with-rpc-min])
+])
+
+AS_IF([test $rpc_max -lt $P11KIT_RPC_MIN || test $rpc_max -gt $P11KIT_RPC_MAX], [
+	AC_MSG_ERROR([Out of range version specified with --with-rpc-max])
+])
+
+AS_IF([test $rpc_min -gt $rpc_max], [
+	AC_MSG_ERROR([Conflicting versions specified with --with-rpc-min and --with-rpc-max])
+])
+
+AC_DEFINE_UNQUOTED(P11_RPC_PROTOCOL_VERSION_MINIMUM, $rpc_min, [Minimum RPC protocol version we support])
+
+AC_DEFINE_UNQUOTED(P11_RPC_PROTOCOL_VERSION_MAXIMUM, $rpc_max, [Maximum RPC protocol version we support])
+
+# --------------------------------------------------------------------
 # GTK Doc
 
 dnl check for tools
@@ -641,5 +675,7 @@ AC_MSG_NOTICE([build options:
 
     Build trust module:              $enable_trust_module
     Trust module paths:              $trust_status
+
+    RPC protocol versions:           $rpc_min upto $rpc_max
 
 ])

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,16 @@ tests_c_args = [
 
 conf.set('SIZEOF_UNSIGNED_LONG', cc.sizeof('unsigned long'))
 
+rpc_min = get_option('rpc_min')
+rpc_max = get_option('rpc_max')
+
+if rpc_min > rpc_max
+  error('rpc_min is larger than rpc_max')
+endif
+
+conf.set('P11_RPC_PROTOCOL_VERSION_MINIMUM', rpc_min)
+conf.set('P11_RPC_PROTOCOL_VERSION_MAXIMUM', rpc_max)
+
 nanosleep_deps = []
 dlopen_deps = []
 socket_deps = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -65,3 +65,11 @@ option('nls', type : 'boolean',
 option('test', type : 'boolean',
        value : true,
        description : 'Enable building test programs')
+
+option('rpc_min', type : 'integer',
+       min : 0, max : 0, value : 0,
+       description : 'Minimum RPC protocol version we support')
+
+option('rpc_max', type : 'integer',
+       min : 0, max : 0, value : 0,
+       description : 'Maximum RPC protocol version we support')

--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -755,6 +755,10 @@ rpc_C_Initialize (CK_X_FUNCTION_LIST *self,
 	assert (module->vtable->connect != NULL);
 	ret = (module->vtable->connect) (module->vtable, reserved);
 
+	if (ret == CKR_OK) {
+		ret = (module->vtable->authenticate) (module->vtable);
+	}
+
 	/* Successfully initialized */
 	if (ret == CKR_OK) {
 		module->initialized_forkid = p11_forkid;

--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -66,6 +66,7 @@ typedef struct {
 	p11_rpc_client_vtable *vtable;
 	unsigned int initialized_forkid;
 	bool initialize_done;
+	uint8_t version;
 } rpc_client;
 
 /* Allocator for call session buffers */
@@ -756,13 +757,16 @@ rpc_C_Initialize (CK_X_FUNCTION_LIST *self,
 	ret = (module->vtable->connect) (module->vtable, reserved);
 
 	if (ret == CKR_OK) {
-		ret = (module->vtable->authenticate) (module->vtable);
+		ret = (module->vtable->authenticate) (module->vtable,
+						      &module->version);
 	}
 
 	/* Successfully initialized */
 	if (ret == CKR_OK) {
 		module->initialized_forkid = p11_forkid;
 		module->initialize_done = true;
+		p11_debug ("authenticated with protocol version %u",
+			   module->version);
 
 	/* Server doesn't exist, initialize but don't call */
 	} else if (ret == CKR_DEVICE_REMOVED) {

--- a/p11-kit/rpc.h
+++ b/p11-kit/rpc.h
@@ -48,6 +48,8 @@ struct _p11_rpc_client_vtable {
 	CK_RV       (* connect)       (p11_rpc_client_vtable *vtable,
 	                               void *init_reserved);
 
+	CK_RV       (* authenticate)  (p11_rpc_client_vtable *vtable);
+
 	CK_RV       (* transport)     (p11_rpc_client_vtable *vtable,
 	                               p11_buffer *request,
 	                               p11_buffer *response);

--- a/p11-kit/rpc.h
+++ b/p11-kit/rpc.h
@@ -39,6 +39,7 @@
 #include "pkcs11.h"
 #include "buffer.h"
 #include "virtual.h"
+#include <stdint.h>
 
 typedef struct _p11_rpc_client_vtable p11_rpc_client_vtable;
 
@@ -48,7 +49,8 @@ struct _p11_rpc_client_vtable {
 	CK_RV       (* connect)       (p11_rpc_client_vtable *vtable,
 	                               void *init_reserved);
 
-	CK_RV       (* authenticate)  (p11_rpc_client_vtable *vtable);
+	CK_RV       (* authenticate)  (p11_rpc_client_vtable *vtable,
+				       uint8_t *version);
 
 	CK_RV       (* transport)     (p11_rpc_client_vtable *vtable,
 	                               p11_buffer *request,

--- a/p11-kit/test-rpc.c
+++ b/p11-kit/test-rpc.c
@@ -709,9 +709,11 @@ rpc_initialize (p11_rpc_client_vtable *vtable,
 }
 
 static CK_RV
-rpc_authenticate (p11_rpc_client_vtable *vtable)
+rpc_authenticate (p11_rpc_client_vtable *vtable,
+		  uint8_t *version)
 {
 	assert_str_eq (vtable->data, "vtable-data");
+	assert_ptr_not_null (version);
 
 	return CKR_OK;
 }

--- a/p11-kit/test-rpc.c
+++ b/p11-kit/test-rpc.c
@@ -709,6 +709,14 @@ rpc_initialize (p11_rpc_client_vtable *vtable,
 }
 
 static CK_RV
+rpc_authenticate (p11_rpc_client_vtable *vtable)
+{
+	assert_str_eq (vtable->data, "vtable-data");
+
+	return CKR_OK;
+}
+
+static CK_RV
 rpc_initialize_fails (p11_rpc_client_vtable *vtable,
                       void *init_reserved)
 {
@@ -754,7 +762,7 @@ rpc_finalize (p11_rpc_client_vtable *vtable,
 static void
 test_initialize (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -780,7 +788,7 @@ test_initialize (void)
 static void
 test_not_initialized (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport, rpc_finalize };
 	p11_virtual mixin;
 	CK_INFO info;
 	bool ret;
@@ -802,7 +810,7 @@ test_not_initialized (void)
 static void
 test_initialize_fails_on_client (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize_fails, rpc_transport, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize_fails, rpc_authenticate, rpc_transport, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -832,7 +840,7 @@ rpc_transport_fails (p11_rpc_client_vtable *vtable,
 static void
 test_transport_fails (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport_fails, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport_fails, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -854,7 +862,7 @@ test_transport_fails (void)
 static void
 test_initialize_fails_on_server (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -894,7 +902,7 @@ rpc_transport_bad_parse (p11_rpc_client_vtable *vtable,
 static void
 test_transport_bad_parse (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport_bad_parse, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport_bad_parse, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -942,7 +950,7 @@ rpc_transport_short_error (p11_rpc_client_vtable *vtable,
 static void
 test_transport_short_error (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport_short_error, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport_short_error, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -989,7 +997,7 @@ rpc_transport_invalid_error (p11_rpc_client_vtable *vtable,
 static void
 test_transport_invalid_error (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport_invalid_error, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport_invalid_error, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -1034,7 +1042,7 @@ rpc_transport_wrong_response (p11_rpc_client_vtable *vtable,
 static void
 test_transport_wrong_response (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport_wrong_response, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport_wrong_response, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -1081,7 +1089,7 @@ rpc_transport_bad_contents (p11_rpc_client_vtable *vtable,
 static void
 test_transport_bad_contents (void)
 {
-	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_transport_bad_contents, rpc_finalize };
+	p11_rpc_client_vtable vtable = { "vtable-data", rpc_initialize, rpc_authenticate, rpc_transport_bad_contents, rpc_finalize };
 	p11_virtual mixin;
 	bool ret;
 	CK_RV rv;
@@ -1105,6 +1113,7 @@ test_transport_bad_contents (void)
 static p11_rpc_client_vtable test_normal_vtable = {
 	NULL,
 	rpc_initialize,
+	rpc_authenticate,
 	rpc_transport,
 	rpc_finalize,
 };
@@ -1112,6 +1121,7 @@ static p11_rpc_client_vtable test_normal_vtable = {
 static p11_rpc_client_vtable test_device_removed_vtable = {
 	NULL,
 	rpc_initialize_device_removed,
+	rpc_authenticate,
 	rpc_transport,
 	rpc_finalize,
 };


### PR DESCRIPTION
This works as follows:
- a couple of build-time constants have been added to represent the
  minimal and maximum supported protocol versions
- the client sends the maximum supported version upon the connection
  establishment (when `C_Initialize` is called for the first time for the client process)
- the server checks the version sent from the client; if it is lower
  than the minimum supported version of the server, sends an error
- otherwise, the server responds with either of smaller value between
  the version sent from the client or the maximum supported version of
  the server

Example:
- the client supports versions from 1 upto 3
- the server supports versions from 0 upto 2
- the client sends 3 to the server upon connection establishment
- the server responds with 2
- version 2 is negotiated

Partially fixes #370