### PR TITLE
meson: optionalise glib's development files for gtk_doc

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -60,7 +60,10 @@ if get_option('gtk_doc')
     'annotation-glossary.xml'
   ]
 
-  glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
+  glib_prefix = get_option('glib_prefix')
+  if glib_prefix == ''
+    glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
+  endif
   fixxref_args = [
     '--html-dir=' + (prefix / gnome.gtkdoc_html_dir(meson.project_name())),
     '--extra-dir=' + (glib_prefix / gnome.gtkdoc_html_dir('glib')),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -54,6 +54,10 @@ option('gtk_doc', type : 'boolean',
        value : false,
        description : 'Build documentation using gtk-doc')
 
+option('glib_prefix', type : 'string',
+       value : '',
+       description : 'GLib installed prefix, used for gtk-doc, taken from pkg-config if undefined')
+
 option('man', type : 'boolean',
        value : false,
        description : 'Build manpages using xsltproc')


### PR DESCRIPTION
In p11-kit, only installation prefix of glib is required to build gtk-doc.

In some distro, those development files are splitted into separated
package.  Pulling those development files in will pull its development
dependencies, too.

Let's give our users an option to build gtk-doc without development
files of glib.