### PR TITLE
Meson: Add libtasn1 to trust programs

### DIFF
--- a/trust/meson.build
+++ b/trust/meson.build
@@ -172,7 +172,7 @@ if get_option('test')
                    dependencies: [asn_h_dep,
                                   libp11_kit_dep,
                                   libp11_library_dep,
-                                  libp11_test_dep] + libffi_deps + dlopen_deps,
+                                  libp11_test_dep] + libtasn1_deps + libffi_deps + dlopen_deps,
                    link_with: [libtrust_testable, libtrust_data, libtrust_test])
   endforeach
 endif


### PR DESCRIPTION
`trust_progs` should depend on libtasn1, otherwise I get:
```
samu: job failed: clang -Itrust/frob-oid.p -Itrust -I../p11-kit-0.24.0/trust -I. -I../p11-kit-0.24.0 -Icommon -I../p11-kit-0.24.0/common -I/opt/65e51442a7726f4c85ead1eec37cf941b5dad691-libffi/include -flto=thin -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -D_GNU_SOURCE -DP11_KIT_FUTURE_UNSTABLE_API -D _FORTIFY_SOURCE=2 -fno-plt -ffunction-sections -fstack-clash-protection -fstack-protector-strong -march=x86-64-v3 -fcf-protection=full -fPIE -pthread '-DSRCDIR="/build/p11-kit-0.24.0"' '-DBUILDDIR="/build/build"' -MD -MQ trust/frob-oid.p/frob-oid.c.o -MF trust/frob-oid.p/frob-oid.c.o.d -o trust/frob-oid.p/frob-oid.c.o -c ../p11-kit-0.24.0/trust/frob-oid.c
../p11-kit-0.24.0/trust/frob-oid.c:38:10: fatal error: 'libtasn1.h' file not found
#include <libtasn1.h>
         ^~~~~~~~~~~~
1 error generated.
samu: job failed: clang -Itrust/frob-ext.p -Itrust -I../p11-kit-0.24.0/trust -I. -I../p11-kit-0.24.0 -Icommon -I../p11-kit-0.24.0/common -I/opt/65e51442a7726f4c85ead1eec37cf941b5dad691-libffi/include -flto=thin -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -D_GNU_SOURCE -DP11_KIT_FUTURE_UNSTABLE_API -D _FORTIFY_SOURCE=2 -fno-plt -ffunction-sections -fstack-clash-protection -fstack-protector-strong -march=x86-64-v3 -fcf-protection=full -fPIE -pthread '-DSRCDIR="/build/p11-kit-0.24.0"' '-DBUILDDIR="/build/build"' -MD -MQ trust/frob-ext.p/frob-ext.c.o -MF trust/frob-ext.p/frob-ext.c.o.d -o trust/frob-ext.p/frob-ext.c.o -c ../p11-kit-0.24.0/trust/frob-ext.c
../p11-kit-0.24.0/trust/frob-ext.c:38:10: fatal error: 'libtasn1.h' file not found
#include <libtasn1.h>
         ^~~~~~~~~~~~
1 error generated.
samu: job failed: clang -Itrust/frob-eku.p -Itrust -I../p11-kit-0.24.0/trust -I. -I../p11-kit-0.24.0 -Icommon -I../p11-kit-0.24.0/common -I/opt/65e51442a7726f4c85ead1eec37cf941b5dad691-libffi/include -flto=thin -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -D_GNU_SOURCE -DP11_KIT_FUTURE_UNSTABLE_API -D _FORTIFY_SOURCE=2 -fno-plt -ffunction-sections -fstack-clash-protection -fstack-protector-strong -march=x86-64-v3 -fcf-protection=full -fPIE -pthread '-DSRCDIR="/build/p11-kit-0.24.0"' '-DBUILDDIR="/build/build"' -MD -MQ trust/frob-eku.p/frob-eku.c.o -MF trust/frob-eku.p/frob-eku.c.o.d -o trust/frob-eku.p/frob-eku.c.o -c ../p11-kit-0.24.0/trust/frob-eku.c
../p11-kit-0.24.0/trust/frob-eku.c:38:10: fatal error: 'libtasn1.h' file not found
#include <libtasn1.h>
         ^~~~~~~~~~~~
1 error generated.
samu: job failed: clang -Itrust/frob-ku.p -Itrust -I../p11-kit-0.24.0/trust -I. -I../p11-kit-0.24.0 -Icommon -I../p11-kit-0.24.0/common -I/opt/65e51442a7726f4c85ead1eec37cf941b5dad691-libffi/include -flto=thin -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -D_GNU_SOURCE -DP11_KIT_FUTURE_UNSTABLE_API -D _FORTIFY_SOURCE=2 -fno-plt -ffunction-sections -fstack-clash-protection -fstack-protector-strong -march=x86-64-v3 -fcf-protection=full -fPIE -pthread '-DSRCDIR="/build/p11-kit-0.24.0"' '-DBUILDDIR="/build/build"' -MD -MQ trust/frob-ku.p/frob-ku.c.o -MF trust/frob-ku.p/frob-ku.c.o.d -o trust/frob-ku.p/frob-ku.c.o -c ../p11-kit-0.24.0/trust/frob-ku.c
../p11-kit-0.24.0/trust/frob-ku.c:40:10: fatal error: 'libtasn1.h' file not found
#include <libtasn1.h>
         ^~~~~~~~~~~~
1 error generated.
samu: job failed: clang -Itrust/frob-bc.p -Itrust -I../p11-kit-0.24.0/trust -I. -I../p11-kit-0.24.0 -Icommon -I../p11-kit-0.24.0/common -I/opt/65e51442a7726f4c85ead1eec37cf941b5dad691-libffi/include -flto=thin -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -D_GNU_SOURCE -DP11_KIT_FUTURE_UNSTABLE_API -D _FORTIFY_SOURCE=2 -fno-plt -ffunction-sections -fstack-clash-protection -fstack-protector-strong -march=x86-64-v3 -fcf-protection=full -fPIE -pthread '-DSRCDIR="/build/p11-kit-0.24.0"' '-DBUILDDIR="/build/build"' -MD -MQ trust/frob-bc.p/frob-bc.c.o -MF trust/frob-bc.p/frob-bc.c.o.d -o trust/frob-bc.p/frob-bc.c.o -c ../p11-kit-0.24.0/trust/frob-bc.c
../p11-kit-0.24.0/trust/frob-bc.c:38:10: fatal error: 'libtasn1.h' file not found
#include <libtasn1.h>
         ^~~~~~~~~~~~
1 error generated
```