### PR TITLE
shell: test -a|o is not POSIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -350,7 +350,7 @@ elif test "$enable_trust_module" != "yes"; then
 	AC_MSG_RESULT([disabled])
 
 # Option was not set, try to detect
-elif test "$with_trust_paths" = "" -o "$with_trust_paths" = "yes"; then
+elif test "$with_trust_paths" = "" || test "$with_trust_paths" = "yes"; then
 	with_trust_paths=""
 	for f in /etc/pki/tls/certs/ca-bundle.crt \
 		/etc/ssl/certs/ca-certificates.crt \

--- a/p11-kit/test-server.sh
+++ b/p11-kit/test-server.sh
@@ -36,7 +36,7 @@ fi
 
 . ./start.env
 
-if test "${P11_KIT_SERVER_ADDRESS+set}" = "set" -a "${P11_KIT_SERVER_PID+set}" = "set"; then
+if test "${P11_KIT_SERVER_ADDRESS+set}" = "set" && test "${P11_KIT_SERVER_PID+set}" = "set"; then
 	echo "ok 2 /server/start-env"
 else
 	echo "not ok 2 /server/start-env"
@@ -54,7 +54,7 @@ fi
 
 . ./stop.env
 
-if test "${P11_KIT_SERVER_ADDRESS-unset}" = "unset" -a "${P11_KIT_SERVER_PID-unset}" = "unset"; then
+if test "${P11_KIT_SERVER_ADDRESS-unset}" = "unset" && test "${P11_KIT_SERVER_PID-unset}" = "unset"; then
 	echo "ok 4 /server/stop-env"
 else
 	echo "not ok 4 /server/stop-env"


### PR DESCRIPTION
I faced `test: too many arguments` when building using [sbase](https://core.suckless.org/sbase/).
This is due to a non-POSIX syntax `test ... -a ...` and `test … -o …`.

> The XSI extensions specifying the -a and -o binary primaries and the '(' and ')' operators have been marked obsolescent.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html

Same as https://github.com/NetworkConfiguration/dhcpcd/pull/38.