### PR TITLE
Meson: p11_system_config_modules instead of p11_package_config_modules

### DIFF
--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -307,7 +307,7 @@ p11_kit_pc_variables = [
   'p11_module_configs=@0@'.format(prefix / p11_package_config_modules),
   'p11_module_path=@0@'.format(prefix / p11_module_path),
   'proxy_module=@0@/p11-kit-proxy.so'.format(prefix / libdir),
-  'p11_system_config_modules=@0@'.format(prefix / p11_package_config_modules)
+  'p11_system_config_modules=@0@'.format(prefix / p11_system_config_modules)
 ]
 
 if trust_paths != ''


### PR DESCRIPTION
A trivial typo.