### PR TITLE
Link libp11-kit so that it cannot unload

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,19 @@ LT_INIT([dlopen disable-static])
 dnl Check if -Wl,--version-script is supported by the linker
 gl_LD_VERSION_SCRIPT
 
+# --------------------------------------------------------------------
+# Check for -z nodelete link flag
+
+SAVE_LDFLAGS="$LDFLAGS"
+LDFLAGS="$LDFLAGS -Wl,-z -Wl,nodelete"
+AC_MSG_CHECKING([whether linker understands -z nodelete])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+	       [LDFLAGS_Z_NODELETE="-Wl,-z -Wl,nodelete"; has_option=yes],
+	       [LDFLAGS_Z_NODELETE=""; has_option=no])
+AC_MSG_RESULT($has_option)
+LDFLAGS="$SAVE_LDFLAGS"
+AC_SUBST(LDFLAGS_Z_NODELETE)
+
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CPP

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -87,6 +87,7 @@ COMMON_LIBS = \
 libp11_kit_la_CFLAGS = $(COMMON_CFLAGS)
 
 libp11_kit_la_LDFLAGS = \
+	$(LDFLAGS_Z_NODELETE) \
 	-no-undefined \
 	-version-info $(P11KIT_LT_RELEASE)
 


### PR DESCRIPTION
libp11-kit installs a pthread_atfork() callback to count forks. If the
library gets unloaded, a stale pointer is called on the next fork(),
leading to a crash.

This fix adds -z nodelete linker flag so that libp11-kit cannot be
unloaded. Unfortunately, that only fixes the problem for GNU ld.
More additionnal flags will be required for other linkers.