### PR TITLE
rpc: Fallback to version 0 if server does not support negotiation

### DIFF
--- a/p11-kit/rpc-transport.c
+++ b/p11-kit/rpc-transport.c
@@ -641,7 +641,7 @@ rpc_transport_authenticate (p11_rpc_client_vtable *vtable,
 	}
 #endif
 
-	*version = P11_RPC_PROTOCOL_VERSION_MAXIMUM;
+	p11_debug ("authenticating with version %u", *version);
 
 	/* Place holder byte, will later carry unix credentials (on some systems) */
 	if (write_all (sock->write_fd, version, 1) != 1) {


### PR DESCRIPTION
Old servers without support for version negotiation cannot handle
version bytes other than 0 and will close the connection if a version
byte greater than 0 is received.  This adds a fallback mechanism to
reconnect and reauthenticate with version 0 in that situation for
backward compatibility.

Suggested by Owen Taylor.