### PR TITLE
gtkdoc: remove dependencies on custom target files

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -73,7 +73,7 @@ if get_option('gtk_doc')
               main_xml: 'p11-kit-docs.xml',
               namespace: 'p11_kit',
               src_dir: 'p11-kit',
-              dependencies: libffi_deps + dlopen_deps + xml_deps,
+              dependencies: libffi_deps + dlopen_deps,
               scan_args: [
                 '--ignore-headers=' + ' '.join(ignore_headers),
                 '--rebuild-types',


### PR DESCRIPTION
Sadly, the `dependencies` kwarg does not actually do what it seems to be trying to be used for, here. It is for listing dependency or library objects whose compiler flags should be added to gtkdoc-scangobj.

It will not actually add ninja target dependencies. The similar kwarg in other meson functions (e.g. genmarshal and compile_schemas) that *do* allow adding target dependencies, is `depend_files`.

Older versions of meson simply did nothing in an if/elif/elif block where these custom_targets never matched anything, and were thus silently ignored.

Meson 0.61 type-validates the arguments and rejects CustomTarget as invalid:

```
doc/manual/meson.build:72:8: ERROR: gnome.gtkdoc keyword argument 'dependencies' was of type array[CustomTarget | PkgConfigDependency] but should have been array[Dependency | SharedLibrary | StaticLibrary]
```

Fixes #406