### PR TITLE
build: Use EXEEXT and SHLEXT

### DIFF
--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -85,7 +85,7 @@ p11_kit_trust (int argc,
 	args = calloc (argc + 2, sizeof (char *));
 	return_val_if_fail (args != NULL, 1);
 
-	args[0] = BINDIR "/trust";
+	args[0] = BINDIR "/trust" EXEEXT;
 	memcpy (args + 1, argv, sizeof (char *) * argc);
 	args[argc + 1] = NULL;
 

--- a/p11-kit/test-conf.c
+++ b/p11-kit/test-conf.c
@@ -278,17 +278,17 @@ test_load_modules_merge (void)
 
 	config = p11_dict_get (configs, "one");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-one.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-one" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "user1");
 
 	config = p11_dict_get (configs, "two.badname");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-two.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-two" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "system2");
 
 	config = p11_dict_get (configs, "three");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-three.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-three" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "user3");
 
 	p11_dict_free (configs);
@@ -311,12 +311,12 @@ test_load_modules_user_none (void)
 
 	config = p11_dict_get (configs, "one");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-one.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-one" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "system1");
 
 	config = p11_dict_get (configs, "two.badname");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-two.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-two" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "system2");
 
 	config = p11_dict_get (configs, "three");
@@ -350,7 +350,7 @@ test_load_modules_user_only (void)
 
 	config = p11_dict_get (configs, "three");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-three.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-three" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "user3");
 
 	p11_dict_free (configs);
@@ -373,12 +373,12 @@ test_load_modules_no_user (void)
 
 	config = p11_dict_get (configs, "one");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-one.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-one" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "system1");
 
 	config = p11_dict_get (configs, "two.badname");
 	assert_ptr_not_null (config);
-	assert_str_eq ("mock-two.so", p11_dict_get (config, "module"));
+	assert_str_eq ("mock-two" SHLEXT, p11_dict_get (config, "module"));
 	assert_str_eq (p11_dict_get (config, "setting"), "system2");
 
 	config = p11_dict_get (configs, "three");

--- a/p11-kit/test-server.c
+++ b/p11-kit/test-server.c
@@ -129,7 +129,8 @@ setup_server (void *arg)
 		close (STDOUT_FILENO);
 		if (dup2 (fds[0], STDOUT_FILENO) == -1)
 			assert_not_reached ();
-		if (execv (BUILDDIR "/p11-kit/p11-kit-server-testable", (char **)args->elem) == -1)
+		if (execv (BUILDDIR "/p11-kit/p11-kit-server-testable" EXEEXT,
+			   (char **)args->elem) == -1)
 			assert_not_reached ();
 		p11_array_free (args);
 		_exit (0);

--- a/p11-kit/test-transport.c
+++ b/p11-kit/test-transport.c
@@ -196,7 +196,7 @@ launch_server (void)
 	argv[1] = P11_MODULE_PATH "/mock-two.so";
 	argv[2] = NULL;
 
-	rc = execv (BUILDDIR "/p11-kit/p11-kit-remote", argv);
+	rc = execv (BUILDDIR "/p11-kit/p11-kit-remote" EXEEXT, argv);
 	assert_num_cmp (rc, !=, -1);
 }
 

--- a/p11-kit/test-transport.c
+++ b/p11-kit/test-transport.c
@@ -193,7 +193,7 @@ launch_server (void)
 	assert_num_cmp (rc, !=, -1);
 
 	argv[0] = "p11-kit-remote";
-	argv[1] = P11_MODULE_PATH "/mock-two.so";
+	argv[1] = P11_MODULE_PATH "/mock-two" SHLEXT;
 	argv[2] = NULL;
 
 	rc = execv (BUILDDIR "/p11-kit/p11-kit-remote" EXEEXT, argv);

--- a/trust/extract.c
+++ b/trust/extract.c
@@ -315,13 +315,14 @@ p11_trust_extract_compat (int argc,
 	 * For compatibility with people who deployed p11-kit 0.18.x
 	 * before trust stuff was put into its own branch.
 	 */
-	path = p11_path_build (PRIVATEDIR, "p11-kit-extract-trust", NULL);
+	path = p11_path_build (PRIVATEDIR, "p11-kit-extract-trust" EXEEXT, NULL);
 	return_val_if_fail (path != NULL, 1);
 	execv (path, argv);
 	error = errno;
 
 	if (error == ENOENT) {
 		free (path);
+		/* "trust-extract-compat" is supposed to be a script, not a binary */
 		path = p11_path_build (PRIVATEDIR, "trust-extract-compat", NULL);
 		return_val_if_fail (path != NULL, 1);
 		execv (path, argv);


### PR DESCRIPTION
For better compatibility with Windows, append EXEEXT when spawning binary executables as well as replace ".so" with SHLEXT determined at build time.