### PR TITLE
#379 Fix support for epoch time 0 in JKS for reproducibility

### DIFF
--- a/trust/extract-jks.c
+++ b/trust/extract-jks.c
@@ -289,7 +289,7 @@ prepare_jks_buffer (p11_enumerate *ex,
 			now = time (NULL);
 	}
 
-	return_val_if_fail (now > 0, false);
+	return_val_if_fail (now >= 0, false);
 	now *= 1000; /* seconds to milliseconds */
 
 	/*


### PR DESCRIPTION
The environment variable `SOURCE_DATE_EPOCH` enables users to create reproducible JKS trust stores.  
Currently users must set this environment variable to greater than 0.  

Because it is common practice to set the the reproducibility date to the UNIX epoch time, the value `0` should be supported for the environment variable `SOURCE_DATE_EPOCH`.