### PR TITLE
pkcs11-gnu: Enable testing with <p11-kit/pkcs11x.h>

### DIFF
--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -217,6 +217,9 @@ gnu_h = gnu_h_gen.process(pkcs11_gnu_headers)
 static_library('p11-kit-pkcs11-gnu',
                gnu_h,
                'pkcs11-gnu.c',
+               c_args: [
+                 '-DCRYPTOKI_GNU=1', '-DP11_KIT_FUTURE_UNSTABLE_API=1',
+               ],
                include_directories: [configinc, commoninc])
 
 # Tests ----------------------------------------------------------------

--- a/p11-kit/p11-kit.h
+++ b/p11-kit/p11-kit.h
@@ -43,11 +43,16 @@
  */
 #ifdef CRYPTOKI_GNU
 typedef ck_rv_t CK_RV;
+typedef ck_object_handle_t CK_OBJECT_HANDLE;
+typedef unsigned long int CK_ULONG;
 typedef struct ck_function_list* CK_FUNCTION_LIST_PTR;
 typedef struct ck_function_list CK_FUNCTION_LIST;
 #endif
 
 #include "p11-kit/deprecated.h"
+
+/* For size_t.  */
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/p11-kit/pkcs11-gnu.c
+++ b/p11-kit/pkcs11-gnu.c
@@ -1,3 +1,8 @@
+#include "config.h"
+
+#include "p11-kit.h"
+#include "pkcs11x.h"
+
 #include "pkcs11-gnu-iter.h"
 #include "pkcs11-gnu-pin.h"
 #include "pkcs11-gnu-uri.h"


### PR DESCRIPTION
This ensures that programs using <p11-kit/pkcs11x.h> can be compiled
with CRYPTOKI_GNU.  The previous coverage was partial as pkcs11-gnu.c
didn't include "pkcs11x.h" and Meson didn't supply -DCRYPTOKI_GNU=1.

Signed-off-by: Daiki Ueno <ueno@gnu.org>