### PR TITLE
trust: Replace deprecated node_asn and ASN1_ARRAY_TYPE macro usage

### DIFF
--- a/trust/asn1.c
+++ b/trust/asn1.c
@@ -49,12 +49,12 @@
 static void
 free_asn1_def (void *data)
 {
-	node_asn *def = data;
+	asn1_node def = data;
 	asn1_delete_structure (&def);
 }
 
 struct {
-	const ASN1_ARRAY_TYPE* tab;
+	const asn1_static_node *tab;
 	const char *prefix;
 	int prefix_len;
 } asn1_tabs[] = {
@@ -67,7 +67,7 @@ p11_dict *
 p11_asn1_defs_load (void)
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *def;
+	asn1_node def;
 	p11_dict *defs;
 	int ret;
 	int i;
@@ -91,7 +91,7 @@ p11_asn1_defs_load (void)
 	return defs;
 }
 
-static node_asn *
+static asn1_node
 lookup_def (p11_dict *asn1_defs,
             const char *struct_name)
 {
@@ -106,12 +106,12 @@ lookup_def (p11_dict *asn1_defs,
 	return NULL;
 }
 
-node_asn *
+asn1_node
 p11_asn1_create (p11_dict *asn1_defs,
                  const char *struct_name)
 {
-	node_asn *def;
-	node_asn *asn;
+	asn1_node def;
+	asn1_node asn;
 	int ret;
 
 	return_val_if_fail (asn1_defs != NULL, NULL);
@@ -129,7 +129,7 @@ p11_asn1_create (p11_dict *asn1_defs,
 	return asn;
 }
 
-node_asn *
+asn1_node
 p11_asn1_decode (p11_dict *asn1_defs,
                  const char *struct_name,
                  const unsigned char *der,
@@ -137,7 +137,7 @@ p11_asn1_decode (p11_dict *asn1_defs,
                  char *message)
 {
 	char msg[ASN1_MAX_ERROR_DESCRIPTION_SIZE];
-	node_asn *asn = NULL;
+	asn1_node asn = NULL;
 	int ret;
 
 	return_val_if_fail (asn1_defs != NULL, NULL);
@@ -161,7 +161,7 @@ p11_asn1_decode (p11_dict *asn1_defs,
 }
 
 unsigned char *
-p11_asn1_encode (node_asn *asn,
+p11_asn1_encode (asn1_node asn,
                  size_t *der_len)
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE];
@@ -193,7 +193,7 @@ p11_asn1_encode (node_asn *asn,
 }
 
 void *
-p11_asn1_read (node_asn *asn,
+p11_asn1_read (asn1_node asn,
                const char *field,
                size_t *length)
 {
@@ -228,7 +228,7 @@ p11_asn1_read (node_asn *asn,
 void
 p11_asn1_free (void *asn)
 {
-	node_asn *node = asn;
+	asn1_node node = asn;
 	if (node != NULL)
 		asn1_delete_structure (&node);
 }
@@ -257,7 +257,7 @@ p11_asn1_tlv_length (const unsigned char *data,
 }
 
 typedef struct {
-	node_asn *node;
+	asn1_node node;
 	char *struct_name;
 	size_t length;
 } asn1_item;
@@ -300,7 +300,7 @@ p11_asn1_cache_new (void)
 	return cache;
 }
 
-node_asn *
+asn1_node
 p11_asn1_cache_get (p11_asn1_cache *cache,
                     const char *struct_name,
                     const unsigned char *der,
@@ -326,7 +326,7 @@ p11_asn1_cache_get (p11_asn1_cache *cache,
 
 void
 p11_asn1_cache_take (p11_asn1_cache *cache,
-                     node_asn *node,
+                     asn1_node node,
                      const char *struct_name,
                      const unsigned char *der,
                      size_t der_len)

--- a/trust/asn1.h
+++ b/trust/asn1.h
@@ -43,19 +43,19 @@ typedef struct _p11_asn1_cache p11_asn1_cache;
 
 p11_dict *       p11_asn1_defs_load                 (void);
 
-node_asn *       p11_asn1_decode                    (p11_dict *asn1_defs,
+asn1_node       p11_asn1_decode                    (p11_dict *asn1_defs,
                                                      const char *struct_name,
                                                      const unsigned char *der,
                                                      size_t der_len,
                                                      char *message);
 
-node_asn *       p11_asn1_create                    (p11_dict *asn1_defs,
+asn1_node       p11_asn1_create                    (p11_dict *asn1_defs,
                                                      const char *struct_name);
 
-unsigned char *  p11_asn1_encode                    (node_asn *asn,
+unsigned char *  p11_asn1_encode                    (asn1_node asn,
                                                      size_t *der_len);
 
-void *           p11_asn1_read                      (node_asn *asn,
+void *           p11_asn1_read                      (asn1_node asn,
                                                      const char *field,
                                                      size_t *length);
 
@@ -68,13 +68,13 @@ p11_asn1_cache * p11_asn1_cache_new                 (void);
 
 p11_dict *       p11_asn1_cache_defs                (p11_asn1_cache *cache);
 
-node_asn *       p11_asn1_cache_get                 (p11_asn1_cache *cache,
+asn1_node       p11_asn1_cache_get                 (p11_asn1_cache *cache,
                                                      const char *struct_name,
                                                      const unsigned char *der,
                                                      size_t der_len);
 
 void             p11_asn1_cache_take                (p11_asn1_cache *cache,
-                                                     node_asn *node,
+                                                     asn1_node node,
                                                      const char *struct_name,
                                                      const unsigned char *der,
                                                      size_t der_len);

--- a/trust/builder.c
+++ b/trust/builder.c
@@ -94,13 +94,13 @@ typedef struct {
 	CK_RV (*validate) (p11_builder *, CK_ATTRIBUTE *, CK_ATTRIBUTE *);
 } builder_schema;
 
-static node_asn *
+static asn1_node
 decode_or_get_asn1 (p11_builder *builder,
                     const char *struct_name,
                     const unsigned char *der,
                     size_t length)
 {
-	node_asn *node;
+	asn1_node node;
 
 	node = p11_asn1_cache_get (builder->asn1_cache, struct_name, der, length);
 	if (node != NULL)
@@ -127,7 +127,7 @@ lookup_extension (p11_builder *builder,
 	CK_ATTRIBUTE *label;
 	void *value;
 	size_t length;
-	node_asn *node;
+	asn1_node node;
 
 	CK_ATTRIBUTE match[] = {
 		{ CKA_PUBLIC_KEY_INFO, },
@@ -288,7 +288,7 @@ check_der_struct (p11_builder *builder,
                   const char *struct_name,
                   CK_ATTRIBUTE *attr)
 {
-	node_asn *asn;
+	asn1_node asn;
 
 	if (attr->ulValueLen == 0)
 		return true;
@@ -510,11 +510,11 @@ century_for_two_digit_year (int year)
 }
 
 static bool
-calc_date (node_asn *node,
+calc_date (asn1_node node,
            const char *field,
            CK_DATE *date)
 {
-	node_asn *choice;
+	asn1_node choice;
 	char buf[64];
 	int century;
 	char *sub;
@@ -575,7 +575,7 @@ calc_date (node_asn *node,
 }
 
 static bool
-calc_element (node_asn *node,
+calc_element (asn1_node node,
 	      const unsigned char *data,
 	      size_t length,
 	      const char *field,
@@ -604,7 +604,7 @@ is_v1_x509_authority (p11_builder *builder,
 	CK_ATTRIBUTE issuer;
 	CK_ATTRIBUTE *value;
 	char buffer[16];
-	node_asn *node;
+	asn1_node node;
 	int len;
 	int ret;
 
@@ -701,7 +701,7 @@ calc_certificate_category (p11_builder *builder,
 static CK_ATTRIBUTE *
 certificate_value_attrs (p11_builder *builder,
                          CK_ATTRIBUTE *attrs,
-                         node_asn *node,
+                         asn1_node node,
                          const unsigned char *der,
                          size_t der_len,
                          CK_ATTRIBUTE *public_key)
@@ -812,7 +812,7 @@ certificate_populate (p11_builder *builder,
 	CK_ULONG categoryv = 0UL;
 	CK_ATTRIBUTE *attrs = NULL;
 	CK_ATTRIBUTE public_key;
-	node_asn *node = NULL;
+	asn1_node node = NULL;
 	unsigned char *der = NULL;
 	size_t der_len = 0;
 
@@ -914,7 +914,7 @@ extension_populate (p11_builder *builder,
 
 	void *der;
 	size_t len;
-	node_asn *asn;
+	asn1_node asn;
 
 	attrs = common_populate (builder, index, extension);
 	return_val_if_fail (attrs != NULL, NULL);

--- a/trust/enumerate.c
+++ b/trust/enumerate.c
@@ -65,7 +65,7 @@ load_attached_extension (p11_dict *attached,
                          size_t len)
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE];
-	node_asn *ext;
+	asn1_node ext;
 	char *oid;
 	int length;
 	int start;
@@ -157,7 +157,7 @@ load_attached_extensions (p11_enumerate *ex,
 static bool
 extract_purposes (p11_enumerate *ex)
 {
-	node_asn *ext = NULL;
+	asn1_node ext = NULL;
 	unsigned char *value = NULL;
 	size_t length;
 

--- a/trust/enumerate.h
+++ b/trust/enumerate.h
@@ -76,7 +76,7 @@ typedef struct {
 	CK_ATTRIBUTE *attrs;
 
 	/* Pre-parsed data for certificates */
-	node_asn *cert_asn;
+	asn1_node cert_asn;
 	const unsigned char *cert_der;
 	size_t cert_len;
 

--- a/trust/extract-openssl.c
+++ b/trust/extract-openssl.c
@@ -114,7 +114,7 @@ load_usage_ext (p11_enumerate *ex,
                 p11_array **oids)
 {
 	unsigned char *value;
-	node_asn *ext = NULL;
+	asn1_node ext = NULL;
 	size_t length;
 
 	if (ex->attached)
@@ -135,7 +135,7 @@ load_usage_ext (p11_enumerate *ex,
 }
 
 static bool
-write_usages (node_asn *asn,
+write_usages (asn1_node asn,
               const char *field,
               p11_array *oids)
 {
@@ -169,7 +169,7 @@ write_usages (node_asn *asn,
 
 static bool
 write_trust_and_rejects (p11_enumerate *ex,
-                         node_asn *asn)
+                         asn1_node asn)
 {
 	p11_array *trusts = NULL;
 	p11_array *rejects = NULL;
@@ -230,10 +230,10 @@ write_trust_and_rejects (p11_enumerate *ex,
 
 static bool
 write_keyid (p11_enumerate *ex,
-             node_asn *asn)
+             asn1_node asn)
 {
 	unsigned char *value = NULL;
-	node_asn *ext = NULL;
+	asn1_node ext = NULL;
 	size_t length = 0;
 	int ret;
 
@@ -253,7 +253,7 @@ write_keyid (p11_enumerate *ex,
 
 static bool
 write_alias (p11_enumerate *ex,
-             node_asn *asn)
+             asn1_node asn)
 {
 	CK_ATTRIBUTE *label;
 	int ret;
@@ -272,7 +272,7 @@ write_alias (p11_enumerate *ex,
 
 static bool
 write_other (p11_enumerate *ex,
-             node_asn *asn)
+             asn1_node asn)
 {
 	int ret;
 
@@ -288,7 +288,7 @@ prepare_pem_contents (p11_enumerate *ex,
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE];
 	unsigned char *der;
-	node_asn *asn;
+	asn1_node asn;
 	size_t offset;
 	int ret;
 	int len;
@@ -461,7 +461,7 @@ p11_openssl_canon_name_der (p11_dict *asn1_defs,
 	p11_buffer value;
 	char outer[64];
 	char field[128];
-	node_asn *name;
+	asn1_node name;
 	void *at;
 	int value_len;
 	bool failed;

--- a/trust/frob-bc.c
+++ b/trust/frob-bc.c
@@ -55,8 +55,8 @@ main (int argc,
       char *argv[])
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *definitions = NULL;
-	node_asn *ext = NULL;
+	asn1_node definitions = NULL;
+	asn1_node ext = NULL;
 	char *buf;
 	int len;
 	int ret;

--- a/trust/frob-cert.c
+++ b/trust/frob-cert.c
@@ -83,8 +83,8 @@ main (int argc,
       char *argv[])
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *definitions = NULL;
-	node_asn *cert = NULL;
+	asn1_node definitions = NULL;
+	asn1_node cert = NULL;
 	p11_mmap *map;
 	void *data;
 	size_t size;

--- a/trust/frob-eku.c
+++ b/trust/frob-eku.c
@@ -55,8 +55,8 @@ main (int argc,
       char *argv[])
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *definitions = NULL;
-	node_asn *ekus = NULL;
+	asn1_node definitions = NULL;
+	asn1_node ekus = NULL;
 	char *buf;
 	int len;
 	int ret;

--- a/trust/frob-ext.c
+++ b/trust/frob-ext.c
@@ -55,8 +55,8 @@ main (int argc,
       char *argv[])
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *definitions = NULL;
-	node_asn *ext = NULL;
+	asn1_node definitions = NULL;
+	asn1_node ext = NULL;
 	unsigned char input[1024];
 	char *buf;
 	size_t size;

--- a/trust/frob-ku.c
+++ b/trust/frob-ku.c
@@ -57,8 +57,8 @@ main (int argc,
       char *argv[])
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *definitions = NULL;
-	node_asn *ku = NULL;
+	asn1_node definitions = NULL;
+	asn1_node ku = NULL;
 	unsigned int usage = 0;
 	char bits[2];
 	char *buf;

--- a/trust/frob-oid.c
+++ b/trust/frob-oid.c
@@ -54,8 +54,8 @@ main (int argc,
       char *argv[])
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *definitions = NULL;
-	node_asn *oid = NULL;
+	asn1_node definitions = NULL;
+	asn1_node oid = NULL;
 	char *buf;
 	int len;
 	int ret;

--- a/trust/parser.c
+++ b/trust/parser.c
@@ -183,7 +183,7 @@ p11_parser_format_x509 (p11_parser *parser,
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE];
 	CK_ATTRIBUTE *attrs;
 	CK_ATTRIBUTE *value;
-	node_asn *cert;
+	asn1_node cert;
 
 	cert = p11_asn1_decode (parser->asn1_defs, "PKIX1.Certificate", data, length, message);
 	if (cert == NULL)
@@ -218,7 +218,7 @@ extension_attrs (p11_parser *parser,
 	CK_ATTRIBUTE oid = { CKA_OBJECT_ID, (void *)oid_der, p11_oid_length (oid_der) };
 
 	CK_ATTRIBUTE *attrs;
-	node_asn *dest;
+	asn1_node dest;
 	unsigned char *der;
 	size_t len;
 	int ret;
@@ -256,7 +256,7 @@ attached_attrs (p11_parser *parser,
                 const char *oid_str,
                 const unsigned char *oid_der,
                 bool critical,
-                node_asn *ext)
+                asn1_node ext)
 {
 	CK_ATTRIBUTE *attrs;
 	unsigned char *der;
@@ -274,7 +274,7 @@ attached_attrs (p11_parser *parser,
 }
 
 static p11_dict *
-load_seq_of_oid_str (node_asn *node,
+load_seq_of_oid_str (asn1_node node,
                      const char *seqof)
 {
 	p11_dict *oids;
@@ -310,7 +310,7 @@ attached_eku_attrs (p11_parser *parser,
 {
 	CK_ATTRIBUTE *attrs;
 	p11_dictiter iter;
-	node_asn *dest;
+	asn1_node dest;
 	int count = 0;
 	void *value;
 	int ret;
@@ -361,7 +361,7 @@ static CK_ATTRIBUTE *
 build_openssl_extensions (p11_parser *parser,
                           CK_ATTRIBUTE *cert,
                           CK_ATTRIBUTE *public_key_info,
-                          node_asn *aux,
+                          asn1_node aux,
                           const unsigned char *aux_der,
                           size_t aux_len)
 {
@@ -501,8 +501,8 @@ parse_openssl_trusted_certificate (p11_parser *parser,
 	CK_ATTRIBUTE public_key_info = { CKA_PUBLIC_KEY_INFO };
 	CK_ATTRIBUTE *value;
 	char *label = NULL;
-	node_asn *cert;
-	node_asn *aux = NULL;
+	asn1_node cert;
+	asn1_node aux = NULL;
 	ssize_t cert_len;
 	size_t len;
 	int start;

--- a/trust/persist.c
+++ b/trust/persist.c
@@ -67,7 +67,7 @@
 
 struct _p11_persist {
 	p11_dict *constants;
-	node_asn *asn1_defs;
+	asn1_node asn1_defs;
 };
 
 bool
@@ -407,7 +407,7 @@ parse_oid (p11_persist *persist,
            CK_ATTRIBUTE *attr)
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *asn;
+	asn1_node asn;
 	size_t length;
 	char *value;
 	int ret;
@@ -464,7 +464,7 @@ format_oid (p11_persist *persist,
             p11_buffer *buf)
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
-	node_asn *asn;
+	asn1_node asn;
 	char *data;
 	size_t len;
 	int ret;

--- a/trust/test-asn1.c
+++ b/trust/test-asn1.c
@@ -95,8 +95,8 @@ test_asn1_cache (void)
 {
 	p11_asn1_cache *cache;
 	p11_dict *defs;
-	node_asn *asn;
-	node_asn *check;
+	asn1_node asn;
+	asn1_node check;
 
 	cache = p11_asn1_cache_new ();
 	assert_ptr_not_null (cache);
@@ -134,7 +134,7 @@ static void
 test_asn1_free (void)
 {
 	p11_dict *defs;
-	node_asn *asn;
+	asn1_node asn;
 
 	defs = p11_asn1_defs_load ();
 	assert_ptr_not_null (defs);

--- a/trust/test-oid.c
+++ b/trust/test-oid.c
@@ -50,8 +50,8 @@ static void
 test_known_oids (void)
 {
 	char buffer[128];
-	node_asn *definitions = NULL;
-	node_asn *node;
+	asn1_node definitions = NULL;
+	asn1_node node;
 	int ret;
 	int len;
 	int i;

--- a/trust/test-x509.c
+++ b/trust/test-x509.c
@@ -280,7 +280,7 @@ test_parse_key_usage (void)
 static void
 test_parse_extension (void)
 {
-	node_asn *cert;
+	asn1_node cert;
 	unsigned char *ext;
 	size_t length;
 	bool is_ca;
@@ -305,7 +305,7 @@ test_parse_extension (void)
 static void
 test_parse_extension_not_found (void)
 {
-	node_asn *cert;
+	asn1_node cert;
 	unsigned char *ext;
 	size_t length;
 

--- a/trust/x509.c
+++ b/trust/x509.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 unsigned char *
-p11_x509_find_extension (node_asn *cert,
+p11_x509_find_extension (asn1_node cert,
                          const unsigned char *oid,
                          const unsigned char *der,
                          size_t der_len,
@@ -92,7 +92,7 @@ p11_x509_find_extension (node_asn *cert,
 }
 
 bool
-p11_x509_hash_subject_public_key (node_asn *cert,
+p11_x509_hash_subject_public_key (asn1_node cert,
                                   const unsigned char *der,
                                   size_t der_len,
                                   unsigned char *keyid)
@@ -120,7 +120,7 @@ p11_x509_parse_subject_key_identifier  (p11_dict *asn1_defs,
                                         size_t *keyid_len)
 {
 	unsigned char *keyid;
-	node_asn *ext;
+	asn1_node ext;
 
 	return_val_if_fail (keyid_len != NULL, false);
 
@@ -143,7 +143,7 @@ p11_x509_parse_basic_constraints (p11_dict *asn1_defs,
                                   bool *is_ca)
 {
 	char buffer[8];
-	node_asn *ext;
+	asn1_node ext;
 	int ret;
 	int len;
 
@@ -178,7 +178,7 @@ p11_x509_parse_key_usage (p11_dict *asn1_defs,
 {
 	char message[ASN1_MAX_ERROR_DESCRIPTION_SIZE] = { 0, };
 	unsigned char buf[2];
-	node_asn *ext;
+	asn1_node ext;
 	int len;
 	int ret;
 
@@ -203,7 +203,7 @@ p11_x509_parse_extended_key_usage (p11_dict *asn1_defs,
                                    const unsigned char *ext_der,
                                    size_t ext_len)
 {
-	node_asn *asn;
+	asn1_node asn;
 	char field[128];
 	p11_array *ekus;
 	size_t len;
@@ -301,7 +301,7 @@ p11_x509_parse_dn_name (p11_dict *asn_defs,
                         size_t der_len,
                         const unsigned char *oid)
 {
-	node_asn *asn;
+	asn1_node asn;
 	char *part;
 
 	asn = p11_asn1_decode (asn_defs, "PKIX1.Name", der, der_len, NULL);
@@ -314,7 +314,7 @@ p11_x509_parse_dn_name (p11_dict *asn_defs,
 }
 
 char *
-p11_x509_lookup_dn_name (node_asn *asn,
+p11_x509_lookup_dn_name (asn1_node asn,
                          const char *dn_field,
                          const unsigned char *der,
                          size_t der_len,

--- a/trust/x509.h
+++ b/trust/x509.h
@@ -40,13 +40,13 @@
 #ifndef P11_X509_H_
 #define P11_X509_H_
 
-unsigned char *  p11_x509_find_extension            (node_asn *cert,
+unsigned char *  p11_x509_find_extension            (asn1_node cert,
                                                      const unsigned char *oid,
                                                      const unsigned char *der,
                                                      size_t der_len,
                                                      size_t *ext_len);
 
-bool             p11_x509_hash_subject_public_key   (node_asn *cert,
+bool             p11_x509_hash_subject_public_key   (asn1_node cert,
                                                      const unsigned char *der,
                                                      size_t der_len,
                                                      unsigned char *keyid);
@@ -75,7 +75,7 @@ char *           p11_x509_parse_dn_name             (p11_dict *asn_defs,
                                                      size_t der_len,
                                                      const unsigned char *oid);
 
-char *           p11_x509_lookup_dn_name            (node_asn *asn,
+char *           p11_x509_lookup_dn_name            (asn1_node asn,
                                                      const char *dn_field,
                                                      const unsigned char *der,
                                                      size_t der_len,


### PR DESCRIPTION
Signed-off-by: Daiki Ueno <ueno@gnu.org>