### PR TITLE
compat: Fix detection of O_BINARY and O_CLOEXEC

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -37,8 +37,9 @@
 
 #include "config.h"
 
-#include <sys/types.h>
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #ifdef HAVE_SYS_UN_H
 #  include <sys/un.h>
 #endif


### PR DESCRIPTION
Previously those macros were defined as 0 unless <fcntl.h> was
included before "compat.h".

Reported and fix suggested by Kevin Adler in:
https://github.com/p11-glue/p11-kit/issues/425

Fixes: #425 
Signed-off-by: Daiki Ueno <ueno@gnu.org>