### PR TITLE
Revert "ci: Switch to using Gcovr instead of LCOV"

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,5 +5,5 @@ MAINTAINER Daiki Ueno <ueno@gnu.org>
 RUN dnf -y update
 RUN dnf -y install 'dnf-command(builddep)'
 RUN dnf -y builddep 'p11-kit'
-RUN dnf install -y gettext-devel git libtool make opensc openssl valgrind meson ninja-build bash-completion gcovr python-pip libasan libubsan clang-analyzer mingw64-gcc mingw64-libffi mingw64-libtasn1 wine cppcheck
+RUN dnf install -y gettext-devel git libtool make opensc openssl valgrind meson ninja-build bash-completion lcov python-pip libasan libubsan clang-analyzer mingw64-gcc mingw64-libffi mingw64-libtasn1 wine cppcheck
 RUN dnf clean all


### PR DESCRIPTION
This reverts commit 2edebe3b674d364430981771cb402e8a1a412e45.

It turned out that neither Gcovr supports LCOV output format that
Coveralls GH action requires, nor Coveralls GH action supports JSON
format produced by gcovr --coveralls.

Signed-off-by: Daiki Ueno <ueno@gnu.org>