### PR TITLE
[WIP] Support for recursive RPC attributes

### DIFF
--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -50,6 +50,7 @@
 #include <assert.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdio.h>
 
 #ifdef ENABLE_NLS
 #include <libintl.h>
@@ -205,6 +206,8 @@ proto_read_attribute_array (p11_rpc_message *msg,
                             CK_ATTRIBUTE_PTR arr,
                             CK_ULONG len)
 {
+	fprintf(stderr, "inside proto_read_attribute_array (client)\n");
+
 	uint32_t i, num;
 	CK_RV ret;
 
@@ -243,10 +246,13 @@ proto_read_attribute_array (p11_rpc_message *msg,
 			return PARSE_ERROR;
 		}
 
+		/*
 		if (IS_ATTRIBUTE_ARRAY (&temp)) {
 			p11_debug("recursive attribute array is not supported");
 			return PARSE_ERROR;
 		}
+		*/
+		fprintf(stderr, "IS_ATTRIBUTE_ARRAY = %s\n", IS_ATTRIBUTE_ARRAY (&temp) ? "true" : "false");
 
 		/* Try and stuff it in the output data */
 		if (arr) {

--- a/p11-kit/rpc-message.h
+++ b/p11-kit/rpc-message.h
@@ -245,6 +245,18 @@ typedef struct {
 	void *extra;
 } p11_rpc_message;
 
+bool
+p11_rpc_alloc_array(p11_rpc_message *msg,
+                    p11_buffer *buffer,
+		    size_t *offset,
+		    CK_ATTRIBUTE *attr);
+
+bool
+p11_rpc_alloc_attribute(p11_rpc_message *msg,
+                        p11_buffer *buffer,
+			size_t *offset,
+			CK_ATTRIBUTE *attr);
+
 void             p11_rpc_message_init                    (p11_rpc_message *msg,
                                                           p11_buffer *input,
                                                           p11_buffer *output);

--- a/p11-kit/test-iter.c
+++ b/p11-kit/test-iter.c
@@ -127,8 +127,8 @@ test_all (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, at);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, at);
 
 	assert (has_handle (objects, at, MOCK_DATA_OBJECT));
 	assert (!has_handle (objects, at, MOCK_PRIVATE_KEY_CAPITALIZE));
@@ -306,8 +306,8 @@ test_with_session (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* 1 modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (3, at);
+	/* 1 modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (4, at);
 
 	assert (has_handle (objects, at, MOCK_DATA_OBJECT));
 	assert (!has_handle (objects, at, MOCK_PRIVATE_KEY_CAPITALIZE));
@@ -357,8 +357,8 @@ test_with_slot (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* 1 modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (3, at);
+	/* 1 modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (4, at);
 
 	assert (has_handle (objects, at, MOCK_DATA_OBJECT));
 	assert (!has_handle (objects, at, MOCK_PRIVATE_KEY_CAPITALIZE));
@@ -400,8 +400,8 @@ test_with_module (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* 1 modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (3, at);
+	/* 1 modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (4, at);
 
 	assert (has_handle (objects, at, MOCK_DATA_OBJECT));
 	assert (!has_handle (objects, at, MOCK_PRIVATE_KEY_CAPITALIZE));
@@ -506,8 +506,8 @@ test_uri_with_type (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 2 public keys */
-	assert_num_eq (6, at);
+	/* Three modules, each with 1 slot, and 3 public keys */
+	assert_num_eq (9, at);
 
 	assert (!has_handle (objects, at, MOCK_DATA_OBJECT));
 	assert (!has_handle (objects, at, MOCK_PRIVATE_KEY_CAPITALIZE));
@@ -579,8 +579,8 @@ test_filter (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 2 public keys */
-	assert_num_eq (6, at);
+	/* Three modules, each with 1 slot, and 3 public keys */
+	assert_num_eq (9, at);
 
 	assert (!has_handle (objects, at, MOCK_DATA_OBJECT));
 	assert (!has_handle (objects, at, MOCK_PRIVATE_KEY_CAPITALIZE));
@@ -655,8 +655,8 @@ test_module_match (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, count);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, count);
 
 	p11_kit_iter_free (iter);
 
@@ -763,8 +763,8 @@ test_slot_match (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, count);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, count);
 
 	p11_kit_iter_free (iter);
 
@@ -875,8 +875,8 @@ test_slot_match_by_id (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, count);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, count);
 
 	p11_kit_iter_free (iter);
 
@@ -977,8 +977,8 @@ test_token_match (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, count);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, count);
 
 	p11_kit_iter_free (iter);
 
@@ -1301,6 +1301,10 @@ test_get_attributes (void)
 			assert (p11_attrs_find_ulong (attrs, CKA_CLASS, &ulong) && ulong == CKO_PUBLIC_KEY);
 			assert (p11_attr_match_value (p11_attrs_find (attrs, CKA_LABEL), "Public prefix key", -1));
 			break;
+		case MOCK_PUBLIC_KEY_PREFIX_2:
+			assert (p11_attrs_find_ulong (attrs, CKA_CLASS, &ulong) && ulong == CKO_PUBLIC_KEY);
+			assert (p11_attr_match_value (p11_attrs_find (attrs, CKA_LABEL), "Public prefix key (for wrap template test)", -1));
+			break;
 		default:
 			assert_fail ("Unknown object matched", NULL);
 			break;
@@ -1311,8 +1315,8 @@ test_get_attributes (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, at);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, at);
 
 	p11_kit_iter_free (iter);
 
@@ -1363,6 +1367,10 @@ test_load_attributes (void)
 			assert (p11_attrs_find_ulong (attrs, CKA_CLASS, &ulong) && ulong == CKO_PUBLIC_KEY);
 			assert (p11_attr_match_value (p11_attrs_find (attrs, CKA_LABEL), "Public prefix key", -1));
 			break;
+		case MOCK_PUBLIC_KEY_PREFIX_2:
+			assert (p11_attrs_find_ulong (attrs, CKA_CLASS, &ulong) && ulong == CKO_PUBLIC_KEY);
+			assert (p11_attr_match_value (p11_attrs_find (attrs, CKA_LABEL), "Public prefix key (for wrap template test)", -1));
+			break;
 		default:
 			assert_fail ("Unknown object matched", NULL);
 			break;
@@ -1375,8 +1383,8 @@ test_load_attributes (void)
 
 	assert (rv == CKR_CANCEL);
 
-	/* Three modules, each with 1 slot, and 3 public objects */
-	assert_num_eq (9, at);
+	/* Three modules, each with 1 slot, and 4 public objects */
+	assert_num_eq (12, at);
 
 	p11_kit_iter_free (iter);
 
@@ -1582,7 +1590,7 @@ test_destroy_object (void)
 
 /* Test all combinations of P11_KIT_ITER_WITH_{TOKENS,SLOTS,MODULES}
  * and P11_KIT_ITER_WITHOUT_OBJECTS, against three modules, each
- * with 1 slot, and 3 public objects */
+ * with 1 slot, and 4 public objects */
 static void
 test_exhaustive_match (void)
 {
@@ -1590,7 +1598,7 @@ test_exhaustive_match (void)
 	P11KitIter *iter;
 	CK_RV rv;
 	int counts[] = {
-		9, 12, 12, 15, 12, 15, 15, 18, 0, 3, 3, 6, 3, 6, 6, 9
+		12, 15, 15, 18, 15, 18, 18, 21, 0, 3, 3, 6, 3, 6, 6, 9
 	};
 	int count;
 	int i;

--- a/p11-kit/test-mock.c
+++ b/p11-kit/test-mock.c
@@ -603,6 +603,54 @@ test_set_attribute_value (void)
 }
 
 static void
+test_wrap_template (void)
+{
+	CK_FUNCTION_LIST_PTR module;
+	CK_SESSION_HANDLE session = 0;
+	CK_ATTRIBUTE attrs[1];
+	CK_ATTRIBUTE template[1];
+	//CK_ATTRIBUTE temp[1];
+	CK_BBOOL local = CK_FALSE;
+	CK_RV rv;
+
+	module = setup_mock_module (&session);
+
+	template[0].type = CKA_LOCAL;
+	template[0].pValue = &local;
+	template[0].ulValueLen = sizeof (local);
+	attrs[0].type = CKA_WRAP_TEMPLATE;
+	attrs[0].pValue = &template;
+	attrs[0].ulValueLen = sizeof (template);
+
+	fprintf(stderr, "\n");
+	fprintf(stderr, "setting attrs.type = %lu\n", attrs[0].type);
+	fprintf(stderr, "setting attrs.pValue = %p\n", attrs[0].pValue);
+	fprintf(stderr, "setting attrs.ulValueLen = %lu\n\n", attrs[0].ulValueLen);
+        fprintf(stderr, "calling C_SetAttributeValue\n");
+	rv = (module->C_SetAttributeValue) (session, MOCK_PUBLIC_KEY_PREFIX_2, attrs, 1);
+        fprintf(stderr, "finished C_SetAttributeValue %ld\n", rv);
+	assert (rv == CKR_OK);
+
+	local = !local;
+/*
+	temp[0].type = CKA_WRAP_TEMPLATE;
+	temp[0].pValue = NULL;
+	temp[0].ulValueLen = 0;
+
+	rv = (module->C_GetAttributeValue) (session, MOCK_PUBLIC_KEY_PREFIX_2, temp, 1);
+	assert (rv == CKR_OK);
+
+	assert_num_eq (temp[0].ulValueLen, sizeof (template));
+*/
+	rv = (module->C_GetAttributeValue) (session, MOCK_PUBLIC_KEY_PREFIX_2, attrs, 1);
+	assert (rv == CKR_OK);
+
+	assert (!local);
+
+	teardown_mock_module (module);
+}
+
+static void
 test_create_object (void)
 {
 	CK_FUNCTION_LIST_PTR module;
@@ -1660,6 +1708,7 @@ test_mock_add_tests (const char *prefix)
 	p11_test (test_login_logout, "%s/test_login_logout", prefix);
 	p11_test (test_get_attribute_value, "%s/test_get_attribute_value", prefix);
 	p11_test (test_set_attribute_value, "%s/test_set_attribute_value", prefix);
+	p11_test (test_wrap_template, "%s/test_wrap_template", prefix);
 	p11_test (test_create_object, "%s/test_create_object", prefix);
 	p11_test (test_copy_object, "%s/test_copy_object", prefix);
 	p11_test (test_destroy_object, "%s/test_destroy_object", prefix);


### PR DESCRIPTION
Adding support for recursive attributes like CKA_WRAP_TEMPLATE.
This MR is just a draft and is full of debugging code.

Signed-off-by: Zoltan Fridrich <zfridric@redhat.com>