### PR TITLE
server: Check SHELL only when neither --sh nor --csh is specified

### DIFF
--- a/p11-kit/server.c
+++ b/p11-kit/server.c
@@ -780,7 +780,7 @@ main (int argc,
 		return 2;
 	}
 
-	if (!csh_opt) {
+	if (!opt_sh && !opt_csh) {
 		const char *shell = secure_getenv ("SHELL");
 		size_t len;
 		if (shell != NULL && (len = strlen (shell)) > 2 &&


### PR DESCRIPTION
Previously C shell syntax is used for printing environment variable setup even if --sh is given when SHELL is csh.

Reported in:
https://github.com/p11-glue/p11-kit/issues/437

Fixes: #437
Signed-off-by: Daiki Ueno <ueno@gnu.org>