### PR TITLE
po: Update translations from Transifex

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -53,6 +53,7 @@ pt
 pt_BR
 ro
 ru
+si
 sk
 sl
 sq

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,21 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Arabic (http://www.transifex.com/freedesktop/p11-kit/language/ar/)\n"
+"Language-Team: Arabic (http://www.transifex.com/freedesktop/p11-kit/language/"
+"ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +428,1007 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/as.po
+++ b/po/as.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Assamese (http://www.transifex.com/freedesktop/p11-kit/language/as/)\n"
+"Language-Team: Assamese (http://www.transifex.com/freedesktop/p11-kit/"
+"language/as/)\n"
+"Language: as\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: as\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -3,340 +3,1428 @@
 # This file is distributed under the same license as the p11-kit package.
 #
 # Translators:
+# enolp <enolp@softastur.org>, 2018
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-08-27 03:16+0000\n"
-"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Asturian (http://www.transifex.com/freedesktop/p11-kit/language/ast/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: enolp <enolp@softastur.org>, 2018\n"
+"Language-Team: Asturian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ast/)\n"
+"Language: ast\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ast\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
-msgstr ""
+msgstr "Encaboxóse la operación"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
-msgstr ""
+msgstr "Nun hai memoria abondo disponible"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
-msgstr ""
+msgstr "La ID especificada de la ranula nun ye válida"
 
 #: p11-kit/messages.c:85
 msgid "Internal error"
-msgstr ""
+msgstr "Fallu internu"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr ""
+msgstr "Falló la operación"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
-msgstr ""
+msgstr "Los argumentos nun son válidos"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr ""
+msgstr "El módulu nun pue crear los filos precisos"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
-msgstr ""
+msgstr "El módulu nun pue bloquiar afayadizamente los datos"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr ""
+msgstr "El campu ye de namái llectura"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
-msgstr ""
+msgstr "El campu ye sensible y nun pue revelase"
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
-msgstr ""
+msgstr "El campu nun ye válidu o nun esiste"
 
 #: p11-kit/messages.c:101
 msgid "Invalid value for field"
-msgstr ""
+msgstr "Valor non válidu pal campu"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr ""
+msgstr "Los datos nun son válidos o nun se reconocen"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
-msgstr ""
+msgstr "Los datos son perllargos"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
-msgstr ""
+msgstr "Asocedió un fallu nel preséu"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr ""
+msgstr "Hai hai memoria abondo disponible nel preséu"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
-msgstr ""
+msgstr "Estráxose o desconeutóse'l preséu"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr ""
+msgstr "Los datos cifraos nun son válidos o nun se reconocen"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
-msgstr ""
+msgstr "Los datos cifraos son perllargos"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
-msgstr ""
+msgstr "Esta operación nun ta sofitada"
 
 #: p11-kit/messages.c:119
 msgid "The key is missing or invalid"
-msgstr ""
+msgstr "Falta la clave o nun ye válida"
 
 #: p11-kit/messages.c:121
 msgid "The key is the wrong size"
-msgstr ""
+msgstr "La clave tien un tamañu incorreutu"
 
 #: p11-kit/messages.c:123
 msgid "The key is of the wrong type"
-msgstr ""
+msgstr "La clave ye d'una triba incorreuta"
 
 #: p11-kit/messages.c:125
 msgid "No key is needed"
-msgstr ""
+msgstr "Nun se precisa denguna clave"
 
 #: p11-kit/messages.c:127
 msgid "The key is different than before"
-msgstr ""
+msgstr "La clave ye diferente a enantes"
 
 #: p11-kit/messages.c:129
 msgid "A key is needed"
-msgstr ""
+msgstr "Precísase una clave"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
-msgstr ""
+msgstr "Nun pue incluyise la clave nel resume"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
-msgstr ""
+msgstr "Esta operación nun pue facese con esta clave"
 
 #: p11-kit/messages.c:135
 msgid "The key cannot be wrapped"
-msgstr ""
+msgstr "La clave nun pue axustase"
 
 #: p11-kit/messages.c:137
 msgid "Cannot export this key"
-msgstr ""
+msgstr "Nun pue esportase esta clave"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr ""
+msgstr "El criptomecanísmu nun ye válidu o nun se reconoz"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
-msgstr ""
+msgstr "El criptomecanismu tien un argumentu non válidu"
 
 #: p11-kit/messages.c:143
 msgid "The object is missing or invalid"
-msgstr ""
+msgstr "Falta l'oxetu o nun ye válidu"
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr ""
+msgstr "Yá ta faciéndose otra operación"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
-msgstr ""
+msgstr "Nun ta faciéndose denguna operación"
 
 #: p11-kit/messages.c:149
 msgid "The password or PIN is incorrect"
-msgstr ""
+msgstr "La contrase o'l PIN nun son correutos"
 
 #: p11-kit/messages.c:151
 msgid "The password or PIN is invalid"
-msgstr ""
+msgstr "La contraseña o'l PIN nun son válidos"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr ""
+msgstr "La contraseña o'l PIN son d'un llargor que nun ye válidu"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
-msgstr ""
+msgstr "La contraseña o'l PIN caducó"
 
 #: p11-kit/messages.c:157
 msgid "The password or PIN is locked"
-msgstr ""
+msgstr "La contraseña o'l PIN tán bloquiaos"
 
 #: p11-kit/messages.c:159
 msgid "The session is closed"
-msgstr ""
+msgstr "Zarróse la sesión"
 
 #: p11-kit/messages.c:161
 msgid "Too many sessions are active"
-msgstr ""
+msgstr "Hai milenta sesiones actives"
 
 #: p11-kit/messages.c:163
 msgid "The session is invalid"
-msgstr ""
+msgstr "La sesión nun ye válida"
 
 #: p11-kit/messages.c:165
 msgid "The session is read-only"
-msgstr ""
+msgstr "La sesión ye de namái llecutra"
 
 #: p11-kit/messages.c:167
 msgid "An open session exists"
-msgstr ""
+msgstr "Esiste una sesión abierta"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
-msgstr ""
+msgstr "Esiste una sesión de namái llectura"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
-msgstr ""
+msgstr "Esiste una sesión d'alministrador"
 
 #: p11-kit/messages.c:173
 msgid "The signature is bad or corrupted"
-msgstr ""
+msgstr "La robla ye incorreuta o ta toyida"
 
 #: p11-kit/messages.c:175
 msgid "The signature is unrecognized or corrupted"
-msgstr ""
+msgstr "Nun se reconoz la robla o ta toyida"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
-msgstr ""
+msgstr "Falten ciertos campos riquíos"
 
 #: p11-kit/messages.c:179
 msgid "Certain fields have invalid values"
-msgstr ""
+msgstr "Ciertos campos tienen valores non válidos"
 
 #: p11-kit/messages.c:181
 msgid "The device is not present or unplugged"
-msgstr ""
+msgstr "Desconeutóse'l preséu o nun ta presente"
 
 #: p11-kit/messages.c:183
 msgid "The device is invalid or unrecognizable"
-msgstr ""
+msgstr "El preséu ye irreconocible o non válidu"
 
 #: p11-kit/messages.c:185
 msgid "The device is write protected"
-msgstr ""
+msgstr "El preséu ta protexíu escontra escritura"
 
 #: p11-kit/messages.c:187
 msgid "Cannot import because the key is invalid"
-msgstr ""
+msgstr "Nun pue importase porque la clave nun ye válida"
 
 #: p11-kit/messages.c:189
 msgid "Cannot import because the key is of the wrong size"
-msgstr ""
+msgstr "Nun pue importase porque la clave tien un tamañu incorreutu"
 
 #: p11-kit/messages.c:191
 msgid "Cannot import because the key is of the wrong type"
-msgstr ""
+msgstr "Nun pue importase porque la clave ye d'una triba incorreuta"
 
 #: p11-kit/messages.c:193
 msgid "You are already logged in"
-msgstr ""
+msgstr "Yá aniciesti sesión"
 
 #: p11-kit/messages.c:195
 msgid "No user has logged in"
-msgstr ""
+msgstr "Dengún usuariu anició sesión"
 
 #: p11-kit/messages.c:197
 msgid "The user's password or PIN is not set"
-msgstr ""
+msgstr "Nun s'afitó la contraseña o'l PIN del usuariu"
 
 #: p11-kit/messages.c:199
 msgid "The user is of an invalid type"
-msgstr ""
+msgstr "L'usuariu ye d'una triba non válida"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
-msgstr ""
+msgstr "Otru usuariu yá anició sesión"
 
 #: p11-kit/messages.c:203
 msgid "Too many users of different types are logged in"
-msgstr ""
+msgstr "Aniciaron sesión milenta usuarios de tribes diferentes"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
-msgstr ""
+msgstr "Nun pue importase una clave non válida"
 
 #: p11-kit/messages.c:207
 msgid "Cannot import a key of the wrong size"
-msgstr ""
+msgstr "Nun pue importase una clave d'un tamañu incorreutu"
 
 #: p11-kit/messages.c:209
 msgid "Cannot export because the key is invalid"
-msgstr ""
+msgstr "Nun pue esportase porque la clave nun ye válida"
 
 #: p11-kit/messages.c:211
 msgid "Cannot export because the key is of the wrong size"
-msgstr ""
+msgstr "Nun pue esportase porque la clave ye d'un tamañu incorreutu"
 
 #: p11-kit/messages.c:213
 msgid "Cannot export because the key is of the wrong type"
-msgstr ""
+msgstr "Nun pue esportase porque la clave ye d'una triba incorreuta"
 
 #: p11-kit/messages.c:215
 msgid "Unable to initialize the random number generator"
-msgstr ""
+msgstr "Nun pue aniciase'l xenerador de númberos al debalu"
 
 #: p11-kit/messages.c:217
 msgid "No random number generator available"
-msgstr ""
+msgstr "Nun hai dengún xenerador de númberos al debalu"
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
-msgstr ""
+msgstr "El criptomecanismu tien un parámetru non válidu"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
-msgstr ""
+msgstr "Nun hai espaciu abondo p'atroxar el resultáu"
 
 #: p11-kit/messages.c:223
 msgid "The saved state is invalid"
-msgstr ""
+msgstr "L'estáu de guardáu nun ye válidu"
 
 #: p11-kit/messages.c:225
 msgid "The information is sensitive and cannot be revealed"
-msgstr ""
+msgstr "La información ye sensible y nun pue revelase"
 
 #: p11-kit/messages.c:227
 msgid "The state cannot be saved"
-msgstr ""
+msgstr "Nun pue guardase l'estáu"
 
 #: p11-kit/messages.c:229
 msgid "The module has not been initialized"
-msgstr ""
+msgstr "Nun s'anició'l módulu"
 
 #: p11-kit/messages.c:231
 msgid "The module has already been initialized"
-msgstr ""
+msgstr "Yá s'anició'l módulu"
 
 #: p11-kit/messages.c:233
 msgid "Cannot lock data"
-msgstr ""
+msgstr "Nun puen bloquiase los datos"
 
 #: p11-kit/messages.c:235
 msgid "The data cannot be locked"
-msgstr ""
+msgstr "Los datos nun puen bloquiase"
 
 #: p11-kit/messages.c:237
 msgid "The request was rejected by the user"
-msgstr ""
+msgstr "La solicitú refugóla l'usuariu"
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr "Desconozse'l fallu"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Azerbaijani (http://www.transifex.com/freedesktop/p11-kit/language/az/)\n"
+"Language-Team: Azerbaijani (http://www.transifex.com/freedesktop/p11-kit/"
+"language/az/)\n"
+"Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: az\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/freedesktop/p11-kit/language/bg/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Bulgarian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Bengali (India) (http://www.transifex.com/freedesktop/p11-kit/language/bn_IN/)\n"
+"Language-Team: Bengali (India) (http://www.transifex.com/freedesktop/p11-kit/"
+"language/bn_IN/)\n"
+"Language: bn_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bn_IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015
+# Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 19:43+0000\n"
-"Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
-"Language-Team: Catalan (http://www.transifex.com/freedesktop/p11-kit/language/ca/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015\n"
+"Language-Team: Catalan (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr "La petició va ser rebutjada per l'usuari"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Error desconegut"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Catalan (Valencian) (http://www.transifex.com/freedesktop/p11-kit/language/ca@valencia/)\n"
+"Language-Team: Catalan (Valencian) (http://www.transifex.com/freedesktop/p11-"
+"kit/language/ca@valencia/)\n"
+"Language: ca@valencia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca@valencia\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,23 +1,112 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Jozef Mlích <xmlich02@stud.fit.vutbr.cz>, 2015
+# Jozef Mlích <jmlich83@gmail.com>, 2015
 # Marek Černocký <marek@manet.cz>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 13:59+0000\n"
-"Last-Translator: Marek Černocký <marek@manet.cz>\n"
-"Language-Team: Czech (http://www.transifex.com/freedesktop/p11-kit/language/cs/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Marek Černocký <marek@manet.cz>, 2016\n"
+"Language-Team: Czech (http://www.transifex.com/freedesktop/p11-kit/language/"
+"cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -342,3 +431,1004 @@ msgstr "Požadavek byl zamítnut uživatelem"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Neznámá chyba"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/cy.po
+++ b/po/cy.po
@@ -1,21 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Welsh (http://www.transifex.com/freedesktop/p11-kit/language/cy/)\n"
+"Language-Team: Welsh (http://www.transifex.com/freedesktop/p11-kit/language/"
+"cy/)\n"
+"Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cy\n"
-"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
+"11) ? 2 : 3;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +428,1005 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -1,22 +1,116 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Joe Hansen <joedalton2@yahoo.dk>, 2013
+# scootergrisen, 2021
+# scootergrisen, 2021
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 19:43+0000\n"
-"Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"
-"Language-Team: Danish (http://www.transifex.com/freedesktop/p11-kit/language/da/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: scootergrisen, 2021\n"
+"Language-Team: Danish (http://www.transifex.com/freedesktop/p11-kit/language/"
+"da/)\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "anvendelse: %s kommando <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Almindelige %s-kommandoer er:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Se '%s <command> --help' for mere information\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "ingen kommando angivet"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "ukendt globalt tilvalg: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "ukendt globalt tilvalg: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' er ikke en gyldig kommando. Se '%s --help'"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: uventet pem-blok"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: uventet section-hoved"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "ugyldig tilstand for 'user-config': %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "ugyldigt filnavn for konfiguration — ignoreres i fremtiden: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "kunne ikke vise mappe: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "kunne ikke stat sti: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "ugyldig indstilling '%s' — bruger standarden '%s'"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "filter kan ikke initieres"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "kunne ikke indlæse modulinformation: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "ekstra argumenter angivet"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -180,7 +274,7 @@ msgstr "Adgangskoden eller PIN er låst"
 
 #: p11-kit/messages.c:159
 msgid "The session is closed"
-msgstr "Sessionen er låst"
+msgstr "Sessionen er lukket"
 
 #: p11-kit/messages.c:161
 msgid "Too many sessions are active"
@@ -292,7 +386,7 @@ msgstr "Kan ikke eksportere da nøglen har forkert type"
 
 #: p11-kit/messages.c:215
 msgid "Unable to initialize the random number generator"
-msgstr "Kan ikke initialisere oprettelsesprogrammet for vilkårlige tal"
+msgstr "Kan ikke initiere oprettelsesprogrammet for vilkårlige tal"
 
 #: p11-kit/messages.c:217
 msgid "No random number generator available"
@@ -320,11 +414,11 @@ msgstr "Tilstanden kan ikke gemmes"
 
 #: p11-kit/messages.c:229
 msgid "The module has not been initialized"
-msgstr "Modulet er ikke blevet initialiseret"
+msgstr "Modulet er ikke blevet initieret"
 
 #: p11-kit/messages.c:231
 msgid "The module has already been initialized"
-msgstr "Modulet er allerede blevet initialiseret"
+msgstr "Modulet er allerede blevet initieret"
 
 #: p11-kit/messages.c:233
 msgid "Cannot lock data"
@@ -341,3 +435,1011 @@ msgstr "Forespørgslen blev afvist af brugeren"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Ukendt fejl"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "kunne ikke indlæse modul: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "kunne ikke finde postpunktet C_GetFunctionList i modul: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "kald til C_GetFunctiontList mislykkedes i modul: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr "nægter at indlæse modulet p11-kit-proxy.so som et registreret modul"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "modulet '%s' har begge tilvalgene enable-in og disable-in"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "afbryder initiering da modulet '%s' blev markeret som kritisk"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit initiering kaldt rekursivt"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "initiering af kritisk modul '%s' mislykkedes: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "Springer over modulet '%s' da dens initiering mislykkedes: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "kunne ikke lukke session: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+"Tilvalget '%s' til modulet '%s' understøttes kun til håndterede moduler"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: modul kunne ikke initiere: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: modul kunne ikke initiere%s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: modul var allerede initieret"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: modul kunne ikke færdiggøre: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "initiering af modul mislykkedes: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Vis moduler og tokens"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Kør et bestemt PKCS#11-modul eksternt"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Kør en serverproces der eksporerer PKCS#11-modul eksternt"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "kunne ikke køre tillidsværktøj"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' er ikke en gyldig kommando. Se 'p11-kit --help'"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "angiv et modul eller tokens til eksterne"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "værktøjet 'remote' er ikke beregnet til at blive kørt fra en terminal"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "der kan kun angives ét modul"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "ugyldigt svar fra rpc-fejl: for kort"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "ugyldigt svar fra rpc-fejl: dårlig fejlkode"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "ugyldigt svar fra rpc-fejl: kald uoverensstemmelse"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "ugyldigt svar fra rpc-fejl: dårlig argumentdata"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "modtog et attributarray med forkert antal attributter"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "returnerede attributter i ugyldig rækkefølge"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "ugyldigt sæt mutexkald angivet"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "kan ikke foretage låsning af styresystem"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize kaldt to gange på samme proces"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "færdiggjort rpc-modul returnerede en fejl: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "ugyldig meddelelse: kunne ikke læse kaldindentifikator"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "ugyldig meddelelse: dårligt kaldid: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "ugyldig meddelelse: kunne ikke læse underskrift"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "ugyldig meddelelse: underskrift passer ikke"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "ugyldig længde mellemsrumstilført streng modtaget: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "ugyldig anmodning fra modul — formodentligt for kort"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "kunne ikke initiere rpc-svar"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "ugyldigt håndtryk modtaget fra modul som opretter forbindelse"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "kunne ikke fortolke pkcs11 rpc-meddelelse"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "ikke mere ledig hukommelse ved oprettelse af meddelelse"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "ikke mere ledig hukommelse ved svar med fejl"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "modtog version som ikke understøttes: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "kan ikke læse loginoplysningsbyte"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "kan ikke skrive loginoplysningsbyte"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "kunne ikke læse rpc-meddelelse"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "uventet fejl ved håndtering af rpc-meddelelse"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "kunne ikke skrive rpc-meddelelse"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "kunne ikke sende data: lukket forbindelse"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "kunne ikke sende data"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "kunne ikke modtage data: lukket forbindelse"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "kunne ikke modtage data"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "modtog ugyldig rpc-headerværdier: måske forkert protokol"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "kunne ikke bruge select til at vente på rpc-pipe"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "kan ikke send sokkelloginoplysninger"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "kan ikke send sokkelloginoplysninger"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "lukker sokkel pga. protokolfejl"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "processen %d fandtes ikke — terminerer"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "kunne ikke vente på kørt barn: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "processen %d afsluttede med statussen %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "processen %d blev termineret med signalet %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "kunne ikke oprette pipe for eksterne"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "kunne ikke fork for eksterne"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "processen %p fandtes ikke — terminerer"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "kunne ikke terminere processen %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "kunne ikke vente på kørt barn: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "kunne ikke hente afslutningsstatus på %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "processen %p afsluttede med statussen %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "kunne ikke duplikere stdin"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "kunne ikke duplikere stdout"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "kunne ikke duplikere barns slutning på pipe"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "kunne ikke starte eksterne"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "kunne ikke genskabe filbeskrivere"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "ugyldig eksterne kommandolinje: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "kunne ikke oprette sokkel for eksterne"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "kunne ikke fortolke vsock-adresse: '%s'"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "eksterne understøttes ikke: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "barnet %u døede med sigsegv"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "barnet %u døede med signalet %d"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "kunne ikke oprette soklen %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "kunne ikke binde soklen %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "kunne ikke lytte til soklen %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "kunne ikke chown soklen %s"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "kunne ikke oprette soklen %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "kunne ikke binde soklen %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "kunne ikke lytte til soklen %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "kunne ikke tjekke uid fra sokkel"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "forbindende uid (%u) passer ikke forventede (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "forbindende gid (%u) passer ikke forventede (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "kunne ikke fork() for at dæmonisere"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "kunne ikke oprette en ny session"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "for mange filbeskrivere modtaget"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "ingen forbindelser til %s i %lu sekunder — afslutter"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "kunne ikke acceptere fra soklen %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "kunne ikke fork for at acceptere"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "ukendt gruppe: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "ukendt bruger: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "kan ikke set gid til %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "kan ikke setgroups til %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "kan ikke set uid til %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "kunne ikke beslutte runtime-mappe"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "kan ikke oprette %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "kunne ikke initiere Windows-sikkerhedsfunktioner"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "kan ikke konstruere SID for %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "kan ikke konstruere ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "kan ikke allokere sikkerhedsbeskriver: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "kan ikke initiere sikkerhedsbeskriver: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "kan ikke indstille ejer i sikkerhedsbeskriver: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "kan ikke indstille DACL i sikkerhedsbeskriver: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "ugyldig PKCS#11-uri: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "filformat ikke genkendt: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "kunne ikke fortolke fil: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: kunne ikke initiere: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: kunne ikke enumerate pladser: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: kunne ikke hente tokeninformation: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: kunne ikke åbne session: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr "ingen konfigureret skrivbar placering til at gemme ankre"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "ingen konfigureret placering til at gemme ankre"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "kunne ikke oprette objekt: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "angiv mindst én ankerinputfil"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "kunne ikke fjene skrivebeskyttede %s"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "kunne ikke fjerne %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "mindst én fil eller uri skal være angivet"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "en handling var allerede angivet"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u fejl ved behandling"
+msgstr[1] "%u fejl ved behandling"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: ugyldig certifikatudvidelse"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: ugyldig certifikatudvidelse med grundlæggende restriktioner"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "ukendt"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "mangler attributten CKA_HASH_OF_SUBJECT_PUBLIC_KEY"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "mangler attributten CKA_HASH_OF_ISSUER_PUBLIC_KEY"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "objektet kan ikke ændres"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "objekter af denne type kan ikke oprettes"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "attributten %s kan ikke indstilles"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "attributten %s kan ikke ændres"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "attributten %s har en ugyldig værdi"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "attributten %s er ikke gyldig for objektet"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "mangler attributten %s"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "ingen CKA_CLASS-attribut fundet"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "kan ikke oprette et %s-objekt"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "token"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "ikke-token"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "mangler %s på objekt"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s ikke-understøttet %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s ikke-understøttet objektklasse"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "ugyldig certifikatudvidelse med nøgleavendelse"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "ugyldig certifikatudvidelse med udvidet nøgleavendelse"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "ugyldig certifikatudvidelse med afvis nøgleavendelse"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "kunne ikke dumpe objekt"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "ekstra argumenter videregivet til kommando"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "kunne ikke fortolke vedhæftede certifikatudvidelse: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "kunne ikke indlæse vedhæftede udvidelser for certifikat: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "kunne ikke fortolke certifikat: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "kunne ikke indlæse attributter: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "springer over objekt som ikke er certifikat"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "kunne ikke indlæse blokliste: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "en PKCS#11-URI er allerede blevet angivet"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "kunne ikke fortolke epkcs11 uri-filter: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "uri'en indeholder komponenter som ikke genkendes — intet udtrækkes"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "ikke-understøttet eller ikke-genkendt filter: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "ikke-understøttet eller ikke-genkendt formål: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "der er ikke registreret nogen moduler med tillidsregel"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "et format var allerede angivet"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "ikke-understøttet eller ikke-genkendt format: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "format understøtter ikke tillidsregel"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"format krævet et formål — angiv det med --purpose; bruger standarden 'server-"
+"auth'"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+"format understøtter ikke mere end ét formål — bruger standarden 'server-auth'"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "angiv en distinationsfil eller -mappe"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "intet outputformat angivet"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "kunne ikke køre kommandoen %s"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr "flere certifikater fundet men kunne kun skrive ét til fil"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "kunne ikke finde certifikater: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "intet certifikat fundet"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "kunne ikke finde certifikat: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "afkorter lang streng"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Miljøvariablen $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "Miljøvariablen $SOURCE_DATE_EPOCH: Ingen cifre blev fundet: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Miljøvariablen $SOURCE_DATE_EPOCH: Efterstillet affald: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Miljøvariablen $SOURCE_DATE_EPOCH: værdien skal være mindre end eller lig "
+"med %lu men den var: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "kunne ikke generere et certifikataliasnavn"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "springer over objekt — kunne ikke bygge uri"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "modulargument ikke genkendt: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "certifikat med mistillid i placering for ankre: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "tilsidesætter tillid for anker i blokeringsliste: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "Kunne ikke fortolke PEM-blok af typen %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "kunne ikke åbne og kortlægge fil: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "ugyldig oid-værdi: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "kunne ikke oprette fil: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "kunne ikke skrive til fil: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "kunne ikke færdiggøre skrivning af fil: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "kunne ikke skrive fil: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "kunne ikke indstille filens tilladelser: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "kunne ikke færdiggøre skrivning af fil: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "kunne ikke fjene oprindelige fil: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "kunne ikke oprette mappe: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "mappen findes allerede: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "kunne ikke oprette mappe: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "kunne ikke indstille mappens tilladelser: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "kunne ikke gøre mappen skrivbar: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "kunne ikke oprette symlink: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "kunne ikke fjerne fil: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "kunne ikke indstille mappens tilladelser: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "kunne ikke indlæse fil ind i objekter: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "kunne ikke stat sti: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "kan ikke få adgang til tillidscertifikatsti: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "kan ikke få adgang til tillidsfil: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "kunne ikke tilgå: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "kunne ikke fortolke certifikat: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "intet certifikat fundet"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -1,23 +1,115 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Ettore Atalan <atalanttore@googlemail.com>, 2014
+# Ettore Atalan <atalanttore@googlemail.com>, 2014,2021
 # Mario Blättermann <mario.blaettermann@gmail.com>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:15+0000\n"
-"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
-"Language-Team: German (http://www.transifex.com/freedesktop/p11-kit/language/de/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>, 2014,2021\n"
+"Language-Team: German (http://www.transifex.com/freedesktop/p11-kit/language/"
+"de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "Aufruf: %s Befehl <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Gebräuchliche %s Befehle sind:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Siehe '%s <command> --help' für weitere Informationen\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "kein Befehl angegeben"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "unbekannte globale Option: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "unbekannte globale Option: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' ist kein gültiger Befehl. Siehe '%s --help'"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "ungültiger Modus für 'user-config': %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "ungültiger Konfigurationsdateiname, wird in Zukunft ignoriert: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "konnte Verzeichnis nicht auflisten: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "Filter kann nicht initialisiert werden"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "zusätzliche Argumente angegeben"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -89,7 +181,9 @@ msgstr "Das Gerät wurde entfernt oder abgezogen."
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr "Die verschlüsselten Daten sind nicht gültig oder konnten nicht erkannt werden."
+msgstr ""
+"Die verschlüsselten Daten sind nicht gültig oder konnten nicht erkannt "
+"werden."
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
@@ -141,7 +235,9 @@ msgstr "Dieser Schlüssel kann nicht exportiert werden."
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr "Der kryptografische Mechanismus ist ungültig oder konnte nicht erkannt werden."
+msgstr ""
+"Der kryptografische Mechanismus ist ungültig oder konnte nicht erkannt "
+"werden."
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
@@ -342,3 +438,1010 @@ msgstr "Der Anfrage wurde vom Benutzer abgelehnt"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "konnte Modul nicht laden: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "Aufruf von C_GetFunctiontList fehlgeschlagen in Modul: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+"Initialisierung wird abgebrochen, weil Modul '%s' als kritisch markiert wurde"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit-Initialisierung rekursiv aufgerufen"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "Initialisierung des kritischen Moduls '%s' fehlgeschlagen: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+"Modul '%s', dessen Initialisierung fehlgeschlagen ist, wird übersprungen: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "konnte Sitzung nicht schließen: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+"die Option '%s' für das Modul '%s' wird nur für verwaltete Module unterstützt"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: konnte nicht initialisieren: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: Modul wurde bereits initialisiert"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "Modulinitialisierung fehlgeschlagen: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Module und Token auflisten"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Ein bestimmtes PKCS#11-Modul aus der Ferne ausführen"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+"Einen Serverprozess ausführen, der das PKCS#11-Modul aus der Ferne "
+"zugänglich macht"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' ist kein gültiger Befehl. Siehe 'p11-kit --help'"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "es kann nur ein Modul angegeben werden"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "zurückgegebene Attribute in ungültiger Reihenfolge"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "ungültiger Satz von Mutex-Aufrufen geliefert"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "kann nicht auf eine Betriebssystemsperre verzichten"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize wurde zweimal für den gleichen Prozess aufgerufen"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "ungültige Nachricht: konnte Aufrufkennung nicht lesen"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "ungültige Nachricht: falsche Aufrufkennung: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "ungültige Nachricht: konnte Signatur nicht lesen"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "ungültige Nachricht: Signatur stimmt nicht überein"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "ungültige Anfrage vom Modul, wahrscheinlich zu kurz"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "ungültiger Handschlag vom Verbindungsmodul erhalten"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "kein Speicher mehr verfügbar reagiert mit Fehler"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "nicht unterstützte Version erhalten: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "konnte Zugangsdaten-Byte nicht lesen"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "konnte Zugangsdaten-Byte nicht schreiben"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "konnte keine Daten senden: geschlossene Verbindung"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "konnte keine Daten senden"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "konnte keine Daten empfangen: geschlossene Verbindung"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "konnte keine Daten empfangen"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "konnte keine Socket-Zugangsdaten senden"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "konnte keine Socket-Zugangsdaten senden"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "Prozess %d hat sich nicht beendet, wird terminiert"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "Prozess %d mit Status %d beendet"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "Prozess %d wurde mit Signal %d terminiert"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "Prozess %p hat sich nicht beendet, wird terminiert"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "konnte Prozess %p nicht terminieren"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "Prozess %p mit Status %lu beendet"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "Fehler beim Duplizieren von stdin"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "Fehler beim Duplizieren von stdout"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "Kind %u Mit Signal %d gestorben"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "konnte Socket %s nicht erstellen"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "konnte keine neue Sitzung erstellen"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "zu viele Dateideskriptoren erhalten"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "unbekannte Gruppe: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "unbekannter Benutzer: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "kann das Laufzeitverzeichnis nicht bestimmen"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "kann %s nicht erstellen"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "nicht erkanntes Dateiformat: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "Fehler beim Parsen der Datei: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: konnte nicht initialisieren: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: konnte Sitzung nicht öffnen: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "konnte Objekt nicht erstellen: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "konnte Schreibschutz %s nicht entfernen"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "konnte %s nicht entfernen: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "es wurde bereits eine Aktion angegeben"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u Fehler bei der Verarbeitung"
+msgstr[1] "%u Fehler bei der Verarbeitung"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: ungültige Zertifikatserweiterung"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "unbekannt"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "das Objekt ist nicht änderbar"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "Objekte dieses Typs können nicht erstellt werden"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "Token"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s nicht unterstützt %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s nicht unterstützte Objektklasse"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "zusätzliche Argumente an den Befehl übergeben"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "konnte Zertifikat nicht parsen: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "konnte Attribute nicht laden: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "Nicht-Zertifikats-Objekt wird übersprungen"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "nicht unterstützter oder nicht erkannter Filter: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "nicht unterstützter oder nicht erkannter Zweck: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "es wurde bereits ein Format angegeben"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "nicht unterstütztes oder nicht erkanntes Format: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "eine Zieldatei oder -verzeichnis angeben"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "kein Ausgabeformat angegeben"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "konnte den Befehl %s nicht ausführen"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "Fehler beim Suchen von Zertifikaten: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "kein Zertifikat gefunden"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "Fehler beim Suchen des Zertifikats: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "lange Zeichenfolge wird abgeschnitten"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Umgebungsvariable $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "Umgebungsvariable $SOURCE_DATE_EPOCH: Keine Ziffern gefunden: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "nicht erkanntes Modulargument: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "konnte Datei nicht öffnen und abbilden: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "ungültiger alter Wert: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "konnte Datei nicht erstellen: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "konnte nicht in die Datei schreiben: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "konnte das Schreiben der Datei nicht abschließen: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "konnte Datei nicht schreiben: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "konnte Dateiberechtigungen nicht festlegen: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "konnte das Schreiben der Datei nicht abschließen: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "konnte die Originaldatei nicht entfernen: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "konnte Verzeichnis nicht erstellen: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "Verzeichnis existiert bereits: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "konnte Verzeichnis nicht erstellen: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "konnte Verzeichnisberechtigungen nicht festlegen: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "konnte das Verzeichnis nicht beschreibbar machen: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "konnte Symlink nicht erstellen: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "konnte Datei nicht erstellen: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "konnte Verzeichnisberechtigungen nicht festlegen: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "konnte Datei nicht in Objekte laden: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "konnte nicht zugreifen: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "konnte Zertifikat nicht parsen: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "kein Zertifikat gefunden"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Maria Mavridou <mavridou@gmail.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 13:46+0000\n"
-"Last-Translator: thanos <tomtryf@gmail.com>\n"
-"Language-Team: Greek (http://www.transifex.com/freedesktop/p11-kit/language/el/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Maria Mavridou <mavridou@gmail.com>, 2014\n"
+"Language-Team: Greek (http://www.transifex.com/freedesktop/p11-kit/language/"
+"el/)\n"
+"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr "Η αίτηση απορρίφθηκε από το χρήστη"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Άγνωστο σφάλμα"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Andi Chandler <andi@gowling.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:45+0000\n"
-"Last-Translator: Andi Chandler <andi@gowling.com>\n"
-"Language-Team: English (United Kingdom) (http://www.transifex.com/freedesktop/p11-kit/language/en_GB/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Andi Chandler <andi@gowling.com>, 2013\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/"
+"freedesktop/p11-kit/language/en_GB/)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr "The request was rejected by the user"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Unknown error"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # kristjan <kristjan.schmidt@googlemail.com>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:07+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Esperanto (http://www.transifex.com/freedesktop/p11-kit/language/eo/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: kristjan <kristjan.schmidt@googlemail.com>, 2012\n"
+"Language-Team: Esperanto (http://www.transifex.com/freedesktop/p11-kit/"
+"language/eo/)\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr ""
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Nekonata eraro"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -1,27 +1,122 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Adolfo Jayme-Barrientos, 2012
-# Daniel Mustieles <inactive+leo@transifex.com>, 2012-2013
+# Adolfo Jayme-Barrientos, 2012
+# 0f759dd1ea6c4c76cedc299039ca4f23_7584d04 <454cc45058db9632179dc8079c0c1af3_5311>, 2012-2013
+# Francisco Serrador, 2022
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:13+0000\n"
-"Last-Translator: Daniel Mustieles <inactive+leo@transifex.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/freedesktop/p11-kit/language/es/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Francisco Serrador, 2022\n"
+"Language-Team: Spanish (http://www.transifex.com/freedesktop/p11-kit/"
+"language/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "modo de empleo: %s instrucción <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Instrucciones %s comunes son:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Vea «%s <command> --help» para más información\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "ninguna instrucción especificada"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "opción global desconocida: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "opción global desconocida: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "«%s» no es una instrucción válido. Vea  «%s --help»"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: bloque pem inesperado"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: cabecera de sección inesperada"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "modo no válido para 'user-config': %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "nombre no válido del archivo config, será descartado en el futuro: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "no pudo enumerar el directorio: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "no pudo especificar ruta: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "parámetro «%s» no válido predeterminando a «%s»"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "filtro no puede ser inicializado"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "no pudo cargar informe del módulo: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "los argumentos adicionales especificados"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
-msgstr "Se canceló la operación"
+msgstr "La operación fue cancelada"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
@@ -37,7 +132,7 @@ msgstr "Error interno"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr "Falló la operación"
+msgstr "La operación ha fallado"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
@@ -169,7 +264,7 @@ msgstr "La contraseña o el PIN no son válidos"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr "La contraseña o PIN tiene una longitud no válida"
+msgstr "La contraseña o el PIN tiene una longitud no válida"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
@@ -342,3 +437,1024 @@ msgstr "El usuario rechazó la solicitud"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Error desconocido"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "no pudo cargar módulo: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+"no pudo encontrar el punto de apunte C_GetFunctionList dentro del módulo: "
+"%s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "invocación errónea a C_GetFunctionList en el módulo: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+"haciendo caso omiso a cargar el módulo p11-kit-proxy.so como un módulo "
+"registrado"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "módulo «%s» tiene ambas opciones activada y desactivada"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+"interrumpiendo inicialización porque el módulo «%s» fue marcado como crítico"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit de inicialización invocada recursivamente"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "inicialización de módulo crítico «%s» erróneo: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "descartando módulo «%s» cuya inicialización falló: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "no pudo cerrar sesión: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+"la opción «%s» para el módulo «%s» solamente está mantenida por módulos "
+"gestionados"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: módulo erróneo al inicializar: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: módulo erróneo al inicializar %s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: módulo ya fue inicializado"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: módulo erróneo al finalizar: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "inicialización de módulo errónea: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Enumera módulos y tickets"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Ejecuta un módulo PKCS#11 específico remotamente"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+"Ejecuta un proceso de servidor que exponga remotamente el módulo PKCS#11"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "no pudo ejecutar herramienta confiada"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "«%s» no es una instrucción válido. Vea «p11-kit --help»"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "especifique un módulo o varios tickets para remoto"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "la herramienta 'remota' no significa ser ejecutada desde un terminal"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "solamente un módulo puede ser especificado"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "respuesta errónea rpc: demasiado breve"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "respuesta errónea rpc: código erróneo"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "respuesta rpc incorrecta: invocación no coincidente"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "respuesta rpc no válida: datos de argumento erróneos"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+"ha recibido un repertorio de atributo con un número equivocado de atributos"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "los atributos devueltos en ordenación no válida"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "conjunto no válido de invocaciones mutex proporcionadas"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "no puede hacer sin bloqueo del SO"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "Se invocó C_Initialize dos veces para el mismo proceso"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "al finalizar el módulo rpc se devolvió un error: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "mensaje no válido: no pudo leer identificador invocado"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "mensaje no válido: ID de invocación erróneo: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "mensaje no válido: no pudo leer firma"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "mensaje no válido: la firma no coincide"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "espacio dejado cadena acolchada no válida recibida: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "solicitud no válida desde módulo, probablemente muy corto"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "no pudo inicializar respuesta rpc"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "negociación no válida recibida desde conexión de módulo"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "no pudo interpretar mensaje rpc de pkcs11"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "error de memoria agotada poniendo mensaje a la vez"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "memoria agotada respondiendo con error"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "versión recibida no está mantenida: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "no pudo leer byte de credenciales"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "no pudo escribir byte credencial"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "erróneo al leer mensaje rpc"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "error inesperado manipulando mensaje rpc"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "erróneo para escribir mensaje rpc"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "no pudo enviar datos: conexión cerrada"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "no pudo enviar datos"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "no pudo recibir datos: conexión cerrada"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "no pudo recibir datos"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "ha recibido valores de cabecera rpc no válido: quizá protocolo erróneo"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "no pudo utilizar selección para espera en tubería rpc"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "no pudo enviar credenciales del zócalo"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "no pudo enviar credenciales del zócalo"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "cerrando zócalo debido a error de protocolo"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "el proceso %d no salió, terminando"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "erróneo al esperar para heredero ejecutado: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "el proceso %d salió con el estado %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "el proceso %d fue terminado con señal %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "error al crear canalización para remoto"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "erróneo al bifurcar para remoto"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "proceso %p no salió, terminando"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "no pudo terminar proceso %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "erróneo al esperar heredero ejecutado: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "erróneo al obtener el estado de salida de %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "proceso %p salió con estado %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "erróneo al duplicar entrada estándar"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "erróneo al duplicar salida estándar"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "erróneo al duplicar herencia final de canalización"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "erróneo en reproducción remota"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "erróneo al restaurar descriptores de archivo"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "línea no válida de instrucción remota: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "erróneo al crear zócalo para remoto"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "erróneo al interpretar dirección vzócalo: «%s»"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "remoto no mantenido: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "%u heredado murió con sigsegv"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "%u heredado murió con la señal %d"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "no se pudo crear zócalo %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "no se pudo vincular zócalo %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "no se pudo escuchas al zócalo %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "no se pudo cambiar propietario al zócalo %s"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "no se pudo crear zócalo %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "no se pudo vincular zócalo %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "no se pudo escuchar al zócalo %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "no se pudo marcar el uid desde zócalo"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "conectando uid (%u) no coincide con lo esperado (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "conectando gid (%u) no coincide con lo esperado (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "no se pudo ejecutar fork() para endemoniar"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "no se pudo crear una sesión nueva"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "demasiados descriptores de archivo recibido"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "ningunas conexiones a %s para %lu segs, saliendo"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "no se pudo aceptar desde zócalo %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "erróneo al bifurcar para aceptar"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "grupo desconocido: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "usuario desconocido: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "no se puede fijar gid a %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "no se puede fijar grupos a %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "no se puede fijar uid a %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "no se puede determinar el directorio en tiempo de ejecución"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "no se puede crear %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "no pudo inicializar funciones de seguridad Windows®"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "imposible construir SID para %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "imposible construir ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "no es capaz de asignar descriptor de seguridad: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "no es capaz de inicializar descriptor de seguridad: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "no puede fijar propietario dentro de descriptor de seguridad: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "no es capaz de fijar DACL en descriptor de seguridad: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "invalida uri PKCS#11: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "no reconoció el formato del archivo: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "erróneo al interpretar archivo: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: no pudo inicializar: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: no pudo enumerar ranuras: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: no pudo obtener informe de testigo: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: no pudo abrir sesión: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr "ninguna ubicación escribible configurada para almacenar anclajes"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "localización no configurada para almacenar anclajes"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "no pudo crear objeto: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "especifica al menos un archivo de ancla de entrada"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "no pudo retirar solo lectura %s"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "no pudo retirar %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "al menos un archivo o uri debe estar especificado"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "una acción ya estaba especificada"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u erróneo mientras procesaba"
+msgstr[1] "%u erróneo mientras procesaba"
+msgstr[2] "%u erróneo mientras procesaba"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: extensión no válida del certificado"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: restricciones básicas no válidas para extensión de certificado"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "desconocido"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "ausentando el atributo CKA_HASH_OF_SUBJECT_PUBLIC_KEY"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "ausentando el atributo CKA_HASH_OF_ISSUER_PUBLIC_KEY"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "el objeto no es modificable"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "objetos de este tipo no puede ser creado"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "el atributo %s no puede ser fijado"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "el atributo %s no puede ser modificado"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "el atributo %s tiene un valor no válido"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "el atributo %s no es válido para el objeto"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "ausentando el atributo %s"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "no ha encontrado ningún atributo CKA_CLASS"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "no se puede crear un objeto %s"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "testigo"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "no-testigo"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "ausentando %s en objeto"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s no mantenido %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "clase de objeto %s no mantenida"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "utilización de tecla no válida para extensión del certificado"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+"utilización de tecla extendida no válida para extensión del certificado"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "tecla utilizada no válida para extensión de certificado rechazada"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "no se pudo volcar objeto"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "argumentos adicionales aprobados a instrucción"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "no pudo interpretar extensión de certificado adjuntado: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "no pudo cargar extensiones adjuntas para certificado: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "no pudo interpretar certificado: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "no pudo cargar atributos. %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "descartando objeto sin certificado"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "no pudo cargar listado de bloque: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "un URI PKCS#11 ya ha sido especificado"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "no pudo interpretar filtro uri de pkcs11: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "uir contenía componentes no reconocidos, no se extraerá nada"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "filtro no admitido o reconocido: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "propósito no admitido o no reconocido: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "no está registrada ninguna normativa de confianza de módulos"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "un formato ya estaba especificado"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "formato no admitido o reconocido: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "el formato no admite normativa de confianza"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"el formato requiere un propósito, especifíquelo con --purpose; por defecto "
+"va a 'server-auth'"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr "formato no admite propósitos múltiples, por defecto a ‘server-auth’"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "especifica un archivo o directorio de destino"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "ningún formato de salida especificado"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "no se pudo ejecutar ejecutar %s"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+"múltiples certificados encontrado pero no pudo solamente escribir uno al "
+"archivo"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "erróneo al encontrar certificados: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "ningún certificado encontrado"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "erróneo al encontrar certificado: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "truncando cadena larga"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Variable de entorno $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+"Variable de entorno $SOURCE_DATE_EPOCH: ninguno de los dígitos fue "
+"encontrado: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Variable de entorno $SOURCE_DATE_EPOCH: cola de basura: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Variable $SOURCE_DATE_EPOCH de entorno: valor debe ser más pequeño o igual "
+"que %lu pero fue encontrado para ser: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "no se pudo generar un nombre alias para certificado"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "descartando objeto, no pudo crear uri"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "argumento de módulo no reconocido: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "certifica con desconfianza en ubicación para anclajes: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "sobrescribiendo confianza para anclaje en listado de bloque: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "No pudo interpretar bloque PEM de tipo %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "no pudo abrir y asociar archivo: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "valor oid no válido: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "no pudo crear archivo: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "no pudo escribir al archivo: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "no pudo completar escritura de archivo: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "no pudo escribir archivo: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "no pudo fijar permisos del archivo: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "no pudo completar escritura al archivo: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "no pudo retirar archivo original: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "no pudo crear directorio: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "directorio ya existe: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "no pudo crear directorio: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "no pudo fijar permisos del directorio: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "no pudo crear directorio escribible: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "no pudo crear enlace simbólico. %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "no pudo retirar archivo: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "no pudo fijar permisos del directorio: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "no pudo cargar archivo internos a objetos: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "no pudo especificar ruta: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "no se puede acceder a la ruta del certificado de confianza: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "no se puede acceder al archivo de confianza: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "no pudo acceder: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "no pudo interpretar certificado: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "ningún certificado encontrado"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Estonian (http://www.transifex.com/freedesktop/p11-kit/language/et/)\n"
+"Language-Team: Estonian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/et/)\n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -1,29 +1,118 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
+# assar <asier.sarasua@gmail.com>, 2019
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Basque (http://www.transifex.com/freedesktop/p11-kit/language/eu/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: assar <asier.sarasua@gmail.com>, 2019\n"
+"Language-Team: Basque (http://www.transifex.com/freedesktop/p11-kit/language/"
+"eu/)\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
-msgstr ""
+msgstr "Eragiketa bertan behera geratu da"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
-msgstr ""
+msgstr "Ez dago nahiko memoriarik erabilgarri"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
@@ -31,19 +120,19 @@ msgstr ""
 
 #: p11-kit/messages.c:85
 msgid "Internal error"
-msgstr ""
+msgstr "Barneko errorea"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr ""
+msgstr "Eragiketak huts egin du"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
-msgstr ""
+msgstr "Argumentu baliogabeak"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr ""
+msgstr "Moduluak ezin izan ditu beharrezkoak ziren hariak sortu"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
@@ -51,7 +140,7 @@ msgstr ""
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr ""
+msgstr "Eremua irakurtzeko soilik da"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
@@ -59,23 +148,23 @@ msgstr ""
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
-msgstr ""
+msgstr "Eremua baliogabea da edo ez da existitzen"
 
 #: p11-kit/messages.c:101
 msgid "Invalid value for field"
-msgstr ""
+msgstr "Balio baliogabea eremurako"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr ""
+msgstr "Datuak ez dira baliozkoak edo ez dira ezagunak"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
-msgstr ""
+msgstr "Datuak luzeegiak dira"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
-msgstr ""
+msgstr "Errorea gertatu da gailuan"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
@@ -83,35 +172,35 @@ msgstr ""
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
-msgstr ""
+msgstr "Gailua kendu edo deskonektatu egin da"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr ""
+msgstr "Zifratutako datuak ez dira baliozkoak edo ezezagunak dira"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
-msgstr ""
+msgstr "Zifratutako datuak luzeegiak dira"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
-msgstr ""
+msgstr "Eragiketa hau ez dago onartuta"
 
 #: p11-kit/messages.c:119
 msgid "The key is missing or invalid"
-msgstr ""
+msgstr "Gakoa falta da edo baliogabea da"
 
 #: p11-kit/messages.c:121
 msgid "The key is the wrong size"
-msgstr ""
+msgstr "Gakoaren tamaina okerra da"
 
 #: p11-kit/messages.c:123
 msgid "The key is of the wrong type"
-msgstr ""
+msgstr "Gakoa mota okerrekoa da"
 
 #: p11-kit/messages.c:125
 msgid "No key is needed"
-msgstr ""
+msgstr "Ez da gakorik behar"
 
 #: p11-kit/messages.c:127
 msgid "The key is different than before"
@@ -119,7 +208,7 @@ msgstr ""
 
 #: p11-kit/messages.c:129
 msgid "A key is needed"
-msgstr ""
+msgstr "Gako bat behar da"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
@@ -339,4 +428,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Persian (http://www.transifex.com/freedesktop/p11-kit/language/fa/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Persian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/fa/)\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fa\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,24 +1,117 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Eerik Uusi-Illikainen https://launchpad.net/~ekiuusi-4, 2012
 # Jiri Grönroos <jiri.gronroos@iki.fi>, 2012-2013
+# Kimmo Kujansuu <mrkujansuu@gmail.com>, 2019,2021-2022
 # Timo Jyrinki <timo.jyrinki@iki.fi>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:56+0000\n"
-"Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
-"Language-Team: Finnish (http://www.transifex.com/freedesktop/p11-kit/language/fi/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>, 2019,2021-2022\n"
+"Language-Team: Finnish (http://www.transifex.com/freedesktop/p11-kit/"
+"language/fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "käyttö: %s komento <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Yleiset %s komennot ovat:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Katso '%s <command> --help' saadaksesi lisätietoja\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "komentoa ei määritetty"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "tuntematon valinta: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "tuntematon valinta: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' ei ole oikea komento. Katso '%s --help'"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: odottamaton pem block"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: odottamaton section header"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "virheellinen tila kohteessa  'user-config': %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "virheellinen määrityksen tiedostonimi, ohitetaan tulevaisuudessa: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "ei voitu listata hakemistoa: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "ei voitu paikallistaa polkua: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "virheellinen asetus '%s' oletuksena '%s'"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "suodatinta ei voi alustaa"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "moduulin tietoja ei voi ladata: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "lisäargumentit määritetty"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -26,7 +119,7 @@ msgstr "Toiminto keskeytettiin"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
-msgstr "Muisti ei riitÃ¤"
+msgstr "Muisti ei riitä"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
@@ -34,19 +127,19 @@ msgstr "Annettu lohkotunniste ei ole kelvollinen"
 
 #: p11-kit/messages.c:85
 msgid "Internal error"
-msgstr "SisÃ¤inen virhe"
+msgstr "Sisäinen virhe"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr "Toiminto epÃ¤onnistui"
+msgstr "Toiminto epäonnistui"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
-msgstr "VirheellisiÃ¤ argumentteja"
+msgstr "Virheellisiä argumentteja"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr "Moduuli ei voi luoda vaadittavia sÃ¤ikeitÃ¤"
+msgstr "Moduuli ei voi luoda vaadittavia säikeitä"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
@@ -54,27 +147,27 @@ msgstr "Moduuli ei voi lukita tietoa kunnolla"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr "KenttÃ¤ on vain luettavissa"
+msgstr "Kenttä on vain luettavissa"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
-msgstr "KenttÃ¤ on arkaluonteinen eikÃ¤ sitÃ¤ voida paljastaa"
+msgstr "Kenttä on arkaluonteinen eikä sitä voida paljastaa"
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
-msgstr "KenttÃ¤ on virheellinen tai sitÃ¤ ei ole olemassa"
+msgstr "Kenttä on virheellinen tai sitä ei ole olemassa"
 
 #: p11-kit/messages.c:101
 msgid "Invalid value for field"
-msgstr "KentÃ¤n arvo on virheellinen"
+msgstr "Kentän arvo on virheellinen"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr "Tieto ei ole kelvollista tai sitÃ¤ ei voida tunnistaa"
+msgstr "Tieto ei ole kelvollista tai sitä ei voida tunnistaa"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
-msgstr "Tieto on liian pitkÃ¤"
+msgstr "Tieto on liian pitkä"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
@@ -82,7 +175,7 @@ msgstr "Tapahtui virhe laitteella"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr "Laitteen muistimÃ¤Ã¤rÃ¤ liian vÃ¤hÃ¤inen"
+msgstr "Laitteen muistimäärä liian vähäinen"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
@@ -90,15 +183,15 @@ msgstr "Laite poistettiin tai irrotettiin"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr "Salattu tieto ei ole kelvollista tai sitÃ¤ ei voida tunnistaa"
+msgstr "Salattu tieto ei ole kelvollista tai sitä ei voida tunnistaa"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
-msgstr "Salattu tieto on liian pitkÃ¤"
+msgstr "Salattu tieto on liian pitkä"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
-msgstr "TÃ¤mÃ¤ toiminto ei ole tuettu"
+msgstr "Tämä toiminto ei ole tuettu"
 
 #: p11-kit/messages.c:119
 msgid "The key is missing or invalid"
@@ -106,11 +199,11 @@ msgstr "Avain puuttuu tai on virheellinen"
 
 #: p11-kit/messages.c:121
 msgid "The key is the wrong size"
-msgstr "Avain on vÃ¤Ã¤rÃ¤n kokoinen"
+msgstr "Avain on väärän kokoinen"
 
 #: p11-kit/messages.c:123
 msgid "The key is of the wrong type"
-msgstr "Avain on vÃ¤Ã¤rÃ¤Ã¤ tyyppiÃ¤"
+msgstr "Avain on väärää tyyppiä"
 
 #: p11-kit/messages.c:125
 msgid "No key is needed"
@@ -126,23 +219,23 @@ msgstr "Avain vaaditaan"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
-msgstr "Avainta ei voi sisÃ¤llyttÃ¤Ã¤ tiivisteeseen"
+msgstr "Avainta ei voi sisällyttää kanavaan"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
-msgstr "TÃ¤tÃ¤ toimintoa ei voi tehdÃ¤ tÃ¤llÃ¤ avaimella"
+msgstr "Tätä toimintoa ei voi tehdä tällä avaimella"
 
 #: p11-kit/messages.c:135
 msgid "The key cannot be wrapped"
-msgstr "Avainta ei voi rivittÃ¤Ã¤"
+msgstr "Avainta ei voi paketoida"
 
 #: p11-kit/messages.c:137
 msgid "Cannot export this key"
-msgstr "TÃ¤tÃ¤ avainta ei voi viedÃ¤"
+msgstr "Tätä avainta ei voi viedä"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr "Salausmekanismi on virheellinen tai sitÃ¤ ei voida tunnistaa"
+msgstr "Salausmekanismi on virheellinen tai sitä ei voida tunnistaa"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
@@ -154,15 +247,15 @@ msgstr "Kohde puuttuu tai on virheellinen"
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr "Toinen toiminto on jo kÃ¤ynnissÃ¤"
+msgstr "Toinen toiminto on jo käynnissä"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
-msgstr "YhtÃ¤Ã¤n toimintoa ei ole kÃ¤ynnissÃ¤"
+msgstr "Yhtään toimintoa ei ole käynnissä"
 
 #: p11-kit/messages.c:149
 msgid "The password or PIN is incorrect"
-msgstr "Salasana tai PIN-koodi on vÃ¤Ã¤rÃ¤"
+msgstr "Salasana tai PIN-koodi on väärä"
 
 #: p11-kit/messages.c:151
 msgid "The password or PIN is invalid"
@@ -206,7 +299,7 @@ msgstr "Lukutilassa oleva istunto on olemassa"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
-msgstr "YllÃ¤pitÃ¤jÃ¤n istunto on olemassa"
+msgstr "Ylläpitäjän istunto on olemassa"
 
 #: p11-kit/messages.c:173
 msgid "The signature is bad or corrupted"
@@ -218,11 +311,11 @@ msgstr "Allekirjoitusta ei voida tunnistaa tai se on vioittunut"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
-msgstr "Jotkut vaadituista kentistÃ¤ puuttuvat"
+msgstr "Jotkut vaadituista kentistä puuttuvat"
 
 #: p11-kit/messages.c:179
 msgid "Certain fields have invalid values"
-msgstr "Jotkin kentÃ¤t sisÃ¤ltÃ¤vÃ¤t virheellisia arvoja"
+msgstr "Jotkin kentät sisältävät virheellisiä arvoja"
 
 #: p11-kit/messages.c:181
 msgid "The device is not present or unplugged"
@@ -230,7 +323,7 @@ msgstr "Laite ei ole saatavilla tai se on irrotettu"
 
 #: p11-kit/messages.c:183
 msgid "The device is invalid or unrecognizable"
-msgstr "Laite on virheellinen tai sitÃ¤ ei voida tunnistaa"
+msgstr "Laite on virheellinen tai sitä ei voida tunnistaa"
 
 #: p11-kit/messages.c:185
 msgid "The device is write protected"
@@ -238,47 +331,47 @@ msgstr "Laite on kirjoitussuojattu"
 
 #: p11-kit/messages.c:187
 msgid "Cannot import because the key is invalid"
-msgstr "Tuonti epÃ¤onnistui koska avain on virheellinen"
+msgstr "Tuonti epäonnistui koska avain on virheellinen"
 
 #: p11-kit/messages.c:189
 msgid "Cannot import because the key is of the wrong size"
-msgstr "Tuonti epÃ¤onnistui koska avain on vÃ¤Ã¤rÃ¤n kokoinen"
+msgstr "Tuonti epäonnistui koska avain on väärän kokoinen"
 
 #: p11-kit/messages.c:191
 msgid "Cannot import because the key is of the wrong type"
-msgstr "Tuonti epÃ¤onnistui koska avain on vÃ¤Ã¤rÃ¤Ã¤ tyyppiÃ¤"
+msgstr "Tuonti epäonnistui koska avain on väärää tyyppiä"
 
 #: p11-kit/messages.c:193
 msgid "You are already logged in"
-msgstr "Olet jo kirjautuneena sisÃ¤Ã¤n"
+msgstr "Olet jo kirjautuneena sisään"
 
 #: p11-kit/messages.c:195
 msgid "No user has logged in"
-msgstr "KÃ¤yttÃ¤jiÃ¤ ei ole kirjautuneena sisÃ¤Ã¤n"
+msgstr "Käyttäjä ei ole kirjautuneena sisään"
 
 #: p11-kit/messages.c:197
 msgid "The user's password or PIN is not set"
-msgstr "KÃ¤yttÃ¤jÃ¤n salasanaa tai PIN-koodia ei ole asetettu"
+msgstr "Käyttäjän salasanaa tai PIN-koodia ei ole asetettu"
 
 #: p11-kit/messages.c:199
 msgid "The user is of an invalid type"
-msgstr "KÃ¤yttÃ¤jÃ¤ on vÃ¤Ã¤rÃ¤n tyyppinen"
+msgstr "Käyttäjä on väärän tyyppinen"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
-msgstr "Toinen kÃ¤yttÃ¤jÃ¤ on jo kirjautunut sisÃ¤Ã¤n"
+msgstr "Toinen käyttäjä on jo kirjautunut sisään"
 
 #: p11-kit/messages.c:203
 msgid "Too many users of different types are logged in"
-msgstr "Liian monta eri tyyppistÃ¤ kÃ¤yttÃ¤jÃ¤Ã¤ on kirjautuneena sisÃ¤Ã¤n"
+msgstr "Liian monta eri tyyppistä käyttäjää on kirjautunut sisään"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
-msgstr "VirheellistÃ¤ avainta ei voida tuoda"
+msgstr "Virheellistä avainta ei voida tuoda"
 
 #: p11-kit/messages.c:207
 msgid "Cannot import a key of the wrong size"
-msgstr "VÃ¤Ã¤rÃ¤n kokoista avainta ei voida tuoda"
+msgstr "Väärän kokoista avainta ei voida tuoda"
 
 #: p11-kit/messages.c:209
 msgid "Cannot export because the key is invalid"
@@ -286,11 +379,11 @@ msgstr "Vienti ei onnistu koska avain on virheellinen"
 
 #: p11-kit/messages.c:211
 msgid "Cannot export because the key is of the wrong size"
-msgstr "Vienti ei onnistu koska avain on vÃ¤Ã¤rÃ¤n kokoinen"
+msgstr "Ei voi viedä, koska avain on väärän kokoinen"
 
 #: p11-kit/messages.c:213
 msgid "Cannot export because the key is of the wrong type"
-msgstr "Vienti ei onnistu koska avain on vÃ¤Ã¤rÃ¤n tyyppinen"
+msgstr "Ei voi viedä, koska avain on väärän tyyppinen"
 
 #: p11-kit/messages.c:215
 msgid "Unable to initialize the random number generator"
@@ -306,7 +399,7 @@ msgstr "Salausmekanismin parametri on virheellinen"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
-msgstr "Liian vÃ¤hÃ¤n tilaa tulosten tallentamiseen"
+msgstr "Ei tarpeeksi tilaa tuloksen tallentamiseen"
 
 #: p11-kit/messages.c:223
 msgid "The saved state is invalid"
@@ -314,7 +407,7 @@ msgstr "Tallennettu tila on virheellinen"
 
 #: p11-kit/messages.c:225
 msgid "The information is sensitive and cannot be revealed"
-msgstr "Tieto on luottamuksellista eikÃ¤ sitÃ¤ voida paljastaa"
+msgstr "Tieto on luottamuksellista eikä sitä voida paljastaa"
 
 #: p11-kit/messages.c:227
 msgid "The state cannot be saved"
@@ -343,3 +436,1009 @@ msgstr "Pyyntö hylättiin käyttäjän toimesta"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Tuntematon virhe"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "moduulia ei voi ladata: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "ei löydy C_GetFunctionList moduulin aloituskohtaa: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "kutsu C_GetFunctiontList epäonnistui moduulissa: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr " kieltäytyy lataamasta p11-kit-proxy.so rekisteröitynä moduulina"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "moduulissa '%s' on molemmat käyttöönotto ja poisto vaihtoehdot"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "alustus keskeytettiin, koska moduuli '%s' on merkitty kriittiseksi"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit alustus kutsutaan rekursiivisesti"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "kriittisen moduulin alustus '%s' epäonnistui: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "ohitetaan moduuli '%s' jonka alustus epäonnistui: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "istunto ei sulkeudu: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "moduulin '%s' valintaa '%s' tuetaan vain hallituissa moduuleissa"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: moduulin alustaminen epäonnistui:%s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: moduulin alustaminen epäonnistui%s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: moduuli oli jo alustettu"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: moduulin viimeisteleminen epäonnistui: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "moduulin alustus epäonnistui: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Listaa moduulit ja tunnukset"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Suorita tietty PKCS#11 moduuli etänä"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Suorita palvelinprosessi, joka näyttää PKCS#11 moduulin etänä"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "luottamustyökalua ei voitu suorittaa"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' ei ole kelvollinen komento. Katso 'p11-kit --help'"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "määrittää moduulin tai tunnukset etänä"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "Päätteessä 'etätyökalua' ei ole tarkoitettu suoritettavaksi"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "vain yksi moduuli voidaan määrittää"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "rpc-virheen vastaus: liian lyhyt"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "rpc-virheen vastaus: virheellinen virhekoodi"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "rpc-virheen vastaus: kutsun ristiriita"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "rpc-virheen vastaus: virheellinen argumentin tieto"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "vastaanotettiin määriterivi, jossa oli väärä määrä määritteitä"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "palautti määritteet virheellisessä järjestyksessä"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "annettujen mutex-kutsujen joukko ei kelpaa"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "ei voi tehdä ilman käyttöjärjestelmän lukitusta"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize kutsutaan kahdesti samalle prosessille"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "rpc-moduulin viimeistely palautti virheen: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "virheellinen viesti: kutsun tunnusta ei voi lukea"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "virheellinen viesti: bad call id: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "virheellinen viesti: allekirjoitusta ei voi lukea"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "virheellinen viesti: allekirjoitus ei täsmää"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "vastaanotettu virheellinen pituus tyhjää merkkijonoon: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "virheellinen pyyntö moduulilta, todennäköisesti liian lyhyt"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "rpc-vastausta ei voitu alustaa"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "yhteysmoduulista saatu virheellinen kättely"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "pkcs11 rpc-viestiä ei voitu jäsentää"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "virhe muistin loppumisesta viestiä koottaessa"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "muistin loppuminen vastasi virheellä"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "vastaanotettu versio, jota ei tueta: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "ei voitu lukea tunnistetietoa"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "ei voitu kirjoittaa tunnistetietoa"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "rpc-viestin lukeminen epäonnistui"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "odottamaton virhe käsiteltäessä rpc-viestiä"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "rpc-viestin kirjoittaminen epäonnistui"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "tietoja ei voitu lähettää: yhteys suljettu"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "ei voitu lähettää tietoja"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "tietoja ei voitu vastaanottaa: yhteys suljettu"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "ei voitu vastaanottaa tietoja"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "vastaanotettiin virheellisiä rpc-arvoja: ehkä väärä protokolla"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "ei voinut käyttää valintaa, odota rpc-putkea"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "ei voitu lähettää socket-tunnuksia"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "ei voitu lähettää socket-tunnuksia"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "sulkee socketin protokollavirheen vuoksi"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "prosessi %d ei poistunut, lopeus"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "ei voitu odottaa suoritettua prosessia: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "prosessi %d poistui tilaviestillä %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "prosessi %d lopetettiin tilakoodilla %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "ei onnistunut luomaan putkea etäkäyttöön"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "ei onnistunut luomaan putkea etäkäyttöön"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "prosessi %p ei poistunut, lopeus"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "ei voitu lopettaa prosessia %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "ei voitu odottaa suoritettua prosessia: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "ei saanut poistumistilaa %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "prosessi %p poistui tilasta %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "stdin kopiointi epäonnistui"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "stdout kopiointi epäonnistui"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "etäyhteyden saaminen epäonnistui"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "tiedostokuvausten palauttaminen epäonnistui"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "virheellinen etäkomentorivi: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "ei pystynyt luomaan liitäntää etäkäyttöön"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "jäsentäminen epäonnistui vsock-osoitteen: '%s'"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "etäkäyttöä ei tueta: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "ei voitu luoda liitäntää %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "liitäntää ei voitu sitoa %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "ei voitu kuunnella liitäntää %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "ei voitu luoda liitäntää %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "liitäntää ei voitu sitoa %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "ei voitu kuunnella liitäntää %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "ei voitu tarkistaa uid liitännästä"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "uid-yhteys (%u) ei vastaa oletettua (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "gid-yhteys (%u) ei vastaa oletettua (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "ei voitu luoda uutta istuntoa"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "liian monta tiedostojen kuvausta vastaanotettu"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "ei yhteyttä %s - %lu sekuntiin, poistutaan"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "ei voinut hyväksyä liitäntää %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "tuntematon ryhmä: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "tuntematon käyttäjä: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "ei voi asettaa arvoksi %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "ei voi asettaa ryhmää %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "ei voi asettaa uid %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "ei voi määrittää hakemistoa ajon aikana"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "ei voi luoda %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "ei voitu alustaa Windowsin suojaustoimintoja"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "voi rakentaa SID %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "voi rakentaa ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "ei voi varata tietoturvan kuvausta: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "ei voi alustaa tietoturvan kuvausta: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "ei voi asettaa omistajaa tietoturvan kuvaukselle: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "ei voi asettaa DACL tietoturvan kuvaukselle: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "virheellinen PKCS#11 uri: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "tunnistamaton tiedoston formaatti: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "tiedoston jäsentäminen epäonnistui: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: ei voitu alustaa: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: ei voitu luetella korttipaikkoja: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: ei saatu tunnustietoja: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: ei voitu avata istuntoa: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "objektia ei voitu luoda: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "vain luku, ei voi poistaa %s"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "ei voi poistaa %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "vähintään yksi tiedosto tai uri on määritettävä"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "toiminto oli jo määritetty"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u virhe käsittelyn aikana"
+msgstr[1] "%u virhe käsittelyn aikana"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: virheellinen laajennus varmenteelle"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: virheellinen perusrajoitukset varmenteen laajennus"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "tuntematon"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "ominaisuus CKA_HASH_OF_SUBJECT_PUBLIC_KEY puuttuu"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "ominaisuus CKA_HASH_OF_ISSUER_PUBLIC_KEY puuttuu"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "objektia ei voi muokata"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "tämän tyyppisiä objekteja ei voi luoda"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "%s määritettä ei voi asettaa"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "%s määritettä ei voi muuttaa"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "%s määritteellä on virheellinen arvo"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "%s määrite ei kelpaa objektille"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "puuttuva %s attribuutti"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "ei CKA_CLASS attribuuttia löydy"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "ei voi luoda objektia %s"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "tunniste"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "tunnisteeton"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "puuttuu %s objektista"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s ei tueta %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s ei tueta objektin luokkaa"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "virheellinen avaimen käyttövarmenteen laajennus"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "virheellinen jatko avaimen käyttövarmenteen laajennus"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "virheellinen, hylkää avaimen käyttövarmenteen laajennus"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "ei voinut poistaa kohdetta"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "ylimääräiset argumentit siirrettiin komennolle"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "liitteenä olevaa varmenteen laajennusta ei voitu jäsentää: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "varmenteeseen liitettyjä laajennuksia ei voi ladata: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "sertifikaattia ei voitu selvittää: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "määritteiden lataaminen epäonnistui: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "ohitetaan muu kuin varmenteen objekti"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "estolistaa ei voitu ladata: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "PKCS#11 URI on jo määritelty"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "pkcs11 uri-suodatinta ei voitu selvittää: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "uri sisälsi tunnistamattomia komponentteja, mitään ei pureta"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "tunnistamaton suodatin: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "rekisteröimätön tarkoitus: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "yhtään luottamuskäytäntöä sisältävää moduulia ei ole rekisteröity"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "muoto oli jo määritetty"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "tunnistamaton muoto: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "muoto ei tue luottamuskäytäntöä"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"formaatti vaatii tarkoituksen, määritä se --purpose; oletuksena 'server-auth'"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr "formaatti ei tue useita tarkoituksia, oletuksena 'server-auth'"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "määritä yksi kohdetiedosto tai hakemisto"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "ulostulon muotoa ei ole määritetty"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "komentoa %s ei voitu suorittaa"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+"useita varmenteita löytyi, mutta pystyivät kirjoittamaan vain yhden tiedoston"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "varmenteiden löytäminen epäonnistui: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "varmennetta ei löytynyt"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "varmenteen löytäminen epäonnistui: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "katkaistaan pitkä merkkijono"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Ympäristömuuttuja $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "Ympäristömuuttuja $SOURCE_DATE_EPOCH: Numeroita ei löytynyt: %s \n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Ympäristömuuttuja $SOURCE_DATE_EPOCH: Loppu roskaa: %s \n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Ympäristömuuttuja $SOURCE_DATE_EPOCH: arvon on oltava pienempi tai yhtä "
+"suuri kuin %lu, mutta sen todettiin olevan: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "sertifikaatin aliaksen nimeä ei voitu luoda"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "objektin ohitus, ei voi rakentaa url"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "tunnistamaton moduulin argumentti: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "sertifikaattin sijaintiin ei luoteta: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "Ei voitu jäsentää PEM block tyyppiä %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "ei voinut avata ja yhdistää tiedostoa: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "virheellinen oid-arvo: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "ei voitu luoda tiedostoa: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "ei voitu kirjoittaa tiedostoon: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "tiedoston kirjoittamista ei suoritettu loppuun: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "ei voitu kirjoittaa tiedostoa: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "tiedoston oikeuksia ei voitu asettaa: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "ei voitu viimeistellä tiedoston kirjoitusta: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "alkuperäisen tiedoston poistaminen epäonnistui: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "ei voitu luoda hakemistoa: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "hakemisto on jo olemassa: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "ei voitu luoda hakemistoa: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "hakemiston käyttöoikeuksia ei voitu asettaa: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "hakemistoa ei voitu tehdä kirjoitettavaksi: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "symlinkin luominen epäonnistui: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "tiedostoa ei voitu poistaa: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "hakemiston käyttöoikeuksia ei voitu asettaa: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "tiedostoa ei voi ladata objekteihin: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "ei voitu paikallistaa polkua: %d:%s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "ei pääsyä luottamuksellisen varmenteen polkuun: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "ei pääsyä luottamukselliseen tiedostoon: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "ei pääsyä: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "sertifikaattia ei voitu selvittää: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "varmennetta ei löytynyt"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/fo.po
+++ b/po/fo.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Faroese (http://www.transifex.com/freedesktop/p11-kit/language/fo/)\n"
+"Language-Team: Faroese (http://www.transifex.com/freedesktop/p11-kit/"
+"language/fo/)\n"
+"Language: fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,23 +1,112 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Jérôme Fenal <jfenal@gmail.com>, 2013
-# lkppo, 2013
+# 4a14a73d523224463300dea5e0502458_3dab472, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 14:15+0000\n"
-"Last-Translator: Jérôme Fenal <jfenal@gmail.com>\n"
-"Language-Team: French (http://www.transifex.com/freedesktop/p11-kit/language/fr/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Jérôme Fenal <jfenal@gmail.com>, 2013\n"
+"Language-Team: French (http://www.transifex.com/freedesktop/p11-kit/language/"
+"fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -342,3 +431,1003 @@ msgstr "La demande a été rejetée par l'utilisateur"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Erreur inconnue"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/fur.po
+++ b/po/fur.po
@@ -7,16 +7,104 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-12-06 15:44+0000\n"
-"Last-Translator: Fabio Tomat <f.t.public@gmail.com>\n"
-"Language-Team: Friulian (http://www.transifex.com/freedesktop/p11-kit/language/fur/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Fabio Tomat <f.t.public@gmail.com>, 2017\n"
+"Language-Team: Friulian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/fur/)\n"
+"Language: fur\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fur\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr "La richieste e je stade refudade dal utent"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Erôr no cognossût"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -1,21 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Irish (http://www.transifex.com/freedesktop/p11-kit/language/ga/)\n"
+"Language-Team: Irish (http://www.transifex.com/freedesktop/p11-kit/language/"
+"ga/)\n"
+"Language: ga\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ga\n"
-"Plural-Forms: nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);\n"
+"Plural-Forms: nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : "
+"4);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +428,1006 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Fran Diéguez <frandieguez@ubuntu.com>, 2012-2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-23 18:09+0000\n"
-"Last-Translator: Fran Diéguez <frandieguez@ubuntu.com>\n"
-"Language-Team: Galician (http://www.transifex.com/freedesktop/p11-kit/language/gl/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Fran Diéguez <frandieguez@ubuntu.com>, 2012-2013\n"
+"Language-Team: Galician (http://www.transifex.com/freedesktop/p11-kit/"
+"language/gl/)\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr "A solicitude foi rexeitada polo usuario"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Erro descoñecido"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Gujarati (http://www.transifex.com/freedesktop/p11-kit/language/gu/)\n"
+"Language-Team: Gujarati (http://www.transifex.com/freedesktop/p11-kit/"
+"language/gu/)\n"
+"Language: gu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: gu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -1,21 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Hebrew (http://www.transifex.com/freedesktop/p11-kit/language/he/)\n"
+"Language-Team: Hebrew (http://www.transifex.com/freedesktop/p11-kit/language/"
+"he/)\n"
+"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +428,1005 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Hindi (http://www.transifex.com/freedesktop/p11-kit/language/hi/)\n"
+"Language-Team: Hindi (http://www.transifex.com/freedesktop/p11-kit/language/"
+"hi/)\n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -1,27 +1,121 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
+# Milo Ivir <mail@milotype.de>, 2020
 # Tomislav Krznar <tomislav.krznar@gmail.com>, 2012
-# gogo <trebelnik2@gmail.com>, 2017
+# gogo <trebelnik2@gmail.com>, 2017,2022
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-23 18:36+0000\n"
-"Last-Translator: gogo <trebelnik2@gmail.com>\n"
-"Language-Team: Croatian (http://www.transifex.com/freedesktop/p11-kit/language/hr/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: gogo <trebelnik2@gmail.com>, 2017,2022\n"
+"Language-Team: Croatian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/hr/)\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hr\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "upotreba: %s naredba <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Uobičajene %s naredbe su:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Pogledajte '%s <command> --help' za više informacija\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "nema navedene naredbe"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "nepoznata globalna mogućnost: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "nepoznata globalna mogućnost: - %c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' nije valjana naredba. Pogledajte '%s --help'"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: neočekivan pem blok"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: neočekivano zaglavlje odjeljka"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "nevaljan način za 'user-config': %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "nevaljani naziv podešavanja, u buduće će se zanemariti: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "nemoguć prikaz sadržaja direktorija: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "nemoguće je navesti putanju: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "nevaljana postavka '%s' zadano je '%s'"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "filtar se ne može pokrenuti"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "nemoguće učitavanje informacija modula: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "navedeni su dodatni argumenti"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
-msgstr "Operacija je prekinuta"
+msgstr "Radnja je prekinuta"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
@@ -37,7 +131,7 @@ msgstr "Unutrašnja greška"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr "Operacija nije uspjela"
+msgstr "Radnja nije uspjela"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
@@ -45,7 +139,7 @@ msgstr "Neispravni argumenti"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr "Modul ne može stvoriti potrebne dretve"
+msgstr "Modul ne može stvoriti potrebne niti"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
@@ -53,15 +147,15 @@ msgstr "Modul ne može pravilno zaključati podatke"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr "Polje ima dozvole samo za čitanje"
+msgstr "Polje ima samo dozvolu za čitanje"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
-msgstr "Polje je osjetljivo i ne može se prikazati"
+msgstr "Polje je osjetljivo i ne može se otkriti"
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
-msgstr "Polje ne postoji ili nije ispravno"
+msgstr "Polje je nevaljano ili ne postoji"
 
 #: p11-kit/messages.c:101
 msgid "Invalid value for field"
@@ -69,7 +163,7 @@ msgstr "Neispravna vrijednost za polje"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr "Podaci nisu prepoznati ili nisu ispravni"
+msgstr "Podaci nisu valjani ili prepoznati"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
@@ -85,11 +179,11 @@ msgstr "Nedovoljno memorije na uređaju"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
-msgstr "Uređaj je uklonjen"
+msgstr "Uređaj je uklonjen ili odspojen"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr "Šifrirani podaci nisu prepoznati ili nisu ispravni"
+msgstr "Šifrirani podaci nisu prepoznati ili ispravni"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
@@ -97,11 +191,11 @@ msgstr "Šifrirani podaci su predugački"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
-msgstr "Ova operacija nije podržana"
+msgstr "Ova radnja nije podržana"
 
 #: p11-kit/messages.c:119
 msgid "The key is missing or invalid"
-msgstr "Nema ključa ili nije ispravan"
+msgstr "Ključ nedostaje ili je nevaljan"
 
 #: p11-kit/messages.c:121
 msgid "The key is the wrong size"
@@ -117,7 +211,7 @@ msgstr "Ključ nije potreban"
 
 #: p11-kit/messages.c:127
 msgid "The key is different than before"
-msgstr "Ključ se razlikuje od prethodnog"
+msgstr "Ključ se razlikuje od prijašnjeg"
 
 #: p11-kit/messages.c:129
 msgid "A key is needed"
@@ -129,7 +223,7 @@ msgstr "Nemoguće uključiti ključ u kontrolnu sumu"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
-msgstr "Ova operacija se ne može izvršiti s ovim ključem"
+msgstr "Ova radnja se ne može izvršiti s ovim ključem"
 
 #: p11-kit/messages.c:135
 msgid "The key cannot be wrapped"
@@ -141,23 +235,23 @@ msgstr "Nemoguć izvoz ovog ključa"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr "Mehanizam šifriranja nije prepoznat ili nije ispravan"
+msgstr "Mehanizam šifriranja je nevaljan ili nije prepoznat"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
-msgstr "Mehanizam šifriranja ima neispravan argument"
+msgstr "Mehanizam šifriranja ima nevaljan argument"
 
 #: p11-kit/messages.c:143
 msgid "The object is missing or invalid"
-msgstr "Nedostaje objekt ili nije ispravan"
+msgstr "Nedostaje objekt ili je nevaljan"
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr "Već se izvršava druga operacija"
+msgstr "Druga radnja se već izvodi"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
-msgstr "Ne izvršava se niti jedna operacija"
+msgstr "Ne izvodi se niti jedna radnja"
 
 #: p11-kit/messages.c:149
 msgid "The password or PIN is incorrect"
@@ -165,15 +259,15 @@ msgstr "Lozinka ili PIN su pogrešni"
 
 #: p11-kit/messages.c:151
 msgid "The password or PIN is invalid"
-msgstr "Lozinka ili PIN nisu ispravni"
+msgstr "Lozinka ili PIN su nevaljani"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr "Lozinka ili PIN nemaju ispravnu duljinu"
+msgstr "Lozinka ili PIN imaju nevaljanu duljinu"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
-msgstr "Lozinki ili PIN-u je istekao rok trajanja"
+msgstr "Lozinki ili PIN-u je isteklo trajanje"
 
 #: p11-kit/messages.c:157
 msgid "The password or PIN is locked"
@@ -189,7 +283,7 @@ msgstr "Previše sesija je aktivno"
 
 #: p11-kit/messages.c:163
 msgid "The session is invalid"
-msgstr "Sesija nije ispravna"
+msgstr "Sesija je nevaljana"
 
 #: p11-kit/messages.c:165
 msgid "The session is read-only"
@@ -201,7 +295,7 @@ msgstr "Postoji otvorena sesija"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
-msgstr "Postoji sesija samo za čitanje"
+msgstr "Postoji sesija samo za čitanja"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
@@ -217,15 +311,15 @@ msgstr "Potpis nije prepoznat ili je oštećen"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
-msgstr "Nedostaju neka neophodna polja"
+msgstr "Nedostaju pojedina potrebna polja"
 
 #: p11-kit/messages.c:179
 msgid "Certain fields have invalid values"
-msgstr "Neka polja imaju neispravne vrijednosti"
+msgstr "Pojedina polja imaju nevaljane vrijednosti"
 
 #: p11-kit/messages.c:181
 msgid "The device is not present or unplugged"
-msgstr "Uređaj nije prisutan ili je iskopčan"
+msgstr "Uređaj nije prisutan ili spojen"
 
 #: p11-kit/messages.c:183
 msgid "The device is invalid or unrecognizable"
@@ -237,7 +331,7 @@ msgstr "Uređaj ima zaštitu pisanja"
 
 #: p11-kit/messages.c:187
 msgid "Cannot import because the key is invalid"
-msgstr "Nemoguć uvoz zbog neispravnog ključa"
+msgstr "Nemoguć uvoz zbog nevaljanog ključa"
 
 #: p11-kit/messages.c:189
 msgid "Cannot import because the key is of the wrong size"
@@ -261,7 +355,7 @@ msgstr "Korisnička lozinka ili PIN nisu postavljeni"
 
 #: p11-kit/messages.c:199
 msgid "The user is of an invalid type"
-msgstr "Vrsta korisnika nije ispravna"
+msgstr "Korisnik je pogrešne vrste"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
@@ -273,7 +367,7 @@ msgstr "Prijavljeno je previše korisnika različitih vrsta"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
-msgstr "Nemoguć uvoz neispravanog ključa"
+msgstr "Nemoguć uvoz nevaljanog ključa"
 
 #: p11-kit/messages.c:207
 msgid "Cannot import a key of the wrong size"
@@ -281,7 +375,7 @@ msgstr "Nemoguć uvoz ključa pogrešne veličine"
 
 #: p11-kit/messages.c:209
 msgid "Cannot export because the key is invalid"
-msgstr "Nemoguć izvoz neispravnog ključa"
+msgstr "Nemoguć izvoz nevaljanog ključa"
 
 #: p11-kit/messages.c:211
 msgid "Cannot export because the key is of the wrong size"
@@ -301,7 +395,7 @@ msgstr "Nema dostupnih generatora slučajnih brojeva"
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
-msgstr "Mehanizam šifriranja ima neispravan parametar"
+msgstr "Mehanizam šifriranja ima nevaljani parametar"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
@@ -309,7 +403,7 @@ msgstr "Nedovoljno prostora za spremanje rezultata"
 
 #: p11-kit/messages.c:223
 msgid "The saved state is invalid"
-msgstr "Spremljeno stanje nije ispravno"
+msgstr "Spremljeno stanje je nevaljano"
 
 #: p11-kit/messages.c:225
 msgid "The information is sensitive and cannot be revealed"
@@ -342,3 +436,1004 @@ msgstr "Zahtjev je odbacio korisnik"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Nepoznata greška"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "nemoguće učitavanje modula: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "nemoguć pronalazak C_GetFunctionList točku unosa u modulu: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "poziv za C_GetFunctiontList je neuspio u modulu: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+"odbijanje učitavanja the p11-kit-proxy.so modula kao registriranog modula"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "modul '%s' ima obje mogućnosti, za omogućavanje i onemogućavanje"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "prekidanje pokretanja jer je modul '%s' označen kao koban"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit pokretanje je pozvano rekurzivno"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "pokretanje kobnog modula '%s' je neuspjelo: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "preskakanje modula '%s' čije je pokretanje neuspjelo: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "nemoguće zatvaranje sesije: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "'%s' mogućnost modula '%s' podržana je samo za upravljive module"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: modul se nije uspio pokrenuti: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: modul se nije uspio pokrenuti%s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: modul je već pokrenut"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: modul se nije uspio dovršiti: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "neuspjelo pokretanje modula: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Prikaži module i tokene"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Pokreni određeni  PKCS#11 modul udaljeno"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Pokreni proces poslužitelja koji izlaže PKCS#11 modul udaljeno"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "nemoguće pokretanje alata za povjerenje"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' nije valjana naredba. Pogledajte 'p11-kit --help'"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "navedite modul ili tokene za daljinsko upravljanje"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "'remote' alat nije namijenjen pokretanju iz terminala"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "samo jedan modul može biti naveden"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "nevaljani odgovor rpc greške: prekratak"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "nevaljani odgovor rpc greške: pogrešan kôd greške"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "nevaljani rpc odgovor: nepodudaranje poziva"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "nevaljani rpc odgovor: pogrešni podaci argumenta"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "primljeno je polje svojstva s pogrešnim brojem svojstva"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "povratno svojstvo je nevaljanog poredka"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "nemoguć prikaz sadržaja direktorija: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "nemoguć prikaz sadržaja direktorija: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,23 +1,115 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Collabora Ltd.
+# Hungarian translation for p11-kit.
+# Copyright (C) 2012, 2014, 2022. Free Software Foundation. Inc.
 # This file is distributed under the same license as the p11-kit package.
-# 
-# Translators:
-# Gabor Kelemen <kelemeng at gnome dot hu>, 2012
-# kelemeng <kelemeng@ubuntu.com>, 2014
+#
+# Gabor Kelemen <kelemeng at gnome dot hu>, 2012, 2014.
+# Balázs Úr <ur.balazs at fsf dot hu>, 2022.
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:28+0000\n"
-"Last-Translator: kelemeng <kelemeng@ubuntu.com>\n"
-"Language-Team: Hungarian (http://www.transifex.com/freedesktop/p11-kit/language/hu/)\n"
+"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/buglist.cgi?component=p11-"
+"kit&product=p11-glue&resolution=---\n"
+"POT-Creation-Date: 2022-07-29 15:27+0000\n"
+"PO-Revision-Date: 2022-10-18 17:02+0200\n"
+"Last-Translator: Balázs Úr <ur.balazs at fsf dot hu>\n"
+"Language-Team: Hungarian <gnome-hu-list at gnome dot org>\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 19.12.3\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "használat: %s parancs <argumentumok>…\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"A közös %s parancsok:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"További információkért nézze meg a(z) „%s <parancs> --help” parancsot\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "nincs parancs megadva"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "ismeretlen globális kapcsoló: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "ismeretlen globális kapcsoló: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "a(z) „%s” nem érvényes parancs. Nézze meg a(z) „%s --help” parancsot."
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: váratlan pem blokk"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: váratlan szakaszfejléc"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "érvénytelen mód a „user-config” kapcsolóhoz: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "érvénytelen beállítási fájlnév, a jövőben mellőzve lesz: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "nem sikerült felsorolni a könyvtárat: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "nem sikerült elérni az útvonalat: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "érvénytelen „%s” beállítás, a(z) „%s” alapértelmezett használata"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "a szűrőt nem lehet előkészíteni"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "nem sikerült betölteni a modulinformációkat: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "további argumentumok lettek megadva"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -29,7 +121,7 @@ msgstr "Nincs elég memória"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
-msgstr "A megadott helyazonosító nem érvényes"
+msgstr "A megadott foglalatazonosító nem érvényes"
 
 #: p11-kit/messages.c:85
 msgid "Internal error"
@@ -37,7 +129,7 @@ msgstr "Belső hiba"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr "A művelet meghiúsult"
+msgstr "A művelet sikertelen"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
@@ -53,7 +145,7 @@ msgstr "A modul nem képes megfelelően zárolni az adatokat"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr "A mező írásvédett"
+msgstr "A mező csak olvasható"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
@@ -69,7 +161,7 @@ msgstr "A mező értéke érvénytelen"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr "Az adat érvénytelen vagy ismeretlen"
+msgstr "Az adat érvénytelen vagy felismerhetetlen"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
@@ -89,7 +181,7 @@ msgstr "Az eszköz eltávolításra vagy leválasztásra került"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr "A titkosított adatok érvénytelenek vagy ismeretlenek"
+msgstr "A titkosított adatok érvénytelenek vagy felismerhetetlenek"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
@@ -117,7 +209,7 @@ msgstr "Nem szükséges kulcs"
 
 #: p11-kit/messages.c:127
 msgid "The key is different than before"
-msgstr "A kulcs megváltozott"
+msgstr "A kulcs eltérő a korábbitól"
 
 #: p11-kit/messages.c:129
 msgid "A key is needed"
@@ -125,11 +217,11 @@ msgstr "Kulcs szükséges"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
-msgstr "A kivonatba nem vehető fel a kulcs"
+msgstr "Nem vehető fel a kulcs a kivonatba"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
-msgstr "Ez a művelet nem végezhető el a kulccsal"
+msgstr "Ez a művelet nem végezhető el ezzel a kulccsal"
 
 #: p11-kit/messages.c:135
 msgid "The key cannot be wrapped"
@@ -137,15 +229,15 @@ msgstr "A kulcs nem alakítható át"
 
 #: p11-kit/messages.c:137
 msgid "Cannot export this key"
-msgstr "A kulcs nem exportálható"
+msgstr "Nem lehet exportálni ezt a kulcsot"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr "A titkosítási mód érvénytelen vagy ismeretlen"
+msgstr "A titkosítási mechanizmus érvénytelen vagy felismerhetetlen"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
-msgstr "A titkosítási mód argumentuma érvénytelen"
+msgstr "A titkosítási mechanizmus érvénytelen argumentummal rendelkezik"
 
 #: p11-kit/messages.c:143
 msgid "The object is missing or invalid"
@@ -153,7 +245,7 @@ msgstr "Az objektum hiányzik vagy érvénytelen"
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr "Már folyamatban van egy művelet"
+msgstr "Egy másik művelet már folyamatban van"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
@@ -161,23 +253,23 @@ msgstr "Nincs folyamatban művelet"
 
 #: p11-kit/messages.c:149
 msgid "The password or PIN is incorrect"
-msgstr "A jelszó vagy PIN helytelen"
+msgstr "A jelszó vagy a PIN-kód helytelen"
 
 #: p11-kit/messages.c:151
 msgid "The password or PIN is invalid"
-msgstr "A jelszó vagy PIN érvénytelen"
+msgstr "A jelszó vagy a PIN-kód érvénytelen"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr "A jelszó vagy PIN érvénytelen hosszúságú"
+msgstr "A jelszó vagy a PIN-kód érvénytelen hosszúságú"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
-msgstr "A jelszó vagy PIN lejárt"
+msgstr "A jelszó vagy a PIN-kód lejárt"
 
 #: p11-kit/messages.c:157
 msgid "The password or PIN is locked"
-msgstr "A jelszó vagy PIN zárolva van"
+msgstr "A jelszó vagy a PIN-kód zárolva van"
 
 #: p11-kit/messages.c:159
 msgid "The session is closed"
@@ -193,7 +285,7 @@ msgstr "A munkamenet érvénytelen"
 
 #: p11-kit/messages.c:165
 msgid "The session is read-only"
-msgstr "A munkamenet írásvédett"
+msgstr "A munkamenet csak olvasható"
 
 #: p11-kit/messages.c:167
 msgid "An open session exists"
@@ -201,7 +293,7 @@ msgstr "Már létezik nyitott munkamenet"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
-msgstr "Már létezik írásvédett munkamenet"
+msgstr "Már létezik csak olvasható munkamenet"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
@@ -213,7 +305,7 @@ msgstr "Az aláírás rossz vagy sérült"
 
 #: p11-kit/messages.c:175
 msgid "The signature is unrecognized or corrupted"
-msgstr "Az aláírás ismeretlen vagy sérült"
+msgstr "Az aláírás felismerhetetlen vagy sérült"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
@@ -221,11 +313,11 @@ msgstr "Néhány szükséges mező hiányzik"
 
 #: p11-kit/messages.c:179
 msgid "Certain fields have invalid values"
-msgstr "Néhány szükséges mező értéke érvénytelen"
+msgstr "Néhány mező értéke érvénytelen"
 
 #: p11-kit/messages.c:181
 msgid "The device is not present or unplugged"
-msgstr "Az eszköz nincs jelen vagy eltávolították"
+msgstr "Az eszköz nincs jelen vagy leválasztásra került"
 
 #: p11-kit/messages.c:183
 msgid "The device is invalid or unrecognizable"
@@ -237,27 +329,27 @@ msgstr "Az eszköz írásvédett"
 
 #: p11-kit/messages.c:187
 msgid "Cannot import because the key is invalid"
-msgstr "Nem importálható, mert a kulcs érvénytelen"
+msgstr "Nem lehet importálni, mert a kulcs érvénytelen"
 
 #: p11-kit/messages.c:189
 msgid "Cannot import because the key is of the wrong size"
-msgstr "Nem importálható, mert a kulcs hibás méretű"
+msgstr "Nem lehet importálni, mert a kulcs hibás méretű"
 
 #: p11-kit/messages.c:191
 msgid "Cannot import because the key is of the wrong type"
-msgstr "Nem importálható, mert a kulcs hibás típusú"
+msgstr "Nem lehet importálni, mert a kulcs hibás típusú"
 
 #: p11-kit/messages.c:193
 msgid "You are already logged in"
-msgstr "Már bejelentkezett"
+msgstr "Már be van jelentkezve"
 
 #: p11-kit/messages.c:195
 msgid "No user has logged in"
-msgstr "Senki sem jelentkezett be"
+msgstr "Nincs felhasználó bejelentkezve"
 
 #: p11-kit/messages.c:197
 msgid "The user's password or PIN is not set"
-msgstr "A felhasználó jelszava vagy PIN kódja nincs beállítva"
+msgstr "A felhasználó jelszava vagy PIN-kódja nincs beállítva"
 
 #: p11-kit/messages.c:199
 msgid "The user is of an invalid type"
@@ -265,7 +357,7 @@ msgstr "A felhasználó érvénytelen típusú"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
-msgstr "Már bejelentkezett egy másik felhasználó"
+msgstr "Egy másik felhasználó már bejelentkezett"
 
 #: p11-kit/messages.c:203
 msgid "Too many users of different types are logged in"
@@ -273,11 +365,11 @@ msgstr "Túl sok eltérő típusú felhasználó jelentkezett be"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
-msgstr "Nem importálható érvénytelen kulcs"
+msgstr "Nem lehet importálni érvénytelen kulcsot"
 
 #: p11-kit/messages.c:207
 msgid "Cannot import a key of the wrong size"
-msgstr "Nem importálható hibás méretű kulcs"
+msgstr "Nem lehet importálni hibás méretű kulcsot"
 
 #: p11-kit/messages.c:209
 msgid "Cannot export because the key is invalid"
@@ -293,15 +385,15 @@ msgstr "Nem lehet exportálni, mert a kulcs hibás típusú"
 
 #: p11-kit/messages.c:215
 msgid "Unable to initialize the random number generator"
-msgstr "A véletlenszám-generátor nem készíthető elő"
+msgstr "Nem lehet előkészíteni a véletlenszám-előállítót"
 
 #: p11-kit/messages.c:217
 msgid "No random number generator available"
-msgstr "Nem áll rendelkezésre véletlenszám-generátor"
+msgstr "Nincs elérhető véletlenszám-előállító"
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
-msgstr "A titkosítási mechanizmus egy paramétere érvénytelen"
+msgstr "A titkosítási mechanizmus érvénytelen paraméterrel rendelkezik"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
@@ -321,7 +413,7 @@ msgstr "Az állapot nem menthető"
 
 #: p11-kit/messages.c:229
 msgid "The module has not been initialized"
-msgstr "A modul nincs előkészítve"
+msgstr "A modul nem lett előkészítve"
 
 #: p11-kit/messages.c:231
 msgid "The module has already been initialized"
@@ -329,11 +421,11 @@ msgstr "A modul már elő lett készítve"
 
 #: p11-kit/messages.c:233
 msgid "Cannot lock data"
-msgstr "Nem zárolhatók az adatok"
+msgstr "Nem lehet zárolni az adatokat"
 
 #: p11-kit/messages.c:235
 msgid "The data cannot be locked"
-msgstr "Az adatok nem zárolhatók"
+msgstr "Az adatokat nem lehet zárolni"
 
 #: p11-kit/messages.c:237
 msgid "The request was rejected by the user"
@@ -342,3 +434,1014 @@ msgstr "A felhasználó elutasította a kérést"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Ismeretlen hiba"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "nem sikerült betölteni a modult: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+"nem sikerült megtalálni a C_GetFunctionList belépési pontot a modulban: %s: "
+"%s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "a C_GetFunctiontList hívása sikertelen a modulban: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+"a p11-kit-proxy.so modul regisztrált modulként való betöltése elutasítva"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "a(z) „%s” modulnak enable-in és disable-in kapcsolója is van"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+"előkészítés megszakítása, mert a(z) „%s” modul kritikusként lett megjelölve"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "a p11-kit előkészítése rekurzívan lett meghívva"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "a(z) „%s” kritikus modul előkészítése sikertelen: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "a(z) „%s” modul kihagyása, amely előkészítése sikertelen: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "nem sikerült lezárni a munkamenetet: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "a(z) „%2$s” modul „%1$s” kapcsolója csak kezelt moduloknál támogatott"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: a modult nem sikerült előkészíteni: %s"
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: a modult nem sikerült előkészíteni, kihagyás: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: a modul már elő lett készítve"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: a modult nem sikerült véglegesíteni: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "a modul előkészítése sikertelen: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Modulok és tokenek felsorolása"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Bizonyos PKCS#11-modul futtatása távolról"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Kiszolgálófolyamat futtatása, amely kiteszi a PKCS#11-modult távolról"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "nem sikerült futtatni a megbízhatósági eszközt"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+"a(z) „%s” nem érvényes parancs. Nézze meg a „p11-kit --help” parancsot."
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "adjon meg egy modult vagy tokeneket a távolihoz"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "a „távoli” eszközt nem terminálból kell futtatni"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "csak egy modult lehet megadni"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "érvénytelen RPC-hibaválasz: túl rövid"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "érvénytelen RPC-hibaválasz: rossz hibakód"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "érvénytelen RPC-válasz: hívási eltérés"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "érvénytelen RPC-válasz: rossz argumentumadatok"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "hibás számú attribútummal rendelkező attribútumtömb érkezett"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "érvénytelen sorrendben érkezetek vissza az attribútumok"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "a mutexhívások érvénytelen halmaza lett megadva"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "nem lehet megtenni az OS zárolása nélkül"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "a C_Initialize kétszer lett meghívva néhány folyamatnál"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "az RPC-modul véglegesítése hibát adott vissza: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "érvénytelen üzenet: nem sikerült olvasni a hívásazonosítót"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "érvénytelen üzenet: rossz hívásazonosító: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "érvénytelen üzenet: nem sikerült olvasni az aláírást"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "érvénytelen üzenet: az aláírás nem egyezik"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+"érvénytelen hosszúságú szóközzel kitöltött karakterlánc érkezett: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "érvénytelen kérés a modultól, valószínűleg túl rövid"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "nem sikerült előkészíteni az RPC-választ"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "érvénytelen kézfogás érkezett a kapcsolódó modultól"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "nem sikerült feldolgozni a PKCS#11 RPC-üzenetét"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "nincs elég memória hibaüzenet összerakása"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "nincs elég memória hibával válaszol"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "nem támogatott verzió érkezett: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "nem sikerült olvasni a hitelesítési adatok bájtját"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "nem sikerült írni a hitelesítési adatok bájtját"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "nem sikerült olvasni az RPC-üzenetet"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "váratlan hibakezelési RPC-üzenet"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "nem sikerült írni az RPC-üzenetet"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "nem sikerült elküldeni az adatokat: lezárt kapcsolat"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "nem sikerült elküldeni az adatokat"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "nem sikerült fogadni az adatokat: lezárt kapcsolat"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "nem sikerült fogadni az adatokat"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "érvénytelen RPC-fejlécértékek érkeztek: valószínűleg hibás protokoll"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "nem sikerült használni a kiválasztást az RPC-csőre várakozáshoz"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "nem sikerült elküldeni a foglalat hitelesítési adatait"
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr "nem sikerült fogadni a foglalat hitelesítési adatait"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr "a partner protokollverziója túl régi"
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "foglalat lezárása protokollhiba miatt"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "a(z) %d folyamat nem lépett ki, befejezés"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "nem sikerült várakozni a végrehajtott gyermekre: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "a(z) %d folyamat kilépett %d állapottal"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "a(z) %d folyamat befejeződött %d szignállal"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "nem sikerült csövet létrehozni a távolihoz"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "nem sikerült elágaztatni a távolihoz"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "a(z) %p folyamat nem lépett ki, befejezés"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "nem sikerült befejezni a(z) %p folyamatot"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "nem sikerült várakozni a végrehajtott gyermekre: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "nem sikerült lekérni a(z) %p kilépési állapotát"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "a(z) %p folyamat kilépett %lu állapottal"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "nem sikerült megkettőzni a szabványos bemenetet"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "nem sikerült megkettőzni a szabványos kimenetet"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "nem sikerült megkettőzni a cső gyermekvégét"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "nem sikerült indítani a távolit"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "nem sikerült visszaállítani a fájlleírókat"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "érvénytelen távoli parancssor: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "nem sikerült foglalatot létrehozni a távolihoz"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "nem sikerült feldolgozni a vsock-címet: „%s”"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "a távoli nem támogatott: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "a(z) %u gyermek meghalt sigsegv-vel"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "a(z) %u gyermek meghalt %d szignállal"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "nem sikerült létrehozni a(z) %s foglalatot"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "nem sikerült kötni a(z) %s foglalatot"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "nem sikerült figyelni a(z) %s foglalatot"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "nem sikerült a tulajdonosváltás a(z) %s foglalaton"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "nem sikerült létrehozni a(z) %u:%u foglalatot"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "nem sikerült kötni a(z) %u:%u foglalatot"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "nem sikerült figyelni a(z) %u:%u foglalatot"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "nem sikerült ellenőrizni a felhasználó-azonosítót a foglalatból"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "a kapcsolódó felhasználó-azonosító (%u) nem egyezik az elvárttal (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "a kapcsolódó csoportazonosító (%u) nem egyezik az elvárttal (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "nem sikerült a fork() hívása a démonizáláshoz"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "nem sikerült létrehozni új munkamenetet"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "túl sok fájlleíró érkezett"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "nincsenek kapcsolatok a(z) %s foglalathoz %lu másodperce, kilépés"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "nem sikerült elfogadni a(z) %s foglalatból"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "nem sikerült elágaztatni az elfogadáshoz"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "ismeretlen csoport: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "ismeretlen felhasználó: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "nem lehet beállítani a csoportazonosítót erre: %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "nem lehet beállítani a csoportokat erre: %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "nem lehet beállítani a felhasználó-azonosítót erre: %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "nem lehet meghatározni a futtatókörnyezet könyvtárát"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "nem lehet létrehozni: %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "nem sikerült előkészíteni a Windows biztonsági függvényeit"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "nem lehet felépíteni a(z) %s SID-ját: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "nem lehet felépíteni az ACL-t: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "nem lehet lefoglalni a biztonsági leírót: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "nem lehet előkészíteni a biztonsági leírót: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "nem lehet beállítani a tulajdonost a biztonsági leíróban: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "nem lehet beállítani a DACL-t a biztonsági leíróban: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "érvénytelen PKCS#11 URI: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "felismerhetetlen fájlformátum: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "nem sikerült feldolgozni a fájlt: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: nem sikerült előkészíteni: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: nem sikerült felsorolni a foglalatokat: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: nem sikerül lekérni a tokeninformációkat: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: nem sikerült megnyitni a munkamenetet: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr "nincs beállított írható hely a horgonyok tárolásához"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "nincs beállított hely a horgonyok tárolásához"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "nem sikerült létrehozni az objektumot: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "adjon meg legalább egy horgony bemeneti fájlt"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "nem sikerült a csak olvasható %s eltávolítása"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "nem sikerült a(z) %s eltávolítása: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "legalább egy fájlt vagy URI-t meg kell adni"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "egy művelet már meg lett adva"
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u hiba a feldolgozás során"
+msgstr[1] "%u hiba a feldolgozás során"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: érvénytelen tanúsítványkiterjesztés"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: érvénytelen alapvető korlátozások tanúsítványkiterjesztés"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "ismeretlen"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "hiányzik a CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribútum"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "hiányzik a CKA_HASH_OF_ISSUER_PUBLIC_KEY attribútum"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "az objektum nem módosítható"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "ilyen típusú objektumok nem hozhatók létre"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "a(z) %s attribútum nem állítható be"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "a(z) %s attribútum nem változtatható meg"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "a(z) „%s” attribútum érvénytelen értékkel rendelkezik"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "a(z) %s attribútum nem érvényes az objektumhoz"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "hiányzik a(z) %s attribútum"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "nem található CKA_CLASS attribútum"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "nem lehet létrehozni egy %s objektumot"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "token"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "nem token"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "a(z) %s hiányzik az objektumnál"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s nem támogatott %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s nem támogatott objektumosztály"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "érvénytelen kulcshasználat tanúsítványkiterjesztés"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "érvénytelen kiterjesztett kulcshasználat tanúsítványkiterjesztés"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "érvénytelen kulcshasználat visszautasítás tanúsítványkiterjesztés"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "nem sikerült kiírni az objektumot"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "további argumentumok lettek átadva a parancsnak"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "nem sikerült feldolgozni a csatolt tanúsítványkiterjesztést: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "nem sikerült betölteni a csatolt kiterjesztéseket a tanúsítványhoz: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "nem sikerült feldolgozni tanúsítványt: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "nem sikerült betölteni az attribútumokat: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "nem tanúsítvány objektumok kihagyása"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "nem sikerült betölteni a tiltólistát: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "egy PKCS#11 URI már meg lett adva"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "nem sikerült feldolgozni a PKCS#11 URI szűrőt: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+"az URI felismerhetetlen összetevőket tartalmazott, semmi sem lesz kinyerve"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "nem támogatott vagy felismerhetetlen szűrő: %s"
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "nem támogatott vagy felismerhetetlen cél: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "nincsenek megbízhatósági házirendet tartalmazó modulok regisztrálva"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "egy formátum már meg lett adva"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "nem támogatott vagy felismerhetetlen formátum: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "a formátum nem támogatja a megbízhatósági házirendet"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"a formátum egy célt igényel, adja meg a --purpose kapcsolóval, a „server-"
+"auth” alapértelmezett használata"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+"a formátum nem támogat több célt, a „server-auth” alapértelmezett használata"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "adjon meg egy célfájlt vagy könyvtárat"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "nincs kimeneti formátum megadva"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "nem sikerült a(z) %s parancs futtatása"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr "több tanúsítvány található, de csak egyet sikerült fájlba írni"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "nem sikerült tanúsítványokat találni: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "nem található tanúsítvány"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "nem sikerült tanúsítványt találni: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "hosszú karakterlánc csonkolása"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "$SOURCE_DATE_EPOCH környezeti változó: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "$SOURCE_DATE_EPOCH környezeti változó: nem találhatók számjegyek: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "$SOURCE_DATE_EPOCH környezeti változó: lezáró szemét: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"$SOURCE_DATE_EPOCH környezeti változó: az érték legfeljebb %lu lehet, de úgy "
+"tűnik, hogy: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "nem sikerült előállítani egy tanúsítvány álnevét"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "objektum kihagyása, nem sikerült összeállítani az URI-t"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "felismerhetetlen modulargumentum: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "bizalmatlansággal rendelkező tanúsítvány a horgonyok helyén: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "a horgony megbízhatóságának felülbírálása a tiltólistában: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "Nem sikerült feldolgozni a(z) %s típusú PEM-blokkot"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "nem sikerült megnyitni és leképezni a fájlt: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "érvénytelen OID érték: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "nem sikerült létrehozni a fájlt: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "nem sikerült fájlba írni: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "nem sikerült befejezni a fájl írását: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "nem sikerült írni a fájlt: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "nem sikerült beállítani a fájl jogosultságait: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "nem sikerült befejezni a fájl írását: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "nem sikerült eltávolítani az eredeti fájlt: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "nem sikerült létrehozni a könyvtárat: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "a könyvtár már létezik: %s"
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr "nem sikerült megnyitni a könyvtárat: %s"
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "nem sikerült ellenőrizni a könyvtár jogosultságait: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "nem sikerült írhatóvá tenni a könyvtárat: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "nem sikerült létrehozni szimbolikus linket: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "nem sikerült eltávolítani a fájlt: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "nem sikerült beállítani a könyvtár jogosultságait: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "nem sikerült betölteni a fájlt objektumokba: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "nem sikerült elérni az útvonalat: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "nem lehet elérni a megbízhatósági tanúsítvány útvonalát: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "nem lehet elérni a megbízhatósági fájlt: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "nem sikerült elérni: %s"
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr "Megbízhatóság vagy tanúsítványok felsorolása"
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr "Tanúsítványok és megbízhatóság kinyerése"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr "Megbízhatóság-kompatibilitási csomagok kinyerése"
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr "Megbízhatósági horgonyok hozzáadása, eltávolítása vagy megváltoztatása"
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr "Megbízhatósági objektumok kiírása belső formátumban"

--- a/po/ia.po
+++ b/po/ia.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Interlingua (http://www.transifex.com/freedesktop/p11-kit/language/ia/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Interlingua (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ia/)\n"
+"Language: ia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ia\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -1,22 +1,114 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Andika Triwidada <andika@gmail.com>, 2012-2013
+# Andika Triwidada <andika@gmail.com>, 2012-2013,2021
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:12+0000\n"
-"Last-Translator: Andika Triwidada <andika@gmail.com>\n"
-"Language-Team: Indonesian (http://www.transifex.com/freedesktop/p11-kit/language/id/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Andika Triwidada <andika@gmail.com>, 2012-2013,2021\n"
+"Language-Team: Indonesian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "cara pakai: %s perintah <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Perintah-perintah %s umum adalah:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Lihat '%s <command> --help' untuk lebih banyak informasi\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "tidak ada perintah yang dinyatakan"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "opsi global tak dikenal: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "opsi global tak dikenal: - %c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' bukanlah perintah yang valid. Lihat '%s--help'"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: blok pem yang tidak diharapkan"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: header seksi yang tidak diharapkan"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "mode yang tidak valid untuk 'user-config': %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "nama berkas konfig tidak valid, akan diabaikan di masa mendatang: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "tidak bisa membuat daftar direktori: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "tidak bisa men-stat path: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "pengaturan tidak valid '%s' memakai nilai baku '%s'"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "filter tidak bisa diinisialisasi"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "tak bisa memuat info modul: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "ada argumen ekstra yang dinyatakan"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +433,1015 @@ msgstr "Permintaan ditolak oleh pengguna"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Galat tak dikenal"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "tak bisa memuat modul: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "tak bisa menemukan titik masuk C_GetFunctionList dalam modul: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "panggilan ke C_GetFunctiontList gagal dalam modul: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr "menolak untuk memuat modul p11-kit-proxy.so sebagai modul terdaftar"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "modul '%s' memiliki opsi enable-in dan disable-in"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "menggugurkan inisialisasi karena modul '%s' ditandai sebagai kritis"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "inisialisasi p11-kit dipanggil secara rekursif"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "inisialisasi modul kritis '%s' gagal: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "melewati modul '%s' yang inisialisasinya gagal: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "tak bisa menutup sesi: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "opsi '%s' untuk modul '%s' hanya didukung untuk modul terkelola"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: modul gagal menginisialisasi: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: modul gagal menginisialisasi%s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: modul sudah diinisialisasi"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: modul gagal difinalisasi: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "inisialisasi modul gagal: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Daftar modul dan token"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Menjalankan modul PKCS#11 tertentu dari jarak jauh"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+"Menjalankan proses server yang mengekspos modul PKCS#11 dari jarak jauh"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "tak bisa menjalankan alat kepercayaan"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' bukanlah perintah yang valid. Lihat 'p11-kit --help'"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "menyatakan modul atau token yang akan diakses jarak jauh"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "alat 'remote' tidak dimaksudkan untuk dijalankan dari terminal"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "hanya satu modul yang dapat ditentukan"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "respons kesalahan rpc tidak valid: terlalu pendek"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "respons kesalahan rpc tidak valid: kode kesalahan buruk"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "respons rpc tidak valid: ketidakcocokan panggilan"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "respons rpc tidak valid: data argumen buruk"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "menerima larik atribut dengan cacah atribut yang salah"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "mengembalikan atribut dalam urutan yang tidak valid"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "set pemanggilan mutex yang tidak valid disediakan"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "tak bisa dilakukan tanpa penguncian os"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize dipanggil dua kali untuk proses yang sama"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "memfinaliasasi modul RPC mengembalikan kesalahan: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "pesan tidak valid: tak bisa membaca pengenal panggilan"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "pesan tidak valid: id panggilan buruk: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "pesan tidak valid: tak bisa membaca tanda tangan"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "pesan tidak valid: tanda tangan tak cocok"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "panjang string yang diganjal spasi yang diterima tidak valid: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "permintaan tidak valid dari modul, mungkin terlalu pendek"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "tak bisa menginisialisasi respon RPC"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "jabat tangan tidak valid diterima dari modul penghubung"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "tak bisa mengurai pesan rpc pkcs#11"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "kehabisan memori saat menyatukan pesan"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "kehabisan memori saat merespon dengan kesalahan"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "versi yang tidak didukung diterima: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "tak bisa membaca byte kredensial"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "tak bisa menulis byte kredensial"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "gagal membaca pesan rpc"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "kesalahan tak terduga saat menangani pesan rpc"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "gagal menulis pesan rpc"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "tak bisa mengirim data: sambungan tertutup"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "tak bisa mengirim data"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "tak bisa menerima data: sambungan tertutup"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "tak bisa menerima data"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+"menerima nilai header rpc yang tidak valid: mungkin protokol yang salah"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "tak bisa menggunakan select untuk menunggu pipa rpc"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "tak bisa mengirim kredensial soket"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "tak bisa mengirim kredensial soket"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "menutup soket karena kegagalan protokol"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "proses %d tidak keluar, mengakhiri"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "gagal menunggu anak yang dieksekusi: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "proses %d keluar dengan status %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "proses %d dihentikan dengan sinyal %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "gagal membuat pipa untuk remote"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "gagal fork untuk remote"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "proses %p tidak keluar, mengakhiri"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "tak bisa mengakhiri proses %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "gagal menunggu anak yang dieksekusi: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "gagal mendapatkan status keluar dari %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "proses %p keluar dengan status %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "gagal menduplikasi stdin"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "gagal menduplikasi stdout"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "gagal menduplikasi ujung pipa anak"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "gagal spawn remote"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "gagal memulihkan deskriptor berkas"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "baris perintah jarak jauh yang tidak valid: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "gagal membuat soket untuk remote"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "gagal mengurai alamat vsock: '%s'"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "remote tidak didukung: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "anak %u mati dengan sigsegv"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "anak %u mati dengan sinyal %d"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "tidak bisa membuat soket %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "tidak bisa mengikat soket %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "tidak bisa mendengarkan soket %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "tidak bisa chown socket %s"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "tidak bisa membuat soket %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "tidak bisa mengikat soket %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "tidak bisa mendengarkan soket %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "tidak bisa memeriksa uid dari soket"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "menghubungkan uid (%u) tidak cocok dengan yang diharapkan (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "menghubungkan gid (%u) tidak sesuai cocok yang diharapkan (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "tidak bisa fork() untuk menjadikan daemon"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "tidak bisa membuat sesi baru"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "terlalu banyak deskriptor berkas yang diterima"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "tidak ada koneksi ke %s selama %lu detik, keluar"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "tidak bisa accept dari soket %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "gagal fork untuk accept"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "grup tidak dikenal: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "pengguna tidak dikenal: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "tidak dapat mengatur gid ke %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "tidak bisa setgroups ke %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "tidak dapat mengatur uid ke %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "tak bisa menentukan direktori runtime"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "tidak bisa membuat %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "tak bisa menginisialisasi fungsi keamanan Windows"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "tidak dapat membangun SID untuk %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "tidak bisa membangun ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "tidak bisa mengalokasikan deskriptor keamanan: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "tidak dapat menginisialisasi deskriptor keamanan: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "tidak bisa mengatur pemilik dalam deskriptor keamanan: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "tidak bisa mengatur DACL dalam deskriptor keamanan: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "uri PKCS#11 tidak valid: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "format berkas tidak dikenal: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "gagal mengurai berkas: '%s'"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: tak bisa menginisialisasi: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: tak bisa mengenumerasi slot: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: tak bisa mendapatkan info token: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: tak bisa membuka sesi: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+"tidak ada lokasi yang dapat ditulis yang dikonfigurasi untuk menyimpan "
+"jangkar"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "tidak ada lokasi yang dikonfigurasi untuk menyimpan jangkar"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "tak bisa membuat objek: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "nyatakan setidaknya satu berkas masukan jangkar"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "tak bisa menghapus yang baca-saja %s"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "tak bisa menghapus %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "setidaknya satu berkas atau uri harus dinyatakan"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "suatu tindakan sudah dinyatakan"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u kesalahan saat memroses"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: ekstensi sertifikat tidak valid"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: ekstensi sertifikat basic constraints yang tidak valid"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "tidak diketahui"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "kurang atribut CKA_HASH_OF_SUBJECT_PUBLIC_KEY"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "kurang atribut CKA_HASH_OF_ISSUER_PUBLIC_KEY"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "objek tidak dapat dimodifikasi"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "objek tipe ini tidak dapat dibuat"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "atribut %s tidak dapat diatur"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "atribut %s tidak dapat diubah"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "atribut %s memiliki nilai yang tidak valid"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "atribut %s tidak berlaku untuk objek"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "kurang atribut %s"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "tidak ditemukan atribut CKA_CLASS"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "tidak dapat membuat objek %s"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "token"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "non-token"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "kurang %s pada objek"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s %s yang tidak didukung"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s kelas objek yang tidak didukung"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "ekstensi sertifikat key usage tidak valid"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "ekstensi sertifikat extended key usage yang tidak valid"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "ekstensi sertifikat reject key usage tidak valid"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "tidak bisa mencurahkan objek"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "argumen tambahan diteruskan ke perintah"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "tak bisa mengurai ekstensi sertifikat terlampir: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "tak bisa memuat ekstensi terlampir untuk sertifikat: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "tak bisa mengurai sertifikat: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "tak bisa memuat atribut: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "melewati objek non-sertifikat"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "tak bisa memuat blocklist: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "suatu URI PKCS#11 telah dinyatakan"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "tak bisa mengurai filter uri pkcs#11: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+"uri mengandung komponen yang tidak dikenal, tidak ada yang akan diekstraksi"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "filter yang tidak didukung atau tidak dikenal: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "tujuan yang tidak didukung atau tidak dikenal: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "tidak ada modul yang berisi kebijakan kepercayaan yang terdaftar"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "suatu format sudah dinyatakan"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "format yang tidak didukung atau tidak dikenal: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "format tidak mendukung kebijakan kepercayaan"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"format membutuhkan tujuan, tentukan dengan --purpose; memakai nilai baku "
+"'server-auth'"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+"format tidak mendukung beberapa tujuan, memakai nilai baku 'server-auth'"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "nyatakan satu berkas atau direktori tujuan"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "tidak ada format keluaran yang dinyatakan"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "tidak bisa menjalankan perintah %s"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr "beberapa sertifikat ditemukan tetapi hanya bisa menulis satu ke berkas"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "gagal menemukan sertifikat: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "tidak ditemukan sertifikat"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "gagal menemukan sertifikat: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "memotong string panjang"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Variabel lingkungan $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+"Variabel lingkungan $SOURCE_DATE_EPOCH: Tidak ada digit yang ditemukan: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Variabel lingkungan $SOURCE_DATE_EPOCH: Sampah di ujung: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Variabel lingkungan $SOURCE_DATE_EPOCH: nilai harus kurang dari atau sama "
+"dengan %lu tetapi ditemukan: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "tidak bisa menghasilkan nama alias sertifikat"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "melewati objek, tidak bisa membangun uri"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "argumen modul yang tidak dikenal: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "sertifikat dengan ketidakpercayaan di lokasi untuk jangkar: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "mengesampingkan kepercayaan untuk jangkar di blocklist: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "Tak bisa mengurai blok PEM tipe %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "tak bisa membuka dan memetakan berkas: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "nilai oid tidak valid: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "tak bisa membuat berkas: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "tak bisa menulis ke berkas: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "tidak dapat menyelesaikan penulisan berkas: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "tak bisa menulis berkas: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "tak bisa mengatur izin berkas: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "tak bisa menyelesaikan penulisan berkas: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "tak bisa menghapus berkas asli: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "tak bisa membuat direktori: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "direktori sudah ada: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "tak bisa membuat direktori: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "tak bisa mengatur izin direktori: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "tak bisa membuat direktori menjadi dapat ditulis: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "tak bisa membuat symlink: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "tak bisa menghapus berkas: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "tak bisa mengatur izin direktori: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "tak bisa memuat berkas ke dalam objek: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "tak bisa stat path: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "tak bisa mengakses path sertifikat kepercayaan: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "tak bisa mengakses berkas kepercayaan: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "tak bisa mengakses: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "tak bisa mengurai sertifikat: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "tidak ditemukan sertifikat"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -1,24 +1,113 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Luca Ferretti <elle.uca@libero.it>, 2012
+# Luca Ferretti <elle.uca@gmail.com>, 2012
 # Milo Casagrande <milo@ubuntu.com>, 2013
 # Milo Casagrande <milo@ubuntu.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:31+0000\n"
-"Last-Translator: Milo Casagrande <milo@ubuntu.com>\n"
-"Language-Team: Italian (http://www.transifex.com/freedesktop/p11-kit/language/it/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Milo Casagrande <milo@ubuntu.com>, 2013\n"
+"Language-Team: Italian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -343,3 +432,1003 @@ msgstr "La richiesta è stata rifiutata dall'utente"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,22 +1,111 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Tomoyuki KATO <inactive+katomo@transifex.com>, 2012-2013
+# Takuro Onoue <kusanaginoturugi@gmail.com>, 2021
+# e93ed3aa97dec2eb31063731872555fc_1460a05 <71305a0095156d8e18373a5b7cfeb79e_8587>, 2012-2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:45+0000\n"
-"Last-Translator: Tomoyuki KATO <inactive+katomo@transifex.com>\n"
-"Language-Team: Japanese (http://www.transifex.com/freedesktop/p11-kit/language/ja/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Takuro Onoue <kusanaginoturugi@gmail.com>, 2021\n"
+"Language-Team: Japanese (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -292,11 +381,11 @@ msgstr "キーが誤った形式のためエクスポートできません"
 
 #: p11-kit/messages.c:215
 msgid "Unable to initialize the random number generator"
-msgstr "乱数生成器を初期化できません"
+msgstr "乱数発生器を初期化できません"
 
 #: p11-kit/messages.c:217
 msgid "No random number generator available"
-msgstr "利用可能な乱数生成器がありません"
+msgstr "利用可能な乱数発生器がありません"
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
@@ -341,3 +430,1001 @@ msgstr "リクエストがユーザーにより拒否されました。"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "未知のエラー"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -1,22 +1,114 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # George Machitidze <giomac@gmail.com>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 13:58+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Georgian (http://www.transifex.com/freedesktop/p11-kit/language/ka/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: George Machitidze <giomac@gmail.com>, 2012\n"
+"Language-Team: Georgian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ka/)\n"
+"Language: ka\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ka\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "გამოყენება: %s ბრძანება <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"გავრცელებული %s ბრძანებები:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"მეტი ინფორმაციისთვის იხილეთ '%s <command> --help'\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "ბრძანება მითითებული არაა"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "უცნობი გლობალური პარამეტრი: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "უცნობი გლობალური პარამეტრი: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: მოულოდნელი PEM ბლოკი"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: სექციის მოულოდნელი თავსართი"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "'user-config'-ის არასწორი რეჟიმი: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "კონფიგურაციის არასწორი ფაილი. მომავალში იგნორირებული იქნება: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "საქაღალდის სიის მიღების შეცდომა: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "ბილიკის აღმოჩენის შეცდომა: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "არასწორი პარამეტრი %s. ნაგულისხმებად გამოიყენება %s"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "ფილტრის ინიციალიზაციის შეცდომა"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "მოდულის ინფორმაციის ჩატვირთვის შეცდომა: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "მითითებულია დამატებითი არგუმენტები"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -44,11 +136,11 @@ msgstr "არგუმენტები არასწორია"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr ""
+msgstr "მოდულს საჭირო ნაკადების შექმნა არ შეუძლია"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
-msgstr ""
+msgstr "მოდულს მონაცემების სწორად დაბლოკვა არ შეუძლია"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
@@ -80,11 +172,11 @@ msgstr "შეცდომა მოწყობილობაში"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr ""
+msgstr "მოწყობილობაზე არსებული მეხსიერება საკმარისი არაა"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
-msgstr ""
+msgstr "მოწყობილობა გამოერთებულია"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
@@ -168,15 +260,15 @@ msgstr "პაროლი ან PIN არასწორია"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr ""
+msgstr "პაროლის ან PIN-ის არასწორი სიგრძე"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
-msgstr ""
+msgstr "პაროლს ან PIN კოდს ვადა გაუვიდა"
 
 #: p11-kit/messages.c:157
 msgid "The password or PIN is locked"
-msgstr ""
+msgstr "პაროლი ან PIN კოდი დაბლოკილია"
 
 #: p11-kit/messages.c:159
 msgid "The session is closed"
@@ -184,7 +276,7 @@ msgstr "სესია დაკეტილია"
 
 #: p11-kit/messages.c:161
 msgid "Too many sessions are active"
-msgstr ""
+msgstr "მეტისმეტად ბევრი აქტიური სესია"
 
 #: p11-kit/messages.c:163
 msgid "The session is invalid"
@@ -196,7 +288,7 @@ msgstr "სესია მხოლოდ კითხვადია"
 
 #: p11-kit/messages.c:167
 msgid "An open session exists"
-msgstr ""
+msgstr "ღია სესია არსებობს"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
@@ -341,3 +433,1002 @@ msgstr ""
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "უცნობი შეცდომა"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "საქაღალდის სიის მიღების შეცდომა: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "საქაღალდის სიის მიღების შეცდომა: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 19:45+0000\n"
-"Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
-"Language-Team: Kazakh (http://www.transifex.com/freedesktop/p11-kit/language/kk/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2014\n"
+"Language-Team: Kazakh (http://www.transifex.com/freedesktop/p11-kit/language/"
+"kk/)\n"
+"Language: kk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: kk\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -340,4 +428,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/kn.po
+++ b/po/kn.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Kannada (http://www.transifex.com/freedesktop/p11-kit/language/kn/)\n"
+"Language-Team: Kannada (http://www.transifex.com/freedesktop/p11-kit/"
+"language/kn/)\n"
+"Language: kn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: kn\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,24 +1,116 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Seong-ho Cho <darkcircle.0426@gmail.com>, 2013
-# Seong-ho Cho <darkcircle.0426@gmail.com>, 2013
+# Seong-ho Cho <darkcircle.0426@gmail.com>, 2013,2021-2022
 # Shinjo Park <kde@peremen.name>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:15+0000\n"
-"Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
-"Language-Team: Korean (http://www.transifex.com/freedesktop/p11-kit/language/ko/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>, 2013,2021-2022\n"
+"Language-Team: Korean (http://www.transifex.com/freedesktop/p11-kit/language/"
+"ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "사용법: %s 명령 <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"일반 %s 명령은 다음과 같습니다:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"자세한 사용법은 '%s<command> --help' 를 입력하십시오\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "지정한 명령이 없습니"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "알 수 없는 전역 옵션: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "알 수 없는 전역 옵션: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' 명령은 적절하지 않습니다. '%s --help' 를 입력하십시오"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: 예기치 않은 pem 블록"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: 예기치 않은 섹션 헤더"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "'user-config'에 부적절한 모드: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "잘못된 설정 파일 이름입니다. 이후 무시합니다: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "디렉터리를 확인할 수 없습니다: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "경로 상태를 확인할 수 없습니다: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "잘못된 '%s' 설정을 '%s' 기본 설정으로 되돌립니다"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "필터를 초기화할 수 없음"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "모듈 정보를 불러올 수 없습니다: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "추가 인자를 지정함"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -82,7 +174,7 @@ msgstr "장치에 오류가 발생함"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr "장치에 메모리가 부족함"
+msgstr "장치 메모리가 부족함"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
@@ -343,3 +435,1002 @@ msgstr "사용자가 요청을 거절했습니다"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "알 수 없는 오류"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "모듈을 불러올 수 없습니다: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "모듈의 C_GetFunctionList 항목 지점을 찾을 수 없습니다: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "모듈의 C_GetFunctionList 호출에 실패했습니다: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr "p11-kit-proxy.so 모듈을 등록 모듈로 불러오기를 거부함"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "'%s' 모듈에 enable-in 옵션과 disable-in 옵션이 같이 들어있음"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "'%s' 모듈이 치명적 문제를 안고 있음을 확인하여 초기화를 취소함"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit 초기화 과정을 재귀적으로 호출했습니다"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "치명적 문제가 있는 '%s' 모듈의 초기화 실패: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "초기화에 실패한 '%s' 모듈을 건너뜁니다: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "세션을 닫을 수 없습니다: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "'%s' 옵션 ('%s' 모듈에서 사용함) 은 관리 모듈에서만 지원합니다"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: 모듈 초기화 실패: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: 모듈의 %s 초기화 실패: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: 모듈을 이미 초기화했음"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: 모듈 초기화 실패: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "모듈 초기화 실패: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "모듈과 토큰을 조회합니다"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "PKCS#11 개별 모듈을 원격으로 실행합니다"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "PKCS#11 모듈을 노출하는 서버 프로세스를 원격으로 실행합니다"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "신뢰 도구를 실행할 수 없음"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' 명령은 적절하지 않습니다. 'p11-kit --help' 를 입력하십시오."
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "'remote' 도구는 터미널에서 실행한다는 의미가 아닙니다."
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "하나의 모듈만 지정할 수 있습니다"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "부적절한 RPC 오류 응답: 너무 짧습니다"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "부적절한 RPC 오류 응답: 잘못된 오류 코드"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "부적절한 RPC 응답: 호출이 일치하지 않음"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "부적절한 RPC 응답: 잘못된 인자 데이터"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "수신한 속성 배열의 속성 갯수가 올바르지 않습니다"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "반환한 속성 순서가 부적절합니다"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "부적절한 뮤텍스 호출 세트가 있습니다"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "OS를 잠그지 않으면 진행할 수 없습니다"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize를 동일한 프로세스에서 두 번 호출했습니다"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "RPC 모듈에서 마무리하는 중 오류를 반환했습니다: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "부적절한 메세지: 호출 식별자를 읽을 수 없습니다."
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "부적절한 메세지: 잘못된 호출 ID: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "부적절한 메세지: 서명을 읽을 수 없음"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "부적절한 메세지: 서명이 일치하지 않음"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "전송한 패딩 문자열에 부적절한 길이의 공백문자: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "모듈에서 부적절한 요청, 짧은 것 같습니다"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "RPC 응답을 초기화할 수 없습니다"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "연결 모듈에서 부적절한 핸드셰이크를 수신했습니다"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "pkcs11 RPC 메세지를 해석할 수 없습니다"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "메세지 동시 처리 중 메모리 부족 오류"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "오류 응답 중 메모리 부족"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "지원하지 않는 버전 정보를 받았습니다: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "인증 바이트를 읽을 수 없습니다"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "인증 바이트를 기록할 수 없습니다"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "RPC 메세지 읽기 실패"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "RPC 메세지 처리 중 예기치 못한 오류"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "RPC 메세지 기록 실패"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "데이터를 보낼 수 없습니다: 연결 끊김"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "데이터를 보낼 수 없습니다"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "데이터를 받을 수 없습니다: 연결 끊김"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "데이터를 받을 수 없습니다"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "부적절한 RPC 헤더 값을 받았습니다: 아마도 잘못된 프로토콜인 것 같음"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "RPC 파이프 대기시 선택을 활용할 수 없음"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "소켓 인증을 보낼 수 없습니다"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "소켓 인증을 보낼 수 없습니다"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "프로토콜 통신 실패로 소켓을 닫음"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "프로세스 %d번을 끝내지 않았습니다. 끝내는 중"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "하위 실행 프로세스 대기 실패: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "프로세스 %d번이 상태 %d번으로 끝났습니다"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "프로세스 %d번이 %d번 시그널로 끝났습니다"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "원격 파이프 생성 실패"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "원격 프로세스 포크 실패"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "%p 프로세스를 끝내지 않았습니다. 끝내는 중"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "%p 프로세스를 끝낼 수 없습니다"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "하위 실행 프로세스 대기 실패: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "%p 프로세스의 끝내기 상태 가져오기 실패"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "%p 프로세스가 %lu 상태로 끝났습니다"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "stdin 복제 실패"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "stdout 복제 실패"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "하위 프로세스 파이프 끝 복제 실패"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "파일 서술자 복구 실패"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "부적절한 원격 명령 행: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "원격 소켓 만들기 실패"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr " vsock 주소 해석 실패: '%s'"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "원격을 지원하지 않습니다: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "%u 하위 프로세스에 SIGSEGV 시그널을 보내어 갑자기 끝났습니다"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "%u 하위 프로세스에 %d 시그널을 보내어 갑자기 끝났습니다"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "%s 소켓을 만들 수 없습니다"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "%s 소켓에 바인딩할 수 없습니다"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "%s 소켓을 감청할 수 없습니다"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "%s 소켓 소유권을 바꿀 수 없습니다"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "%u 소켓을 만들 수 없습니다: %u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "%u 소켓에 바인딩할 수 없습니다: %u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "%u 소켓을 감청할 수 없습니다: %u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "소켓의 UID를 확인할 수 없습니다."
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "연결할 UID(%u)가 필요 대상(%u)과 일치하지 않습니다"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "연결할 GID(%u)가 필요 대상(%u)과 일치하지 않습니다"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "데몬화 과정에서 fork()를 호출할 수 없습니다"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "새 세션을 만들 수 없습니다"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "너무 많은 파일 서술자를 받았습니다"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "%s 소켓에서 수락할 수 없습니다"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "알 수 없는 그룹: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "알 수 없는 사용자: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "%u에 GID를 설정할 수 없습니다"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "%u에 setgroups를 실행할 수 없습니다"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "%u에 UID를 설정할 수 없습니다"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "실행 시간 디렉터리를 알 수 없습니다"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "지원하지 않는 버전 정보를 받았습니다: %d"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "디렉터리를 확인할 수 없습니다: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "디렉터리를 확인할 수 없습니다: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -1,25 +1,116 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
+# Moo, 2020-2021
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Lithuanian (http://www.transifex.com/freedesktop/p11-kit/language/lt/)\n"
+"Last-Translator: Moo, 2020-2021\n"
+"Language-Team: Lithuanian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/lt/)\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lt\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
-msgstr ""
+msgstr "Operacijos buvo atsisakyta"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
@@ -31,27 +122,27 @@ msgstr ""
 
 #: p11-kit/messages.c:85
 msgid "Internal error"
-msgstr ""
+msgstr "Vidinė klaida"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr ""
+msgstr "Operacija nepavyko"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
-msgstr ""
+msgstr "Neteisingi argumentai"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr ""
+msgstr "Modulis negali sukurti reikalingų gijų"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
-msgstr ""
+msgstr "Modulis negali tinkamai užrakinti duomenų"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr ""
+msgstr "Šis laukas yra tik skaitymui"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
@@ -71,19 +162,19 @@ msgstr ""
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
-msgstr ""
+msgstr "Duomenys yra per ilgi"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
-msgstr ""
+msgstr "Įrenginyje įvyko klaida"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr ""
+msgstr "Įrenginyje nepakanka prieinamos atminties"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
-msgstr ""
+msgstr "Įrenginyje buvo pašalintas ar atjungtas"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
@@ -91,11 +182,11 @@ msgstr ""
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
-msgstr ""
+msgstr "Šifruoti duomenys yra per ilgi"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
-msgstr ""
+msgstr "Ši operacija yra nepalaikoma"
 
 #: p11-kit/messages.c:119
 msgid "The key is missing or invalid"
@@ -135,7 +226,7 @@ msgstr ""
 
 #: p11-kit/messages.c:137
 msgid "Cannot export this key"
-msgstr ""
+msgstr "Nepavyksta eksportuoti šio rakto"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
@@ -151,11 +242,11 @@ msgstr ""
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr ""
+msgstr "Jau vykdoma kita operacija"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
-msgstr ""
+msgstr "Nevykdoma jokia operacija"
 
 #: p11-kit/messages.c:149
 msgid "The password or PIN is incorrect"
@@ -207,11 +298,11 @@ msgstr ""
 
 #: p11-kit/messages.c:173
 msgid "The signature is bad or corrupted"
-msgstr ""
+msgstr "Parašas yra blogas arba pažeistas"
 
 #: p11-kit/messages.c:175
 msgid "The signature is unrecognized or corrupted"
-msgstr ""
+msgstr "Parašas yra neatpažintas ar pažeistas"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
@@ -327,16 +418,1017 @@ msgstr ""
 
 #: p11-kit/messages.c:233
 msgid "Cannot lock data"
-msgstr ""
+msgstr "Nepavyksta užrakinti duomenų"
 
 #: p11-kit/messages.c:235
 msgid "The data cannot be locked"
-msgstr ""
+msgstr "Duomenys negali būti užrakinti"
 
 #: p11-kit/messages.c:237
 msgid "The request was rejected by the user"
-msgstr ""
+msgstr "Naudotojas atmetė užklausą"
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr "Nežinoma klaida"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -1,22 +1,111 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Rūdolfs Mazurs <rudolfs.mazurs@gmail.com>, 2013
+# Rūdolfs Mazurs <alta.liepa@gmail.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 15:00+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Latvian (http://www.transifex.com/freedesktop/p11-kit/language/lv/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Rūdolfs Mazurs <alta.liepa@gmail.com>, 2013\n"
+"Language-Team: Latvian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/lv/)\n"
+"Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lv\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +430,1003 @@ msgstr ""
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Nezināma kļūda"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Malayalam (http://www.transifex.com/freedesktop/p11-kit/language/ml/)\n"
+"Language-Team: Malayalam (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ml/)\n"
+"Language: ml\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ml\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Marathi (http://www.transifex.com/freedesktop/p11-kit/language/mr/)\n"
+"Language-Team: Marathi (http://www.transifex.com/freedesktop/p11-kit/"
+"language/mr/)\n"
+"Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Malay (http://www.transifex.com/freedesktop/p11-kit/language/ms/)\n"
+"Language-Team: Malay (http://www.transifex.com/freedesktop/p11-kit/language/"
+"ms/)\n"
+"Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ms\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1002 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Norwegian Bokmål (http://www.transifex.com/freedesktop/p11-kit/language/nb/)\n"
+"Language-Team: Norwegian Bokmål (http://www.transifex.com/freedesktop/p11-"
+"kit/language/nb/)\n"
+"Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Richard E. van der Luit <nippur@fedoraproject.org>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:45+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Dutch (http://www.transifex.com/freedesktop/p11-kit/language/nl/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Richard E. van der Luit <nippur@fedoraproject.org>, 2012\n"
+"Language-Team: Dutch (http://www.transifex.com/freedesktop/p11-kit/language/"
+"nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr ""
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Onbekende fout"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Norwegian Nynorsk (http://www.transifex.com/freedesktop/p11-kit/language/nn/)\n"
+"Language-Team: Norwegian Nynorsk (http://www.transifex.com/freedesktop/p11-"
+"kit/language/nn/)\n"
+"Language: nn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -1,22 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Cédric Valmary <cvalmary@yahoo.fr>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-23 20:04+0000\n"
-"Last-Translator: Cédric Valmary <cvalmary@yahoo.fr>\n"
-"Language-Team: Occitan (post 1500) (http://www.transifex.com/freedesktop/p11-kit/language/oc/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Cédric Valmary <cvalmary@yahoo.fr>, 2016\n"
+"Language-Team: Occitan (post 1500) (http://www.transifex.com/freedesktop/p11-"
+"kit/language/oc/)\n"
+"Language: oc\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: oc\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +429,1002 @@ msgstr "La demanda es estada regetada per l'utilizaire"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Error desconeguda"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/or.po
+++ b/po/or.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Oriya (http://www.transifex.com/freedesktop/p11-kit/language/or/)\n"
+"Language-Team: Odia (http://www.transifex.com/freedesktop/p11-kit/language/"
+"or/)\n"
+"Language: or\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: or\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -1,22 +1,111 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# A S Alam <alam.yellow@gmail.com>, 2012
+# A S Alam, 2021
+# A S Alam, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 13:38+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Panjabi (Punjabi) (http://www.transifex.com/freedesktop/p11-kit/language/pa/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: A S Alam, 2021\n"
+"Language-Team: Panjabi (Punjabi) (http://www.transifex.com/freedesktop/p11-"
+"kit/language/pa/)\n"
+"Language: pa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pa\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -56,7 +145,7 @@ msgstr "ਖੇਤਰ ਕੇਵਲ ਪੜ੍ਹਨ ਲਈ ਹੈ"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
-msgstr ""
+msgstr "ਖੇਤਰ ਸੰਵੇਦਨਸ਼ਲੀ ਹੈ ਅਤੇ ਦਿਖਾਇਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ"
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
@@ -124,7 +213,7 @@ msgstr "ਕੁੰਜੀ ਦੀ ਲੋੜ ਹੈ"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
-msgstr ""
+msgstr "ਕੁੰਜੀ ਸਾਰ ਵਿੱਚ ਸ਼ਾਮਲ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
@@ -132,7 +221,7 @@ msgstr "ਇਹ ਕਾਰਵਾਈ ਇਸ ਕੁੰਜੀ ਨਾਲ ਨਹੀਂ 
 
 #: p11-kit/messages.c:135
 msgid "The key cannot be wrapped"
-msgstr ""
+msgstr "ਕੁੰਜੀ ਲਪੇਟੀ ਨਹੀਂ ਜਾ ਸਕਦੀ"
 
 #: p11-kit/messages.c:137
 msgid "Cannot export this key"
@@ -252,23 +341,23 @@ msgstr "ਤੁਸੀਂ ਪਹਿਲਾਂ ਹੀ ਲਾਗਇਨ ਹੋ"
 
 #: p11-kit/messages.c:195
 msgid "No user has logged in"
-msgstr "ਕੋਈ ਯੂਜ਼ਰ ਲਾਗਇਨ ਨਹੀਂ ਹੈ"
+msgstr "ਕੋਈ ਵਰਤੋਂਕਾਰ ਲਾਗਇਨ ਨਹੀਂ ਹੈ"
 
 #: p11-kit/messages.c:197
 msgid "The user's password or PIN is not set"
-msgstr "ਯੂਜ਼ਰ ਦਾ ਪਾਸਵਰਡ ਜਾਂ ਪਿੰਨ ਸੈੱਟ ਨਹੀਂ ਹੈ"
+msgstr "ਵਰਤੋਂਕਾਰ ਦਾ ਪਾਸਵਰਡ ਜਾਂ ਪਿੰਨ ਸੈੱਟ ਨਹੀਂ ਹੈ"
 
 #: p11-kit/messages.c:199
 msgid "The user is of an invalid type"
-msgstr "ਯੂਜ਼ਰ ਦੀ ਕਿਸਮ ਗਲਤ ਹੈ"
+msgstr "ਵਰਤੋਂਕਾਰ ਦੀ ਕਿਸਮ ਗਲਤ ਹੈ"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
-msgstr "ਹੋਰ ਯੂਜ਼ਰ ਪਹਿਲਾਂ ਹੀ ਲਾਗਇਨ ਹੈ"
+msgstr "ਹੋਰ ਵਰਤੋਂਕਾਰ ਪਹਿਲਾਂ ਹੀ ਲਾਗਇਨ ਹੈ"
 
 #: p11-kit/messages.c:203
 msgid "Too many users of different types are logged in"
-msgstr ""
+msgstr "ਵੱਖੋ-ਵੱਖ ਕਿਸਮ ਦੇ ਕਈ ਸਾਰੇ ਵਰਤੋਂਕਾਰ ਲਾਗਇਨ ਹਨ"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
@@ -300,7 +389,7 @@ msgstr "ਕੋਈ ਰੈਂਡਮ ਨੰਬਰ ਜਰਨੇਟਰ ਉਪਲੱ�
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
-msgstr ""
+msgstr "ਕ੍ਰਿਪਟੂ ਢੰਗ ਵਿੱਚ ਗ਼ਲਤ ਪੈਰਾਮੀਟਰ ਹੈ"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
@@ -312,7 +401,7 @@ msgstr "ਸੰਭਾਲੀ ਹਾਲਤ ਗਲਤ ਹੈ"
 
 #: p11-kit/messages.c:225
 msgid "The information is sensitive and cannot be revealed"
-msgstr ""
+msgstr "ਜਾਣਕਾਰੀ ਸੰਵੇਦਨਸ਼ੀਲ ਹੈ ਅਤੇ ਦਿਖਾਈ ਨਹੀਂ ਜਾ ਸਕਦੀ ਹੈ"
 
 #: p11-kit/messages.c:227
 msgid "The state cannot be saved"
@@ -336,8 +425,1007 @@ msgstr "ਡਾਟਾ ਲਾਕ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ"
 
 #: p11-kit/messages.c:237
 msgid "The request was rejected by the user"
-msgstr ""
+msgstr "ਮੰਗ ਨੂੰ ਵਰਤੋਂਕਾਰ ਵਲੋਂ ਇਨਕਾਰ ਕੀਤਾ"
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
-msgstr "ਅਣਜਾਣ ਗਲਤੀ"
+msgstr "ਅਣਪਛਾਤੀ ਗਲਤੀ"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,22 +1,117 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
-# Piotr Drąg <piotrdrag@gmail.com>, 2012-2013,2016
+# Piotr Drąg <piotrdrag@gmail.com>, 2012-2013,2016,2021
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:46+0000\n"
-"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Polish (http://www.transifex.com/freedesktop/p11-kit/language/pl/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>, 2012-2013,2016,2021\n"
+"Language-Team: Polish (http://www.transifex.com/freedesktop/p11-kit/language/"
+"pl/)\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "użycie: %s polecenie <args>…\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Wspólne polecenia %s:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Polecenie „%s <command> --help” wyświetli więcej informacji\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "nie podano polecenia"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "nieznana globalna opcja: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "nieznana globalna opcja: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+"„%s” nie jest prawidłowym poleceniem. „%s --help” zawiera więcej informacji"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "nie można zainicjować filtru"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "nie można wczytać informacji o module: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "podano dodatkowe parametry"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +436,1006 @@ msgstr "Żądanie zostało odrzucone przez użytkownika"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Nieznany błąd"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Wyświetla listę modułów i tokenów"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Zdalnie uruchamia podany moduł PKCS#11"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Uruchamia proces serwera zdalnie eksponujący moduł PKCS#11"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+"„%s” nie jest prawidłowym poleceniem. „p11-kit --help” zawiera więcej "
+"informacji"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "podaje moduł lub tokeny dla polecenia remote"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "narzędzie „remote” nie powinno być uruchamiane w terminalu"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "można podać tylko jeden moduł"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "nie można wczytać informacji o module: %s"
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,22 +1,111 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Pedro Albuquerque <palbuquerque73@openmailbox.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 19:45+0000\n"
-"Last-Translator: Pedro Albuquerque <palbuquerque73@gmail.com>\n"
-"Language-Team: Portuguese (http://www.transifex.com/freedesktop/p11-kit/language/pt/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Pedro Albuquerque <palbuquerque73@openmailbox.com>, 2015\n"
+"Language-Team: Portuguese (http://www.transifex.com/freedesktop/p11-kit/"
+"language/pt/)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +430,1003 @@ msgstr "O pedido foi rejeitado pelo utilizador"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Erro desconhecido"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,22 +1,117 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
+# Matheus Barbosa <mdpb.matheus@gmail.com>, 2022
 # Rafael Fontenelle <rffontenelle@gmail.com>, 2012-2013
+# Rafael Fontenelle <rffontenelle@gmail.com>, 2021
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:53+0000\n"
-"Last-Translator: Rafael Fontenelle <rffontenelle@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/freedesktop/p11-kit/language/pt_BR/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Matheus Barbosa <mdpb.matheus@gmail.com>, 2022\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/freedesktop/p11-"
+"kit/language/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "uso: %s comando <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Comandos comuns %s são:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Veja “%s <comando> --help” para mais informações\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "nenhum comando especificado"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "opção global desconhecida: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "opção global desconhecida: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "“%s” não é um comando válido. Veja “%s --help”"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: bloco pem inesperado"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: cabeçalho de sessão inesperado"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "modo inválido para “user-config”: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "nome de configuração inválida, será ignorada no futuro: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "não foi possível listar diretório: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "caminho declarado não possível: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "configuração “%s” inválida padronizada para “%s”"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "o filtro não pôde ser inicializado"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "não foi possível carregar módulo de informação: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "argumentos extra especificados"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -168,7 +263,7 @@ msgstr "A senha ou PIN é inválida"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr "A senha ou PIN possui um comprimeto inválido"
+msgstr "A senha ou PIN possui um tamanho inválido"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
@@ -341,3 +436,1021 @@ msgstr "A requisição foi rejeitada pelo usuário"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Erro desconhecido"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "não foi possível carregar módulo: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+"não foi possível encontrar o ponto de entrada C_GetFunctionList no módulo: "
+"%s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "falha na chamada de C_GetFunctionList no módulo: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+"recusado o carregamento do módulo p11-kit-proxy.so como um módulo registrado"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "módulo “%s” tem ambas opções habilitar e desabilitar"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+"inicialização abortada por causa do módulo '%s' foi marcado como crítico"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "inicialização de p11-kit chamada recursivamente"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "inicialização do módulo critico “%s” falhou: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "pulando o módulo “%s” cuja inicialização falhou: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "não foi possível fechar sessão: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+"a opção '%s' do módulo '%s' é somente suportada para módulos gerenciados"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: o módulo falhou ao inicializar: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: o módulo falhou ao iniciar %s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: o módulo já foi inicializado"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: o módulo falhou ao finalizar: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "inicialização do módulo falhou: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Lista módulos e tokens"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Executa um módulo PKCS#11 específico remotamente"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Executa o processo de servidor que expõe o módulo PKCS#11 remotamente"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "não foi possível executar a ferramenta trust"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "“%s” não é um comando válido. Veja “p11-kit --help”"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "especifique alguns tokens ou um módulo para remoto"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "a ferramenta “remote” não foi feita para executar de um terminal"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "somente um módulo pode ser especificado"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "resposta de erro rpc errada: muito curta"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "resposta de erro rpc inválida: código com erro grave"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "resposta rpc inválida: chamada equivocada"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "resposta rpc inválida: argumento de dados errado"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "recebido um vetor de atributo com número de atributos errado"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "atributos retornados em ordem inválida"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "conjunto inválido de chamadas mutex fornecido"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "não é possível fazer sem trava do sistema operacional"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "chamada duplicada de C_Initialize para o mesmo processo"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "finalização do módulo rpc retornou um erro: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "mensagem inválida: não foi possível ler o identificador de chamadas"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "mensagem inválida: id de chamada equivocado: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "mensagem inválida: não foi possível ler a assinatura"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "mensagem inválida: assinatura não confere"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+"string preenchida com espaço de comprimento inválido recebida: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "requisição de módulo inválida, provavelmente muito curta"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "não foi possível inicializar resposta rpc"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "handshake inválida recebida de módulo conector"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "não foi possível analisar a mensagem rpc do pkcs11"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "erro de memória insuficiente ao juntar a mensagem"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "erro de memória insuficiente respondeu com erro"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "versão recebida não suportada: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "não foi possível ler byte credencial"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "não foi possível ler byte credencial"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "falha ao ler mensagem rpc"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "erro inesperado ao manusear mensagem rpc"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "falha ao escrever mensagem rpc"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "não foi possível enviar dados: conexão encerrada"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "não foi possível enviar dados"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "não foi possível receber dados: conexão encerrada"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "não foi possível receber dados"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+"valores de cabeçalho rpc inválidos recebidos: talvez o protocolo esteja "
+"errado"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "não foi possível utilizar o selecionar para esperar em canal rpc"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "não foi possível enviar credenciais de socket"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "não foi possível enviar credenciais de socket"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "fechando socket devido a falha de protocolo"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "processo %d não saiu, terminando"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "falha ao esperar filho executado: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "processo %d finalizado com o status %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "processo %d terminou com sinal %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "falha ao criar canal para o remoto"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "falha em fazer fork para o remoto"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "processo %p não finalizou, terminando"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "não foi possível terminar o processo %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "falha ao esperar filho executado: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "falha ao obter o status de encerramento de %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "processo %p finalizado com status %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "falha ao duplicar stdin"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "falha ao duplicar stdout"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "falha ao duplicar filho final do canal"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "falha ao gerar remoto"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "falha ao restaurar arquivos de descrição"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "remoto de linha de comando inválido: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "falha ao criar socket para remoto"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "falha ao analisar o endereço vsock: “%s”"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "remoto não suportado: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "filho %u morreu com sigsegv"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "filho %u morreu com sinal %d"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "não foi possível criar socket %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "não foi possível unir socket %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "não foi possível ouvir ao socket %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "não foi possível semear socket %s"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "não foi possível criar socket %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "não foi possível semear %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "não foi possível ouvir ao socket %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "não foi possível checar uid do socket"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "uid conector (%u) não combinou ao esperado (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "gid conector (%u) não combinou com o esperado (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "não foi possível usar fork() para executar com daemon"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "não foi possível criar nova missão"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "recebido muitos arquivos descritores"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "sem conexões para %s de %lu segundos, saindo"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "não foi possível aceitar do socket %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "falha ao fazer fork para aceitar"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "grupo desconhecido: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "usuário desconhecido: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "não foi possível definir gid para %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "não foi possível definir grupos para %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "não foi possível definir uid para %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "não foi possível determinar diretório de tempo de execução"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "não foi possível criar %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "não foi possível inicializar funções de segurança do Windows"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "não foi possível construir SID para %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "não foi possível construir ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "não foi possível alocar descritor de segurança: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "não foi possível inicializar descritor de segurança: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "não foi possível definir dono do descritor de segurança: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "não foi possível definir DACL no descritor de segurança: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "uri PKCS#11 inválido: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "arquivo de formato não reconhecido: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "falha ao analisar o arquivo: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: não conseguiu inicializar: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: não foi possível enumerar slots: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: não foi possível obter a informação do token: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: não foi possível abrir a sessão: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr "local de escrita não configurado para armazenar âncoras"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "local não configurado para armazenar âncoras"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "não foi possível criar objeto: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "especifique pelo menos um arquivo de entrada âncora"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "não foi possível remover o %s somente leitura"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "não foi possível remover %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "pelo menos um arquivo ou uri deve ser especificado"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "uma ação já foi especificada"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u erro enquanto processava"
+msgstr[1] "%u erro enquanto processava"
+msgstr[2] "%u erro enquanto processava"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: extensão de certificação inválida"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: restrição de extensão de certificação básica inválida"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "desconhecido"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "faltando o atributo CKA_HASH_OF_SUBJECT_PUBLIC_KEY"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "faltando o atributo CKA_HASH_OF_ISSUER_PUBLIC_KEY"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "O objeto não é modificável"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "objetos deste tipo não podem ser criados"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "o atributo %s não pode ser definido"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "o atributo %s não pode ser modificado"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "o atributo %s possui um valor inválido"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "o atributo %s não é válido para o objeto"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "faltando o atributo %s"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "não foi encontrado o atributo CKA_CLASS"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "não foi possível criar um objeto %s"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "token"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "não-token"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "faltando %s no objeto"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s não suportado %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "classe de objeto %s não suportada"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "extensão de certificado de uso de chave inválida"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "extensão de certificado de uso de chave estendida inválida"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "extensão de certificado de uso de chave rejeitada inválida"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "não foi possível liquidar objeto"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "argumentos extra passados ao comando"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "não foi possível dividir o certificado de extensão anexado: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "não foi possível carregar extensões anexadas para o certificado: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "não foi possível analisar o certificado: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "não foi possível carregar os atributos: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "pulando objeto não-certificado"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "não foi possível carregar lista de bloqueio: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "um URI PKCS#11 já foi especificado"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "não foi possível analisar o filtro de uri pkcs11: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "uri contém componentes irreconhecidos, nada será extraído"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "filtro não suportado ou não reconhecido: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "propósito sem suporte ou não reconhecido: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "nenhum módulo contendo politicas de confiança está registrado"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "o formato já foi especificado"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "formato não suportado ou não reconhecido: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "o formato não suporta politicas de confiança"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"formato requer um propósito, especifique-o com --purpose; padronizando-o "
+"para 'server-auth'"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+"o formato não suporta múltiplos propósitos, padronizando-o para 'server-auth'"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "especifique um arquivo de destino ou diretório"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "formato de saída não especificado"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "não foi possível executar o comando %s"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+"múltiplos certificados executados mas somente pode escrever um no arquivo"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "falha a encontrar certificados: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "nenhum certificado encontrado"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "falha a encontrar o certificado: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "truncando string longa"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Variável de ambiente $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+"Variável de ambiente $SOURCE_DATE_EPOCH: Nenhum dígito encontrado: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Variável de ambiente $SOURCE_DATE_EPOCH: Lixo à direita: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Variável de ambiente $SOURCE_DATE_EPOCH: o valor deve ser menor que ou igual "
+"a %lu, mas foi visto como: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "não foi possível gerar um certificado apelido"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "objeto pulado, uri não construído"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "argumento do módulo não reconhecido: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "certificado com desconfiança no local para âncoras: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "sobrescrevendo confiança para âncora na lista de bloqueio: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "não foi possível analisar bloco PEM do tipo %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "não foi possível abrir e mapear o arquivo: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "valor oid inválido: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "não foi possível criar arquivo: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "não foi possível escrever no arquivo: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "não foi possível completar a escrita do arquivo: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "não foi possível escrever o arquivo: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "não foi possível definir permissões de arquivo: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "não foi possível completar arquivo de escrita: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "não foi possível remover arquivo original: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "não foi possível criar diretório: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "o diretório já existe: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "não foi possível criar diretório: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "não foi possível definir permissões do diretório: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "não foi possível fazer o diretório gravável: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "não foi possível criar um link simbólico: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "não foi possível remover arquivo: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "não foi possível definir permissões do diretório: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "não foi possível carregar arquivo em objetos: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "não foi possível obter estado do caminho: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "não foi possível acessar caminho de certificado de confiança: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "não foi possível acessar arquivo de confiança: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "não foi possível acessar: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "não foi possível analisar o certificado: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "nenhum certificado encontrado"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,21 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Romanian (http://www.transifex.com/freedesktop/p11-kit/language/ro/)\n"
+"Language-Team: Romanian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ro/)\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +428,1004 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2011
 # Stas Solovey <whats_up@tut.by>, 2013
@@ -9,16 +9,106 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 14:17+0000\n"
-"Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
-"Language-Team: Russian (http://www.transifex.com/freedesktop/p11-kit/language/ru/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Yuri Kozlov <yuray@komyakino.ru>, 2014\n"
+"Language-Team: Russian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -343,3 +433,1004 @@ msgstr "Запрос отклонён пользователем"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Неизвестная ошибка"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
 "POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Last-Translator: Transifex contributor\n"
 "Language-Team: Sinhala (http://www.transifex.com/freedesktop/p11-kit/"
 "language/si/)\n"
 "Language: si\n"
@@ -869,7 +869,7 @@ msgstr "බොහෝ ගොනු විස්තර ලැබී ඇත"
 #: p11-kit/server.c:556
 #, c-format
 msgid "no connections to %s for %lu secs, exiting"
-msgstr "තත්පර %lu ක් සඳහා %s වෙත සම්බන්ධතා නොමැත, පිටවීම"
+msgstr "තත්පර %2$lu ක් සඳහා %1$s වෙත සම්බන්ධතා නොමැත, පිටවීම"
 
 #: p11-kit/server.c:565
 #, c-format

--- a/po/si.po
+++ b/po/si.po
@@ -1,0 +1,1438 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Collabora Ltd.
+# This file is distributed under the same license as the p11-kit package.
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: p11-kit\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Sinhala (http://www.transifex.com/freedesktop/p11-kit/"
+"language/si/)\n"
+"Language: si\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "භාවිතය: %s විධානය <args>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"පොදු %s විධාන වන්නේ:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"වැඩි විස්තර සඳහා '%s <command> --help' බලන්න\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "විධානයක් නියම කර නැත"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "නොදන්නා ගෝලීය විකල්පය: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "නොදන්නා ගෝලීය විකල්පය: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "'%s' වලංගු විධානයක් නොවේ. '%s --උදව්' බලන්න"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: අනපේක්ෂිත පෙම් බ්ලොක්"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: අනපේක්ෂිත කොටස් ශීර්ෂකය"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "'user-config' සඳහා වලංගු නොවන මාදිලිය: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "වලංගු නොවන වින්‍යාස ගොනු නාමය, අනාගතයේදී නොසලකා හරිනු ඇත: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "නාමාවලිය ලැයිස්තුගත කළ නොහැක: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "ස්ටැට් මාර්ගය නොහැකි විය: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "වලංගු නොවන සැකසුම '%s' පෙරනිමියෙන් '%s' වෙත"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "පෙරහන ආරම්භ කළ නොහැක"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "මොඩියුල තොරතුරු පූරණය කළ නොහැකි විය: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "අමතර තර්ක නිශ්චිතව දක්වා ඇත"
+
+#: p11-kit/messages.c:78
+msgid "The operation was cancelled"
+msgstr "මෙහෙයුම අවලංගු කරන ලදී"
+
+#: p11-kit/messages.c:81
+msgid "Insufficient memory available"
+msgstr "ප්‍රමාණවත් මතකයක් නොමැත"
+
+#: p11-kit/messages.c:83
+msgid "The specified slot ID is not valid"
+msgstr "නිශ්චිත තව් ID වලංගු නොවේ"
+
+#: p11-kit/messages.c:85
+msgid "Internal error"
+msgstr "අභ්‍යන්තර දෝෂයක්"
+
+#: p11-kit/messages.c:87
+msgid "The operation failed"
+msgstr "මෙහෙයුම අසාර්ථක විය"
+
+#: p11-kit/messages.c:89
+msgid "Invalid arguments"
+msgstr "වලංගු නොවන තර්ක"
+
+#: p11-kit/messages.c:91
+msgid "The module cannot create needed threads"
+msgstr "මොඩියුලයට අවශ්‍ය නූල් සෑදිය නොහැක"
+
+#: p11-kit/messages.c:93
+msgid "The module cannot lock data properly"
+msgstr "මොඩියුලයට දත්ත නිසි ලෙස අගුළු දැමිය නොහැක"
+
+#: p11-kit/messages.c:95
+msgid "The field is read-only"
+msgstr "ක්ෂේත්‍රය කියවීමට පමණි"
+
+#: p11-kit/messages.c:97
+msgid "The field is sensitive and cannot be revealed"
+msgstr "ක්ෂේත්‍රය සංවේදී වන අතර හෙළි කළ නොහැක"
+
+#: p11-kit/messages.c:99
+msgid "The field is invalid or does not exist"
+msgstr "ක්ෂේත්‍රය වලංගු නැත හෝ නොපවතී"
+
+#: p11-kit/messages.c:101
+msgid "Invalid value for field"
+msgstr "ක්ෂේත්‍රය සඳහා වලංගු නොවන අගයක්"
+
+#: p11-kit/messages.c:103
+msgid "The data is not valid or unrecognized"
+msgstr "දත්ත වලංගු හෝ හඳුනා නොගත් ඒවා නොවේ"
+
+#: p11-kit/messages.c:105
+msgid "The data is too long"
+msgstr "දත්ත දිග වැඩියි"
+
+#: p11-kit/messages.c:107
+msgid "An error occurred on the device"
+msgstr "උපාංගයේ දෝෂයක් ඇති විය"
+
+#: p11-kit/messages.c:109
+msgid "Insufficient memory available on the device"
+msgstr "උපාංගයේ ප්‍රමාණවත් මතකයක් නොමැත"
+
+#: p11-kit/messages.c:111
+msgid "The device was removed or unplugged"
+msgstr "උපාංගය ඉවත් කර හෝ පේනුවෙන් ඉවත් කර ඇත"
+
+#: p11-kit/messages.c:113
+msgid "The encrypted data is not valid or unrecognized"
+msgstr "සංකේතනය කළ දත්ත වලංගු හෝ හඳුනා නොගත් ඒවා නොවේ"
+
+#: p11-kit/messages.c:115
+msgid "The encrypted data is too long"
+msgstr "සංකේතනය කළ දත්ත දිග වැඩියි"
+
+#: p11-kit/messages.c:117
+msgid "This operation is not supported"
+msgstr "මෙම මෙහෙයුම සහාය නොදක්වයි"
+
+#: p11-kit/messages.c:119
+msgid "The key is missing or invalid"
+msgstr "යතුර අතුරුදහන් හෝ අවලංගුය"
+
+#: p11-kit/messages.c:121
+msgid "The key is the wrong size"
+msgstr "ප්රධාන දෙය වන්නේ වැරදි ප්රමාණයයි"
+
+#: p11-kit/messages.c:123
+msgid "The key is of the wrong type"
+msgstr "යතුර වැරදි වර්ගයකි"
+
+#: p11-kit/messages.c:125
+msgid "No key is needed"
+msgstr "යතුරක් අවශ්‍ය නොවේ"
+
+#: p11-kit/messages.c:127
+msgid "The key is different than before"
+msgstr "යතුර පෙරට වඩා වෙනස් ය"
+
+#: p11-kit/messages.c:129
+msgid "A key is needed"
+msgstr "යතුරක් අවශ්යයි"
+
+#: p11-kit/messages.c:131
+msgid "Cannot include the key in the digest"
+msgstr "ආහාර දිරවීමේ යතුර ඇතුළත් කළ නොහැක"
+
+#: p11-kit/messages.c:133
+msgid "This operation cannot be done with this key"
+msgstr "මෙම යතුර සමඟ මෙම මෙහෙයුම සිදු කළ නොහැක"
+
+#: p11-kit/messages.c:135
+msgid "The key cannot be wrapped"
+msgstr "යතුර ඔතා ගත නොහැක"
+
+#: p11-kit/messages.c:137
+msgid "Cannot export this key"
+msgstr "මෙම යතුර අපනයනය කළ නොහැක"
+
+#: p11-kit/messages.c:139
+msgid "The crypto mechanism is invalid or unrecognized"
+msgstr "ක්‍රිප්ටෝ යාන්ත්‍රණය අවලංගු හෝ හඳුනාගෙන නොමැත"
+
+#: p11-kit/messages.c:141
+msgid "The crypto mechanism has an invalid argument"
+msgstr "ක්‍රිප්ටෝ යාන්ත්‍රණයට වලංගු නොවන තර්කයක් ඇත"
+
+#: p11-kit/messages.c:143
+msgid "The object is missing or invalid"
+msgstr "වස්තුව අතුරුදහන් හෝ වලංගු නොවේ"
+
+#: p11-kit/messages.c:145
+msgid "Another operation is already taking place"
+msgstr "තවත් මෙහෙයුමක් දැනටමත් සිදුවෙමින් පවතී"
+
+#: p11-kit/messages.c:147
+msgid "No operation is taking place"
+msgstr "කිසිදු මෙහෙයුමක් සිදු නොවේ"
+
+#: p11-kit/messages.c:149
+msgid "The password or PIN is incorrect"
+msgstr "මුරපදය හෝ PIN අංකය වැරදියි"
+
+#: p11-kit/messages.c:151
+msgid "The password or PIN is invalid"
+msgstr "මුරපදය හෝ PIN අංකය වලංගු නොවේ"
+
+#: p11-kit/messages.c:153
+msgid "The password or PIN is of an invalid length"
+msgstr "මුරපදය හෝ PIN වලංගු නොවන දිගකි"
+
+#: p11-kit/messages.c:155
+msgid "The password or PIN has expired"
+msgstr "මුරපදය හෝ PIN අංකය කල් ඉකුත් වී ඇත"
+
+#: p11-kit/messages.c:157
+msgid "The password or PIN is locked"
+msgstr "මුරපදය හෝ PIN අංකය අගුළු දමා ඇත"
+
+#: p11-kit/messages.c:159
+msgid "The session is closed"
+msgstr "සැසිය වසා ඇත"
+
+#: p11-kit/messages.c:161
+msgid "Too many sessions are active"
+msgstr "බොහෝ සැසි සක්‍රීයයි"
+
+#: p11-kit/messages.c:163
+msgid "The session is invalid"
+msgstr "සැසිය වලංගු නොවේ"
+
+#: p11-kit/messages.c:165
+msgid "The session is read-only"
+msgstr "සැසිය කියවීමට පමණි"
+
+#: p11-kit/messages.c:167
+msgid "An open session exists"
+msgstr "විවෘත සැසියක් පවතී"
+
+#: p11-kit/messages.c:169
+msgid "A read-only session exists"
+msgstr "කියවීමට පමණක් සැසියක් පවතී"
+
+#: p11-kit/messages.c:171
+msgid "An administrator session exists"
+msgstr "පරිපාලක සැසියක් පවතී"
+
+#: p11-kit/messages.c:173
+msgid "The signature is bad or corrupted"
+msgstr "අත්සන නරක හෝ දූෂිත ය"
+
+#: p11-kit/messages.c:175
+msgid "The signature is unrecognized or corrupted"
+msgstr "අත්සන හඳුනා නොගත් හෝ දූෂිත ය"
+
+#: p11-kit/messages.c:177
+msgid "Certain required fields are missing"
+msgstr "අවශ්‍ය ඇතැම් ක්ෂේත්‍ර අස්ථානගත වී ඇත"
+
+#: p11-kit/messages.c:179
+msgid "Certain fields have invalid values"
+msgstr "ඇතැම් ක්ෂේත්‍ර වල වලංගු නොවන අගයන් ඇත"
+
+#: p11-kit/messages.c:181
+msgid "The device is not present or unplugged"
+msgstr "උපාංගය නොපවතී හෝ පේනු විසන්ධි කර නැත"
+
+#: p11-kit/messages.c:183
+msgid "The device is invalid or unrecognizable"
+msgstr "උපාංගය අවලංගු හෝ හඳුනාගත නොහැක"
+
+#: p11-kit/messages.c:185
+msgid "The device is write protected"
+msgstr "උපාංගය ලිවීමට ආරක්ෂිතයි"
+
+#: p11-kit/messages.c:187
+msgid "Cannot import because the key is invalid"
+msgstr "යතුර වලංගු නොවන නිසා ආයාත කළ නොහැක"
+
+#: p11-kit/messages.c:189
+msgid "Cannot import because the key is of the wrong size"
+msgstr "යතුර වැරදි ප්‍රමාණයේ නිසා ආයාත කළ නොහැක"
+
+#: p11-kit/messages.c:191
+msgid "Cannot import because the key is of the wrong type"
+msgstr "යතුර වැරදි ආකාරයේ නිසා ආයාත කළ නොහැක"
+
+#: p11-kit/messages.c:193
+msgid "You are already logged in"
+msgstr "ඔබ දැනටමත් පුරනය වී ඇත"
+
+#: p11-kit/messages.c:195
+msgid "No user has logged in"
+msgstr "කිසිම පරිශීලකයෙක් ලොග් වී නැත"
+
+#: p11-kit/messages.c:197
+msgid "The user's password or PIN is not set"
+msgstr "පරිශීලකයාගේ මුරපදය හෝ PIN අංකය සකසා නැත"
+
+#: p11-kit/messages.c:199
+msgid "The user is of an invalid type"
+msgstr "පරිශීලකයා වලංගු නොවන වර්ගයකි"
+
+#: p11-kit/messages.c:201
+msgid "Another user is already logged in"
+msgstr "වෙනත් පරිශීලකයෙකු දැනටමත් පුරනය වී ඇත"
+
+#: p11-kit/messages.c:203
+msgid "Too many users of different types are logged in"
+msgstr "විවිධ වර්ගවල බොහෝ පරිශීලකයින් පුරනය වී ඇත"
+
+#: p11-kit/messages.c:205
+msgid "Cannot import an invalid key"
+msgstr "වලංගු නොවන යතුරක් ආයාත කළ නොහැක"
+
+#: p11-kit/messages.c:207
+msgid "Cannot import a key of the wrong size"
+msgstr "වැරදි ප්‍රමාණයේ යතුරක් ආයාත කළ නොහැක"
+
+#: p11-kit/messages.c:209
+msgid "Cannot export because the key is invalid"
+msgstr "යතුර වලංගු නොවන නිසා අපනයනය කළ නොහැක"
+
+#: p11-kit/messages.c:211
+msgid "Cannot export because the key is of the wrong size"
+msgstr "යතුර වැරදි ප්‍රමාණයේ නිසා අපනයනය කළ නොහැක"
+
+#: p11-kit/messages.c:213
+msgid "Cannot export because the key is of the wrong type"
+msgstr "යතුර වැරදි ආකාරයේ නිසා අපනයනය කළ නොහැක"
+
+#: p11-kit/messages.c:215
+msgid "Unable to initialize the random number generator"
+msgstr "අහඹු සංඛ්යා උත්පාදක යන්ත්රය ආරම්භ කිරීමට නොහැකි විය"
+
+#: p11-kit/messages.c:217
+msgid "No random number generator available"
+msgstr "සසම්භාවී අංක උත්පාදකයක් නොමැත"
+
+#: p11-kit/messages.c:219
+msgid "The crypto mechanism has an invalid parameter"
+msgstr "ක්‍රිප්ටෝ යාන්ත්‍රණයට වලංගු නොවන පරාමිතියක් ඇත"
+
+#: p11-kit/messages.c:221
+msgid "Not enough space to store the result"
+msgstr "ප්රතිඵලය ගබඩා කිරීමට ප්රමාණවත් ඉඩක් නැත"
+
+#: p11-kit/messages.c:223
+msgid "The saved state is invalid"
+msgstr "සුරැකි තත්ත්වය වලංගු නොවේ"
+
+#: p11-kit/messages.c:225
+msgid "The information is sensitive and cannot be revealed"
+msgstr "තොරතුරු සංවේදී වන අතර හෙළි කළ නොහැක"
+
+#: p11-kit/messages.c:227
+msgid "The state cannot be saved"
+msgstr "රාජ්යය සුරැකිය නොහැක"
+
+#: p11-kit/messages.c:229
+msgid "The module has not been initialized"
+msgstr "මොඩියුලය ආරම්භ කර නොමැත"
+
+#: p11-kit/messages.c:231
+msgid "The module has already been initialized"
+msgstr "මොඩියුලය දැනටමත් ආරම්භ කර ඇත"
+
+#: p11-kit/messages.c:233
+msgid "Cannot lock data"
+msgstr "දත්ත අගුළු දැමිය නොහැක"
+
+#: p11-kit/messages.c:235
+msgid "The data cannot be locked"
+msgstr "දත්ත අගුලු දැමිය නොහැක"
+
+#: p11-kit/messages.c:237
+msgid "The request was rejected by the user"
+msgstr "පරිශීලකයා විසින් ඉල්ලීම ප්‍රතික්ෂේප කරන ලදී"
+
+#: p11-kit/messages.c:240
+msgid "Unknown error"
+msgstr "නොදන්නා දෝෂයකි"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "මොඩියුලය පූරණය කළ නොහැකි විය: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "මොඩියුලයේ C_GetFunctionList ප්‍රවේශ ලක්ෂ්‍යය සොයාගත නොහැකි විය: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "C_GetFunctiontList වෙත ඇමතීම මොඩියුලය තුළ අසාර්ථක විය: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr "p11-kit-proxy.so මොඩියුලය ලියාපදිංචි මොඩියුලයක් ලෙස පැටවීම ප්‍රතික්ෂේප කිරීම"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "මොඩියුලය '%s' හි සක්‍රීය සහ අක්‍රීය කිරීමේ විකල්ප දෙකම ඇත"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "'%s' මොඩියුලය තීරනාත්මක ලෙස සලකුණු කර ඇති නිසා ආරම්භ කිරීම නවත්වයි"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit ආරම්භ කිරීම පුනරාවර්තන ලෙස හැඳින්වේ"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "විවේචනාත්මක මොඩියුලය '%s' ආරම්භ කිරීම අසාර්ථක විය: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "ආරම්භ කිරීම අසාර්ථක වූ '%s' මොඩියුලය මඟ හැරීම: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "සැසිය වැසීමට නොහැකි විය: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "'%s' මොඩියුලය සඳහා '%s' විකල්පය සහය දක්වන්නේ කළමනාකරණය කළ මොඩියුල සඳහා පමණි"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: මොඩියුලය ආරම්භ කිරීමට අසමත් විය: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: මොඩියුලය%s: %sආරම්භ කිරීමට අසමත් විය"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: මොඩියුලය දැනටමත් ආරම්භ කර ඇත"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: මොඩියුලය අවසන් කිරීමට අසමත් විය: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "මොඩියුලය ආරම්භ කිරීම අසාර්ථක විය: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "මොඩියුල සහ ටෝකන ලැයිස්තුගත කරන්න"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "නිශ්චිත PKCS#11 මොඩියුලයක් දුරස්ථව ධාවනය කරන්න"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "PKCS#11 මොඩියුලය දුරස්ථව නිරාවරණය කරන සේවාදායක ක්‍රියාවලියක් ධාවනය කරන්න"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "විශ්වාස මෙවලම ධාවනය කළ නොහැකි විය"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "'%s' වලංගු විධානයක් නොවේ. 'p11-kit --help' බලන්න"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "දුරස්ථ කිරීමට මොඩියුලයක් හෝ ටෝකන සඳහන් කරන්න"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "'දුරස්ථ' මෙවලම ටර්මිනලයකින් ධාවනය කිරීමට අදහස් නොකෙරේ"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "එක් මොඩියුලයක් පමණක් නියම කළ හැක"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "වලංගු නොවන rpc දෝෂ ප්‍රතිචාරය: කෙටි වැඩියි"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "වලංගු නොවන rpc දෝෂ ප්‍රතිචාරය: නරක දෝෂ කේතය"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "වලංගු නොවන rpc ප්‍රතිචාරය: ඇමතුම් නොගැලපීම"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "වලංගු නොවන rpc ප්‍රතිචාරය: නරක තර්ක දත්ත"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "වැරදි උපලක්ෂණ සංඛ්‍යාවක් සහිත උපලක්ෂණ අරාවක් ලැබී ඇත"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "වලංගු නොවන අනුපිළිවෙලින් ගුණාංග ආපසු ලබා දුන්නේය"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "වලංගු නොවන mutex ඇමතුම් කට්ටලයක් සපයා ඇත"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "os locking නැතුව කරන්න බෑ"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize එකම ක්‍රියාවලිය සඳහා දෙවරක් කැඳවනු ලැබේ"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "rpc මොඩියුලය අවසන් කිරීමේදී දෝෂයක් ඇති විය: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "වලංගු නොවන පණිවිඩය: ඇමතුම් හැඳුනුම්කාරකය කියවිය නොහැක"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "වලංගු නොවන පණිවිඩය: නරක ඇමතුම් හැඳුනුම්පත: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "වලංගු නොවන පණිවිඩය: අත්සන කියවිය නොහැක"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "වලංගු නොවන පණිවිඩය: අත්සන නොගැලපේ"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "වලංගු නොවන දිග ඉඩක් පිරවූ තන්තුවක් ලැබී ඇත: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "මොඩියුලයෙන් වලංගු නොවන ඉල්ලීමක්, සමහරවිට කෙටි වැඩියි"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "rpc ප්‍රතිචාරය ආරම්භ කිරීමට නොහැකි විය"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "සම්බන්ධක මොඩියුලයෙන් වලංගු නොවන අතට අත දීම"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "pkcs11 rpc පණිවිඩය විග්‍රහ කිරීමට නොහැකි විය"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "පණිවිඩය එකතු කිරීමේ මතක දෝෂයකි"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "මතකයෙන් බැහැර දෝෂයකින් ප්‍රතිචාර දක්වයි"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "ලැබුණු සහය නොදක්වන අනුවාදය: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "අක්තපත්‍ර බයිට් කියවිය නොහැකි විය"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "අක්තපත්‍ර බයිට් ලිවීමට නොහැකි විය"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "rpc පණිවිඩය කියවීමට අසමත් විය"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "rpc පණිවිඩය හැසිරවීමේ අනපේක්ෂිත දෝෂයකි"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "rpc පණිවිඩය ලිවීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "දත්ත යැවීමට නොහැකි විය: වසා දැමූ සම්බන්ධතාවය"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "දත්ත යැවීමට නොහැකි විය"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "දත්ත ලබා ගැනීමට නොහැකි විය: වසා දැමූ සම්බන්ධතාවය"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "දත්ත ලබා ගැනීමට නොහැකි විය"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "වලංගු නොවන rpc ශීර්ෂ අගයන් ලැබී ඇත: සමහර විට වැරදි ප්‍රොටෝකෝලය"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "rpc පයිප්පයේ රැඳී සිටීමට තේරීම භාවිතා කළ නොහැක"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "සොකට් අක්තපත්‍ර යැවීමට නොහැකි විය"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "සොකට් අක්තපත්‍ර යැවීමට නොහැකි විය"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "ප්රොටෝකෝලය අසමත් වීම හේතුවෙන් වසා දැමීමේ සොකට්"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "ක්‍රියාවලිය %d පිට නොවී, අවසන් වේ"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "ක්රියාත්මක කරන ලද දරුවා බලා සිටීමට අසමත් විය: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "ක්‍රියාවලිය %d තත්ත්වය %dසමඟින් ඉවත් විය"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "ක්‍රියාවලිය %d සංඥාව %dසමඟ අවසන් විය"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "දුරස්ථ සඳහා නලයක් සෑදීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "දුරස්ථ පාලකය සඳහා ෆෝක් කිරීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "ක්‍රියාවලිය %p පිට නොවී, අවසන් වේ"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "%pක්‍රියාවලිය අවසන් කිරීමට නොහැකි විය"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "ක්රියාත්මක කරන ලද දරුවා බලා සිටීමට අසමත් විය: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "%pහි පිටවීමේ තත්ත්වය ලබා ගැනීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "ක්‍රියාවලිය %p තත්ත්වය %luසමඟින් ඉවත් විය"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "stdin අනුපිටපත් කිරීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "stdout අනුපිටපත් කිරීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "පයිප්පයේ ළමා කෙළවර අනුපිටපත් කිරීමට අපොහොසත් විය"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "දුරස්ථව බිහි කිරීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "ගොනු විස්තර ප්‍රතිසාධනය කිරීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "වලංගු නොවන දුරස්ථ විධාන රේඛාව: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "දුරස්ථ පාලකය සඳහා සොකට් සෑදීමට අසමත් විය"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "vsock ලිපිනය විග්‍රහ කිරීමට අපොහොසත් විය: '%s'"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "දුරස්ථ පාලකය සහාය නොදක්වයි: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "%u දරුවා sigsegv සමඟ මිය ගියේය"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "%u දරුවා සංඥා %dසමඟ මිය ගියේය"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "සොකට් %sනිර්මාණය කිරීමට නොහැකි විය"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "සොකට් %sබැඳීමට නොහැකි විය"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "සොකට් %sට සවන් දීමට නොහැකි විය"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "සොකට් %sචූන් කළ නොහැක"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "සොකට් %u:%uනිර්මාණය කිරීමට නොහැකි විය"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "සොකට් %u:%uබැඳීමට නොහැකි විය"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "සොකට් %u:%uට සවන් දීමට නොහැකි විය"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "සොකට් එකෙන් uid පරීක්ෂා කළ නොහැකි විය"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "uid සම්බන්ධ කිරීම (%u) අපේක්ෂිත හා නොගැලපේ (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "සම්බන්ධ කිරීම gid (%u) අපේක්ෂිත නොගැලපේ (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "demonize කිරීමට fork() නොහැකි විය"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "නව සැසියක් නිර්මාණය කිරීමට නොහැකි විය"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "බොහෝ ගොනු විස්තර ලැබී ඇත"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "තත්පර %lu ක් සඳහා %s වෙත සම්බන්ධතා නොමැත, පිටවීම"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "සොකට් %sවෙතින් පිළිගත නොහැකි විය"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "පිළිගැනීම සඳහා දෙබල කිරීමට අසමත් විය"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "නොදන්නා කණ්ඩායම: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "නොදන්නා පරිශීලක: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "gid %uට සැකසිය නොහැක"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "කණ්ඩායම් %uට සැකසිය නොහැක"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "uid %uලෙස සැකසිය නොහැක"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "ධාවන කාල නාමාවලිය තීරණය කළ නොහැක"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "%sසෑදිය නොහැක"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "වින්ඩෝස් ආරක්ෂක කාර්යයන් ආරම්භ කිරීමට නොහැකි විය"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "%s: %luසඳහා SID තැනීමට නොහැක"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "ACL තැනීමට නොහැක: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "ආරක්ෂක විස්තරය වෙන් කළ නොහැක: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "ආරක්ෂක විස්තරය ආරම්භ කළ නොහැක: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "ආරක්ෂක විස්තරයේ හිමිකරු සැකසීමට නොහැක: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "ආරක්ෂක විස්තරය තුළ DACL සැකසීමට නොහැක: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "වලංගු නොවන PKCS#11 uri: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "හඳුනා නොගත් ගොනු ආකෘතිය: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "ගොනුව විග්‍රහ කිරීමට අපොහොසත් විය: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: ආරම්භ කිරීමට නොහැකි විය: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: තව් ගණන් කළ නොහැක: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: ටෝකන තොරතුරු ලබා ගැනීමට නොහැකි විය: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: සැසිය විවෘත කිරීමට නොහැකි විය: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr "නැංගුරම් ගබඩා කිරීම සඳහා වින්‍යාස කර ඇති ලිවිය හැකි ස්ථානයක් නොමැත"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "නැංගුරම් ගබඩා කිරීමට වින්‍යාසගත ස්ථානයක් නොමැත"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "වස්තුව නිර්මාණය කළ නොහැක: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "අවම වශයෙන් එක් නැංගුරම් ආදාන ගොනුවක් සඳහන් කරන්න"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "කියවීමට පමණක් %sඉවත් කිරීමට නොහැකි විය"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "%s: %sඉවත් කිරීමට නොහැකි විය"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "අවම වශයෙන් එක් ගොනුවක් හෝ uri සඳහන් කළ යුතුය"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "ක්‍රියාවක් දැනටමත් සඳහන් කර ඇත"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "සැකසීමේදී %u දෝෂයකි"
+msgstr[1] "සැකසීමේදී %u දෝෂයකි"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: වලංගු නොවන සහතික දිගුව"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: වලංගු නොවන මූලික බාධා සහතික දිගුව"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "නොදන්නා"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "CKA_HASH_OF_SUBJECT_PUBLIC_KEY ගුණාංගය මග හැරී ඇත"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "CKA_HASH_OF_ISSUER_PUBLIC_KEY ගුණාංගය මග හැරී ඇත"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "වස්තුව වෙනස් කළ නොහැකි ය"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "මෙම වර්ගයේ වස්තූන් නිර්මාණය කළ නොහැක"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "%s ගුණාංගය සැකසිය නොහැක"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "%s ගුණාංගය වෙනස් කළ නොහැක"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "%s ගුණාංගයට වලංගු නොවන අගයක් ඇත"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "වස්තුව සඳහා %s ගුණාංගය වලංගු නොවේ"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "%s ගුණාංගය මග හැරී ඇත"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "CKA_CLASS ගුණාංගයක් හමු නොවීය"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "%s වස්තුවක් සෑදිය නොහැක"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "සංකේතය"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "ටෝකන් නොවන"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "වස්තුවේ %s අතුරුදහන්"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s සහාය නොදක්වයි %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s සහාය නොදක්වන වස්තු පන්තිය"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "වලංගු නොවන යතුරු භාවිත සහතික දිගුව"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "වලංගු නොවන දිගු යතුරු භාවිත සහතික දිගුව"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "වලංගු නොවන ප්‍රතික්ෂේප කිරීමේ යතුරු භාවිත සහතික දිගුව"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "වස්තුව ඉවත දැමිය නොහැකි විය"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "අමතර තර්ක විධානයට ලබා දී ඇත"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "අමුණා ඇති සහතික දිගුව විග්‍රහ කළ නොහැක: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "සහතිකය සඳහා අමුණා ඇති දිගු පූරණය කළ නොහැකි විය: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "සහතිකය විග්‍රහ කිරීමට නොහැකි විය: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "ගුණාංග පූරණය කළ නොහැකි විය: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "සහතික නොවන වස්තුව මඟ හැරීම"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "වාරණ ලැයිස්තුව පූරණය කළ නොහැකි විය: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "PKCS#11 URI දැනටමත් නිශ්චිතව දක්වා ඇත"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "pkcs11 uri ෆිල්ටරය විග්‍රහ කිරීමට නොහැකි විය: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "uri හි හඳුනා නොගත් සංරචක අඩංගු වේ, කිසිවක් උපුටා නොගනු ඇත"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "සහාය නොදක්වන හෝ හඳුනා නොගත් පෙරහන: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "සහාය නොදක්වන හෝ හඳුනා නොගත් අරමුණ: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "විශ්වාස ප්‍රතිපත්ති අඩංගු මොඩියුල කිසිවක් ලියාපදිංචි කර නොමැත"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "ආකෘතියක් දැනටමත් සඳහන් කර ඇත"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "සහාය නොදක්වන හෝ හඳුනා නොගත් ආකෘතිය: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "ආකෘතිය විශ්වාස ප්‍රතිපත්තියට සහය නොදක්වයි"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr "ආකෘතියට අරමුණක් අවශ්‍ය වේ, එය --අරමුණ සමඟ සඳහන් කරන්න; 'server-auth' වෙත පෙරනිමි"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr "ආකෘතිය බහු අරමුණු සඳහා සහය නොදක්වයි, 'සර්වර්-අත්' වෙත පෙරනිමියෙන්"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "එක් ගමනාන්ත ගොනුවක් හෝ නාමාවලියක් සඳහන් කරන්න"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "නිමැවුම් ආකෘතියක් සඳහන් කර නොමැත"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "%s විධානය ක්‍රියාත්මක කළ නොහැක"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr "සහතික කිහිපයක් හමු වූ නමුත් ගොනු කිරීමට ලිවිය හැක්කේ එකක් පමණි"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "සහතික සොයා ගැනීමට අපොහොසත් විය: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "සහතිකයක් හමු නොවීය"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "සහතිකය සොයා ගැනීමට අපොහොසත් විය: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "දිගු නූල් කප්පාදු කිරීම"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "පරිසර විචල්‍යය $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "පරිසර විචල්‍යය $SOURCE_DATE_EPOCH: ඉලක්කම් කිසිවක් හමු නොවීය: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "පරිසර විචල්‍යය $SOURCE_DATE_EPOCH: පසුපසින් යන කුණු: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"පරිසර විචල්‍යය $SOURCE_DATE_EPOCH: අගය %lu ට වඩා කුඩා හෝ සමාන විය යුතු නමුත් එය සොයා "
+"ගන්නා ලදී: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "සහතිකය අන්වර්ථ නාමයක් ජනනය කිරීමට නොහැකි විය"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "skipping object, uri ගොඩනැගීමට නොහැකි විය"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "හඳුනා නොගත් මොඩියුල තර්කය: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "නැංගුරම් සඳහා ස්ථානයේ අවිශ්වාසය සහිත සහතිකය: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "වාරණ ලැයිස්තුවේ නැංගුරම සඳහා විශ්වාසය ඉක්මවා යාම: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "%sවර්ගයේ PEM වාරණ විග්‍රහ කිරීමට නොහැකි විය"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "ගොනුව විවෘත කර සිතියම්ගත කිරීමට නොහැකි විය: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "වලංගු නොවන oid අගය: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "ගොනුව සෑදීමට නොහැකි විය: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "ගොනුව වෙත ලිවීමට නොහැකි විය: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "ගොනුව ලිවීම සම්පූර්ණ කළ නොහැකි විය: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "ගොනුව ලිවීමට නොහැකි විය: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "ගොනු අවසර සැකසීමට නොහැකි විය: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "ලිවීමේ ගොනුව සම්පූර්ණ කිරීමට නොහැකි විය: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "මුල් ගොනුව ඉවත් කිරීමට නොහැකි විය: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "නාමාවලිය සෑදිය නොහැක: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "නාමාවලිය දැනටමත් පවතී: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "නාමාවලිය සෑදිය නොහැක: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "නාමාවලි අවසර සැකසීමට නොහැකි විය: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "නාමාවලිය ලිවිය හැකි බවට පත් කිරීමට නොහැකි විය: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "symlink නිර්මාණය කිරීමට නොහැකි විය: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "ගොනුව ඉවත් කිරීමට නොහැකි විය: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "නාමාවලි අවසර සැකසීමට නොහැකි විය: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "වස්තු වලට ගොනුව පැටවීමට නොහැකි විය: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "%d: %sමාර්ගය සඳහන් කළ නොහැක"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "විශ්වාස සහතික මාර්ගයට පිවිසිය නොහැක: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "විශ්වාස ගොනුවට ප්‍රවේශ විය නොහැක: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "ප්‍රවේශ විය නොහැක: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "සහතිකය විග්‍රහ කිරීමට නොහැකි විය: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "සහතිකයක් හමු නොවීය"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,23 +1,112 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Dušan Kazik <prescott66@gmail.com>, 2015
-# helix84 <helix84@centrum.sk>, 2015
+# Ivan Masár <helix84@centrum.sk>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 14:13+0000\n"
-"Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
-"Language-Team: Slovak (http://www.transifex.com/freedesktop/p11-kit/language/sk/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Dušan Kazik <prescott66@gmail.com>, 2015\n"
+"Language-Team: Slovak (http://www.transifex.com/freedesktop/p11-kit/language/"
+"sk/)\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sk\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
+">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -342,3 +431,1004 @@ msgstr "Požiadavka bola odmietnutá používateľom"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Neznáma chyba"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -1,22 +1,111 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Martin Srebotnjak <miles@filmsi.net>, 2012-2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:46+0000\n"
-"Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
-"Language-Team: Slovenian (http://www.transifex.com/freedesktop/p11-kit/language/sl/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Martin Srebotnjak <miles@filmsi.net>, 2012-2013\n"
+"Language-Team: Slovenian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +430,1004 @@ msgstr "Zahtevo je zavrnil uporabnik"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Neznana napaka"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Albanian (http://www.transifex.com/freedesktop/p11-kit/language/sq/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Albanian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/sq/)\n"
+"Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sq\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,22 +1,112 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Мирослав Николић <miroslavnikolic@rocketmail.com>, 2013-2014
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 14:23+0000\n"
-"Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
-"Language-Team: Serbian (http://www.transifex.com/freedesktop/p11-kit/language/sr/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>, "
+"2013-2014\n"
+"Language-Team: Serbian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/sr/)\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +431,1003 @@ msgstr "Корисник је одбио захтев"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Непозната грешка"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,21 +1,110 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Serbian (Latin) (http://www.transifex.com/freedesktop/p11-kit/language/sr@latin/)\n"
+"Language-Team: Serbian (Latin) (http://www.transifex.com/freedesktop/p11-kit/"
+"language/sr@latin/)\n"
+"Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr@latin\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +428,1004 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,22 +1,115 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
+# Anders Jonsson <transifex@norsjovallen.se>, 2021
 # Josef Andersson <josef.andersson@fripost.org>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 19:45+0000\n"
-"Last-Translator: Josef Andersson <josef.andersson@fripost.org>\n"
-"Language-Team: Swedish (http://www.transifex.com/freedesktop/p11-kit/language/sv/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Anders Jonsson <transifex@norsjovallen.se>, 2021\n"
+"Language-Team: Swedish (http://www.transifex.com/freedesktop/p11-kit/"
+"language/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "användning: %s kommando <arg>…\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Vanliga %s-kommandon är:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Se ”%s <kommando> --help” för mer information\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "inget kommando angivet"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "okänd global flagga: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "okänd global flagga: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "”%s” är inte ett giltigt kommando. Se ”%s --help”"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: oväntat pem-block"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: oväntad avsnittsrubrik"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "ogiltigt läge för ”user-config”: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "ogiltigt konfigurationsfilnamn, kommer ignoreras i framtiden: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "kunde inte lista katalog: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "kunde inte köra stat på sökväg: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "ogiltig inställning ”%s”, använder standardvärdet ”%s”"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "filtret kan inte initieras"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "kunde inte läsa in modulinfo: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "extra argument angivna"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -24,7 +117,7 @@ msgstr "Åtgärden avbröts"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
-msgstr "Otillräckligt med tillgängligt minne"
+msgstr "För lite tillgängligt minne"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
@@ -52,7 +145,7 @@ msgstr "Modulen kan inte låsa data korrekt"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr "Fältet är endast läsbart"
+msgstr "Fältet är skrivskyddat"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
@@ -68,11 +161,11 @@ msgstr "Ogiltigt värde för fält"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr "Datan är ogiltig eller okänd"
+msgstr "Data är ogiltig eller okänd"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
-msgstr "Datan är för lång"
+msgstr "Data är för lång"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
@@ -80,7 +173,7 @@ msgstr "Ett fel uppstod i enheten"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr "Otillräckligt med tillgängligt minne på enheten"
+msgstr "För lite tillgängligt minne på enheten"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
@@ -88,11 +181,11 @@ msgstr "Enheten togs bort eller matades ut"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr "Den krypterade datan är ogiltig eller okänd"
+msgstr "Krypterad data är ogiltig eller okänd"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
-msgstr "Den krypterade datan är för lång"
+msgstr "Krypterad data är för lång"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
@@ -140,7 +233,7 @@ msgstr "Kan inte exportera denna nyckel"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr "Krypteringsmekanismen har ett ogiltigt argument eller är okänd"
+msgstr "Krypteringsmekanismen är ogiltig eller okänd"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
@@ -192,7 +285,7 @@ msgstr "Sessionen är ogiltig"
 
 #: p11-kit/messages.c:165
 msgid "The session is read-only"
-msgstr "Sessionen är endast läsbar"
+msgstr "Sessionen är skrivskyddad"
 
 #: p11-kit/messages.c:167
 msgid "An open session exists"
@@ -200,19 +293,19 @@ msgstr "En öppen session existerar"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
-msgstr "En endast läsbar session existerar"
+msgstr "En skrivskyddad session existerar"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
-msgstr "En administratörsession existerar"
+msgstr "En administratörssession existerar"
 
 #: p11-kit/messages.c:173
 msgid "The signature is bad or corrupted"
-msgstr "Signaturen är dålig eller korrupt"
+msgstr "Signaturen är felaktig eller skadad"
 
 #: p11-kit/messages.c:175
 msgid "The signature is unrecognized or corrupted"
-msgstr "Signaturen är okänd eller korrupt"
+msgstr "Signaturen är okänd eller skadad"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
@@ -332,7 +425,7 @@ msgstr "Kan inte låsa data"
 
 #: p11-kit/messages.c:235
 msgid "The data cannot be locked"
-msgstr "Datan kan inte låsas"
+msgstr "Data kan inte låsas"
 
 #: p11-kit/messages.c:237
 msgid "The request was rejected by the user"
@@ -341,3 +434,1010 @@ msgstr "Begäran avvisades av användaren"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Okänt fel"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "kunde inte läsa in modul: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "kunde inte hitta ingångspunkt för C_GetFunctionList i modul: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "anrop till C_GetFunctionList misslyckades i modul: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr "vägrar att läsa in p11-kit-proxy.so-modulen som en registrerad modul"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "modulen ”%s” har både flaggorna enable-in och disable-in"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr "avbryter initiering för att modulen ”%s” markerats som kritisk"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "p11-kit-initiering anropad rekursivt"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "initiering av kritisk modul ”%s” misslyckades: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "hoppar över modulen ”%s” vars initiering misslyckades: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "kunde inte stänga session: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr "flaggan ”%s” för modulen ”%s” stöds endast för hanterade moduler"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: modulen kunde inte initieras: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: modulen kunde inte initieras%s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: modulen var redan initierad"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: modulen kunde inte slutföras: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "modulinitiering misslyckades: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Lista moduler och token"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Kör en specifik PKCS#11-modul på distans"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr "Kör en serverprocess som exponerar en PKCS#11-modul på distans"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "kunde inte köra tillitsverktyg"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "”%s” är inte ett giltigt kommando. Se ”p11-kit --help”"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "ange en modul eller token till remote"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "verktyget ”remote” är inte avsett att köras från en terminal"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "endast en modul kan anges"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "ogiltigt rpc-felsvar: för kort"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "ogiltigt rpc-felsvar: felaktig felkod"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "ogiltigt rpc-svar: anrop stämmer ej överens"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "ogiltigt rpc-svar: felaktiga argumentdata"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "mottog en attributvektor med fel antal attribut"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "returnerade attribut i ogiltig ordning"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "ogiltig uppsättning mutexanrop tillhandahölls"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "klarar oss inte utan os-låsning"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize anropad två gånger för samma process"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr "slutförande av rpc-modul returnerade ett fel: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "ogiltigt meddelande: kunde inte läsa anropsidentifierare"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "ogiltigt meddelande: felaktigt anrops-ID: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "ogiltigt meddelande: kunde inte läsa signatur"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "ogiltigt meddelande: signaturen matchar inte"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "ogiltig längd på sträng utfylld med blanksteg mottogs: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "ogiltig förfrågan från modul, troligen för kort"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "kunde inte initiera rpc-svar"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr "ogiltig handskakning mottagen från anslutande modul"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "kunde inte tolka pkcs11 rpc-meddelande"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "slut på minne då meddelande sattes ihop"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "slut på minne vid svar med fel"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "version som inte stöds mottogs: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "kunde inte läsa identifieringsbyte"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "kunde inte skriva identifieringsbyte"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "misslyckades med att läsa rpc-meddelande"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "oväntat fel vid hantering av rpc-meddelande"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "misslyckades med att skriva rpc-meddelande"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "kunde inte skicka data: anslutning stängd"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "kunde inte skicka data"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "kunde inte ta emot data: anslutning stängd"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "kunde inte ta emot data"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr "mottog ogiltiga rpc-rubrikvärden: kanske fel protokoll"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "kunde inte använda select för att vänta på rpc-rör"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "kunde inte skicka uttagets identifiering"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "kunde inte skicka uttagets identifiering"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "stänger uttag på grund av protokollfel"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "process %d avslutades inte, terminerar"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "misslyckades med att vänta på exekverad underordnad: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "process %d avslutades med status %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "process %d terminerades med signal %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "misslyckades med att skapa rör för fjärr"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "misslyckades med att köra fork för fjärr"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "process %p avslutades inte, terminerar"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "kunde inte terminera process %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "misslyckades med att vänta på exekverad underordnad: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "misslyckades med att få avslutningsstatus för %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "process %p avslutades med status %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "misslyckades med att duplicera standard in"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "misslyckades med att duplicera standard ut"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "misslyckades med att duplicera underordnads ände på röret"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "misslyckades med att starta fjärr"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "misslyckades med att återställa filhandtag"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "ogiltig fjärrkommandorad: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "misslyckades med att skapa uttag för fjärr"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "misslyckades med att tolka vsock-adress: ”%s”"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "fjärranrop stöds inte: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "underordnad %u dog med sigsegv"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "underordnad %u dog med signal %d"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "kunde inte skapa uttag %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "kunde inte binda uttag %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "kunde inte lyssna på uttag %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "kunde inte köra chown på uttag %s"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "kunde inte skapa uttag %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "kunde inte binda uttag %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "kunde inte lyssna på uttag %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "kunde inte kontrollera uid från uttag"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "anslutande uid (%u) matchar inte det förväntade (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "anslutande gid (%u) matchar inte det förväntade (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "kunde inte köra fork() för att köra som demon"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "kunde inte skapa en ny session"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "för många filhandtag mottagna"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "inga anslutningar till %s på %lu sekunder, avslutar"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "kunde inte acceptera från uttag %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "misslyckades med att köra fork för accept"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "okänd grupp: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "okänd användare: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "kan inte ställa in gid till %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "kan inte ställa setgroups till %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "kan inte ställa in uid till %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "kan inte avgöra katalog för exekveringsmiljö"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "kan inte skapa %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "kunde inte initiera Windows-säkerhetsfunktioner"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "kunde inte konstruera SID för %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "kunde inte konstruera ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "kunde inte allokera säkerhetsbeskrivare: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "kunde inte initiera säkerhetsbeskrivare: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "kunde inte ställa in ägare i säkerhetsbeskrivare: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "kunde inte ställa in DACL i säkerhetsbeskrivare: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "ogiltig PKCS#11-uri: %s"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "okänt filformat: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "misslyckades med att tolka fil: %s"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: kunde inte initiera: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: kunde inte räkna upp platser: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: kunde inte få token-information: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: kunde inte öppna session: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr "ingen konfigurerad skrivbar plats för att lagra ankare"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "ingen konfigurerad plats för att lagra ankare"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "kunde inte skapa objekt: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "ange minst en ankarinmatningsfil"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "kunde inte ta bort skrivskyddad %s"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "kunde inte ta bort %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "åtminstone en fil eller uri måste anges"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "en åtgärd hade redan angivits"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u fel vid behandling"
+msgstr[1] "%u fel vid behandling"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: ogiltigt certifikattillägg"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: ogiltigt certifikattillägg för grundläggande begränsning"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "okänd"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "saknar CKA_HASH_OF_SUBJECT_PUBLIC_KEY-attributet"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "saknar CKA_HASH_OF_ISSUER_PUBLIC_KEY-attributet"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "objektet kan inte ändras"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "objekt av denna typ kan inte skapas"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "%s-attributet kan inte ställas in"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "%s-attributet kan inte ändras"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "%s-attributet har ett ogiltigt värde"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "%s-attributet är inte giltigt för objektet"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "saknar attributet %s"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "inget CKA_CLASS-attribut hittades"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "kan inte skapa ett %s-objekt"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "token"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "icke-token"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "saknar %s för objekt"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "för %s stöds inte %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "objektklassen %s stöds inte"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "ogiltigt certifikattillägg för nyckelanvändning"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "ogiltigt certifikattillägg för utökad nyckelanvändning"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "ogiltigt certifikattillägg för att avvisa nyckelanvändning"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "kunde inte dumpa objekt"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "extra argument skickade till kommando"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "kunde inte tolka bifogat certifikattillägg: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "kunde inte läsa in bifogade tillägg för certifikat: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "kunde inte tolka certifikat: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "kunde inte läsa in attribut: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "hoppar över objekt som inte är certifikat"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "kunde inte läsa in blockeringslista: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "en PKCS#11-URI har redan angivits"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "kunde inte tolka pkcs11-urifilter: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "uri innehöll okända komponenter, inget kommer att extraheras"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "filtret är okänt eller stöds inte: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "syftet är okänt eller stöds inte: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "inga moduler som innehåller tillitspolicy finns registrerade"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "ett format hade redan angivits"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "formatet är okänt eller stöds inte: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "formatet stöder inte tillitspolicyn"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"formatet kräver ett syfte, ange det med --purpose; använder standardvärdet "
+"”server-auth”"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+"formatet stöder inte flera syften, använder standardvärdet ”server-auth”"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "ange en destinationsfil eller katalog"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "inget utdataformat angivet"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "kunde inte köra kommandot %s"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr "flera certifikat hittades men kunde bara skriva ett till fil"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "misslyckades med att hitta certifikat: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "inget certifikat hittades"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "misslyckades med att hitta certifikat: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "trunkerar lång sträng"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Miljövariabeln $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "Miljövariabeln $SOURCE_DATE_EPOCH: Inga siffror hittades: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Miljövariabeln $SOURCE_DATE_EPOCH: Efterföljande skräp: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Miljövariabeln $SOURCE_DATE_EPOCH: värdet måste vara mindre eller lika med "
+"%lu men visade sig vara: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "kunde inte generera ett certifikataliasnamn"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "hoppar över objekt, kunde inte bygga uri"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "okänt modulargument: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "certifikat med misstro i plats för ankare: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "åsidosätter tillit för ankare i blockeringslista: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "Kunde inte tolka PEM-block av typen %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "kunde inte öppna och mappa fil: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "ogiltigt oid-värde: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "kunde inte skapa fil: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "kunde inte skriva till fil: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "kunde inte slutföra skrivning av fil: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "kunde inte skriva fil: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "kunde inte ställa in filrättigheter: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "kunde inte slutföra skrivning av fil: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "kunde inte ta bort ursprunglig fil: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "kunde inte skapa katalog: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "katalogen finns redan: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "kunde inte skapa katalog: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "kunde inte ställa in katalogrättigheter: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "kunde inte göra katalogen skrivbar: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "kunde inte skapa symbolisk länk: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "kunde inte ta bort fil: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "kunde inte ställa in katalogrättigheter: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "kunde inte läsa in fil i objekt: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "kunde inte köra stat på sökväg: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "kan inte komma åt tillitscertifikatsökväg: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "kan inte komma åt tillitsfil: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "kunde inte komma åt: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "kunde inte tolka certifikat: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "inget certifikat hittades"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Tamil (http://www.transifex.com/freedesktop/p11-kit/language/ta/)\n"
+"Language-Team: Tamil (http://www.transifex.com/freedesktop/p11-kit/language/"
+"ta/)\n"
+"Language: ta\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ta\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Telugu (http://www.transifex.com/freedesktop/p11-kit/language/te/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Telugu (http://www.transifex.com/freedesktop/p11-kit/language/"
+"te/)\n"
+"Language: te\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: te\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Thai (http://www.transifex.com/freedesktop/p11-kit/language/th/)\n"
+"Language-Team: Thai (http://www.transifex.com/freedesktop/p11-kit/language/"
+"th/)\n"
+"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: th\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1002 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,22 +1,112 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
+# Emin Tufan Çetin <etcetin@gmail.com>, 2020
 # Necdet Yücel <necdetyucel@gmail.com>, 2012
+# Sabri Ünal <libreajans@gmail.com>, 2022
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:28+0000\n"
-"Last-Translator: Necdet Yücel <necdetyucel@gmail.com>\n"
-"Language-Team: Turkish (http://www.transifex.com/freedesktop/p11-kit/language/tr/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Sabri Ünal <libreajans@gmail.com>, 2022\n"
+"Language-Team: Turkish (http://www.transifex.com/freedesktop/p11-kit/"
+"language/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -24,7 +114,7 @@ msgstr "İşlem iptal edildi"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
-msgstr "Yeterli hafıza yok"
+msgstr "Yeterli bellek yok"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
@@ -44,11 +134,11 @@ msgstr "Geçersiz değişkenler"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr "Modül ihtiyaç duyulan iş parçacıklarını oluşturamadı"
+msgstr "Modül, gereksinilen iş parçacıklarını oluşturamadı"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
-msgstr "Modül veriyi düzgün kilitleyemedi"
+msgstr "Modül, veriyi düzgün kilitleyemedi"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
@@ -60,7 +150,7 @@ msgstr "Bu alan hassas olduğundan gösterilemez"
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
-msgstr "Alan geçersiz veya mevcut değil"
+msgstr "Alan geçersiz veya yok"
 
 #: p11-kit/messages.c:101
 msgid "Invalid value for field"
@@ -76,11 +166,11 @@ msgstr "Veri çok uzun"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
-msgstr "Aygıtta bir hata oluştu"
+msgstr "Aygıtta hata oluştu"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr "Aygıtta yeterli hafıza yok"
+msgstr "Aygıtta yeterli bellek yok"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
@@ -124,7 +214,7 @@ msgstr "Anahtar gerekli"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
-msgstr "Anahtar özete dahil edilemez"
+msgstr "Anahtar özete eklenemez"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
@@ -144,7 +234,7 @@ msgstr "Şifreleme mekanizması geçersiz veya algılanamadı"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
-msgstr "Şifreleme mekanizması geçersiz bir değişken içeriyor"
+msgstr "Şifreleme mekanizması geçersiz değişken içeriyor"
 
 #: p11-kit/messages.c:143
 msgid "The object is missing or invalid"
@@ -152,7 +242,7 @@ msgstr "Nesne eksik veya geçersiz"
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr "Başka bir işlem zaten sürüyor"
+msgstr "Başka işlem zaten sürüyor"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
@@ -196,19 +286,19 @@ msgstr "Oturum salt-okunur"
 
 #: p11-kit/messages.c:167
 msgid "An open session exists"
-msgstr "Açık bir oturum var"
+msgstr "Açık oturum var"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
-msgstr "Salt okunur bir oturum var"
+msgstr "Salt okunur oturum var"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
-msgstr "Bir yönetici oturumu var"
+msgstr "Yönetici oturumu var"
 
 #: p11-kit/messages.c:173
 msgid "The signature is bad or corrupted"
-msgstr "İmza kötü veya hatalı"
+msgstr "İmza kötü veya bozulmuş"
 
 #: p11-kit/messages.c:175
 msgid "The signature is unrecognized or corrupted"
@@ -220,7 +310,7 @@ msgstr "Bazı gerekli alanlar eksik"
 
 #: p11-kit/messages.c:179
 msgid "Certain fields have invalid values"
-msgstr "Bazı alanlar geçersiz değerlere sahip"
+msgstr "Bazı alanlar geçersiz değerler içeriyor"
 
 #: p11-kit/messages.c:181
 msgid "The device is not present or unplugged"
@@ -264,19 +354,19 @@ msgstr "Kullanıcı geçersiz türde"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
-msgstr "Başka bir kullanıcı zaten oturum açtı"
+msgstr "Başka kullanıcı zaten oturum açtı"
 
 #: p11-kit/messages.c:203
 msgid "Too many users of different types are logged in"
-msgstr "Farklı türden çok fazla kullanıcı oturum açtı"
+msgstr "Farklı türlerden çok fazla kullanıcı oturum açtı"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
-msgstr "Geçersiz bir anahtar içe aktarılamaz"
+msgstr "Geçersiz anahtar içe aktarılamaz"
 
 #: p11-kit/messages.c:207
 msgid "Cannot import a key of the wrong size"
-msgstr "Hatalı boyuttaki bir anahtar içe aktarılamaz"
+msgstr "Hatalı boyuttaki anahtar içe aktarılamaz"
 
 #: p11-kit/messages.c:209
 msgid "Cannot export because the key is invalid"
@@ -296,7 +386,7 @@ msgstr "Rastgele sayı oluşturucuyu başlatılamadı"
 
 #: p11-kit/messages.c:217
 msgid "No random number generator available"
-msgstr "Kullanılabilir rasgele sayı oluşturucu yok"
+msgstr "Kullanılabilir rastgele sayı oluşturucu yok"
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
@@ -304,7 +394,7 @@ msgstr "Şifreleme mekanizması geçersiz değişken içeriyor"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
-msgstr "Sonucu saklamak için yeterli alan yok"
+msgstr "Sonucu saklayacak yeterli alan yok"
 
 #: p11-kit/messages.c:223
 msgid "The saved state is invalid"
@@ -312,7 +402,7 @@ msgstr "Kaydedilen durum geçersiz"
 
 #: p11-kit/messages.c:225
 msgid "The information is sensitive and cannot be revealed"
-msgstr "Bu alan hassas olduğundan gösterilemez"
+msgstr "Bilgi hassas olduğundan gösterilemez"
 
 #: p11-kit/messages.c:227
 msgid "The state cannot be saved"
@@ -341,3 +431,1002 @@ msgstr "İstek kullanıcı tarafından reddedildi"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Bilinmeyen hata"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,22 +1,118 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Yuri Chornoivan <yurchor@ukr.net>, 2012-2013
+# Yuri Chornoivan <yurchor@ukr.net>, 2021
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 11:46+0000\n"
-"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
-"Language-Team: Ukrainian (http://www.transifex.com/freedesktop/p11-kit/language/uk/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>, 2021\n"
+"Language-Team: Ukrainian (http://www.transifex.com/freedesktop/p11-kit/"
+"language/uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr "користування: %s команад <аргументи>...\n"
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+"\n"
+"Типові команди %s:\n"
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+"\n"
+"Див. «%s <команда> --help», щоб дізнатися більше\n"
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "не вказано команду"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "невідомий загальний параметр: %s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "невідомий загальний параметр: -%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr "«%s» не є коректною командою. Див. «%s --help»"
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr "%s: неочікуваний блок pem"
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr "%s: неочікуваний заголовок розділу"
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr "некоректний режим для «user-config»: %s"
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr "некоректна назва файла налаштувань, файл надалі буде проігноровано: %s"
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr "не вдалося побудувати список вмісту каталогу: %s"
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr "не вдалося отримати статистичні дані щодо шляху: %s"
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr "некоректний параметр «%s», повертаємося до типового значення «%s»"
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "не вдалося ініціалізувати фільтр"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr "не вдалося завантажити дані щодо модуля: %s"
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr "вказано зайві аргументи"
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -341,3 +437,1024 @@ msgstr "Користувач відмовив у задоволенні запи
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "Невідома помилка"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "не вдалося завантажити модуль: %s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr "не вдалося знайти точку входу C_GetFunctionList до модуля: %s: %s"
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr "помилка виклику C_GetFunctiontList у модулі: %s: %s"
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+"відмова у завантаженні модуля p11-kit-proxy.so як зареєстрованого модуля"
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr "для модуля «%s» одночасно вказано параметри enable-in і disable-in"
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+"перериваємо ініціалізацію, оскільки модуль «%s» було позначено як критичний"
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr "ініціалізацію p11-kit викликано рекурсивно"
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr "помилка під час спроби ініціалізувати критичний модуль «%s»: %s"
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr "пропускаємо модуль «%s», чию ініціалізацію не вдалося виконати: %s"
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr "не вдалося закрити сеанс: %s"
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+"підтримку параметра «%s» для модуля «%s» передбачено лише для керованих "
+"модулів"
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr "%s: не вдалося ініціалізувати модуль: %s"
+
+#: p11-kit/modules.c:2176
+#, fuzzy, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr "%s: не вдалося ініціалізувати модуль%s: %s"
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr "%s: модуль вже ініціалізовано"
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr "%s: не вдалося завершити завантаження модуля: %s"
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr "помилка ініціалізації модуля: %s"
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr "Вивести список модулів і жетонів"
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr "Запустити певний модуль PKCS#11 віддалено"
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+"Запустити процес сервера, який надаватиме доступ до модуля PKCS#11 віддалено"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr "не вдалося запустити інструмент довіри"
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr "«%s» не є коректною командою. Див. «p11-kit --help»"
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr "вказати модуль або жетони для remote"
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr "інструмент «remote» не призначено для запуску з термінала"
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr "можна вказати лише один модуль"
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr "некоректна відповідь щодо помилки rpc: надто коротка"
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr "некоректна відповідь щодо помилки rpc: помилковий код помилки"
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr "некоректна відповідь rpc: невідповідність викликів"
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr "некоректна відповідь rpc: помилкові дані в аргументі"
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr "отримано масив атрибутів із помилковою кількістю атрибутів"
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr "атрибути повернуто у некоректному порядку"
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr "надано некоректний набір викликів семафорів"
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr "неможливо виконати без блокування операційної системи"
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr "C_Initialize викликано двічі для одного процесу"
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+"у відповідь на спробу завершення завантаження модуля rpc повернуто "
+"повідомлення про помилку: %lu"
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr "некоректне повідомлення: не вдалося прочитати ідентифікатор виклику"
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr "некоректне повідомлення: помилковий ідентифікатор виклику: %d"
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr "некоректне повідомлення: не вдалося прочитати підпис"
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr "некоректне повідомлення: підпис є невідповідним"
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr "отримано некоректну довжину рядка, доповненого пробілами: %d != %d"
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr "некоректний запит від модуля; ймовірно, надто короткий"
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr "не вдалося ініціалізувати відповідь rpc"
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+"отримано некоректну відповідь щодо узгодження зв'язку від модуля з'єднання"
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr "не вдалося обробити повідомлення rpc pkcs11"
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr "вичерпано пам'ять під час спроби з'єднати повідомлення"
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr "відповідь щодо вичерпання пам'яті із помилкою"
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr "отримано повідомлення щодо непідтримуваної версії: %d"
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr "не вдалося прочитати байт реєстраційних даних"
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr "не вдалося записати байт реєстраційних даних"
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr "не вдалося прочитати повідомлення rpc"
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr "неочікувана помилка під час пробити повідомлення rpc"
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr "не вдалося записати повідомлення rpc"
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr "не вдалося надіслати дані: з'єднання розірвано"
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr "не вдалося надіслати дані"
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr "не вдалося отримати дані: з'єднання розірвано"
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr "не вдалося отримати дані"
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+"отримано некоректні значення заголовка rpc: можливо, помилковий протокол"
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr "не вдалося скористатися select для очікування на канал rpc"
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr "не вдалося надіслати реєстраційні дані сокета"
+
+#: p11-kit/rpc-transport.c:653
+#, fuzzy
+msgid "couldn't receive socket credentials"
+msgstr "не вдалося надіслати реєстраційні дані сокета"
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr "закриваємо сокет через помилку протоколу"
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr "процес %d не завершив роботу, перериваємо"
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr "не вдалося дочекатися виконання дочірнього процесу: %d"
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr "процес %d завершив роботу зі станом %d"
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr "процес %d було перервано сигналом %d"
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr "не вдалося створити канал для remote"
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr "не вдалося створити відгалуження для remote"
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr "процес %p не завершив роботу, перериваємо"
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr "не вдалося перервати процес %p"
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr "не вдалося дочекатися виконання дочірнього процесу: %p"
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr "не вдалося отримати стан виходу %p"
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr "процес %p завершив роботу зі станом %lu"
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr "не вдалося здублювати stdin"
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr "не вдалося здублювати stdout"
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr "не вдалося здублювати кінець каналу дочірнього процесу"
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr "не вдалося породити remote"
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr "не вдалося відновити дескриптори файлів"
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr "некоректний рядок віддаленої команди: %s"
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr "не вдалося створити сокет для remote"
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr "не вдалося обробити адресу vsock: «%s»"
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr "підтримки remote не передбачено: %s"
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr "дочірній процес %u завершив роботу із sigsegv"
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr "дочірній процес %u завершив роботу із сигналом %d"
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr "не вдалося створити сокет %s"
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr "не вдалося прив'язати сокет %s"
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr "не вдалося почати очікування даних на сокеті %s"
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr "не вдалося змінити власника сокета %s"
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr "не вдалося створити сокет %u:%u"
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr "не вдалося прив'язати сокет %u:%u"
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr "не вдалося почати очікування даних на сокеті %u:%u"
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr "не вдалося перевірити uid від сокета"
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr "uid з'єднання (%u) не збігається із очікуваним (%u)"
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr "gid з'єднання (%u) не збігається із очікуваним (%u)"
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr "не вдалося виконати fork() для створення фонової служби"
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr "не вдалося створити сеанс"
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr "отримано занадто багато файлових дескрипторів"
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr "немає з'єднань із %s протягом %lu секунд, завершуємо роботу"
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr "не вдалося прийняти дані з сокета %s"
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr "не вдалося створити відгалуження для accept"
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr "невідома група: %s"
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr "невідомий користувач: %s"
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr "не вдалося встановити gid у значення %u"
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr "не вдалося виконати setgroups зі значенням %u"
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr "не вдалося встановити для uid значення %u"
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr "не вдалося визначити каталог запуску"
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr "не вдалося створити %s"
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr "не вдалося ініціалізувати функції захисту Windows"
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr "не вдалося побудувати SID для %s: %lu"
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr "не вдалося побудувати ACL: %d"
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr "не вдалося розмістити у пам'яті дескриптор захисту: %lu"
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr "не вдалося ініціалізувати дескриптор захисту: %lu"
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr "не вдалося встановити власника у дескрипторі захисту: %lu"
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr "не вдалося встановити DACL у дескрипторі захисту: %lu"
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr "некоректна адреса PKCS#11: «%s»"
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr "невідомий формат файла: %s"
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr "не вдалося обробити файл: «%s»"
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr "%s: не вдалося ініціалізувати: %s"
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr "%s: не вдалося пронумерувати слоти: %s"
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr "%s: не вдалося отримати відомості щодо жетона: %s"
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr "%s: не вдалося відкрити сеанс: %s"
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+"немає налаштованого придатного до запису місця для зберігання прив'язок"
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr "немає налаштованого місця для зберігання прив'язок"
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr "не вдалося створити об'єкт: %s"
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr "вкажіть принаймні один вхідний файл прив'язки"
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr "не вдалося вилучити позначений лише для читання %s"
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr "не вдалося вилучити %s: %s"
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr "має бути вказано принаймні один файл або адресу"
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr "дію вже вказано"
+
+#: trust/anchor.c:702
+#, fuzzy, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] "%u помилка під час обробки"
+msgstr[1] "%u помилка під час обробки"
+msgstr[2] "%u помилка під час обробки"
+msgstr[3] "%u помилка під час обробки"
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr "%.*s: некоректне розширення сертифіката"
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr "%.*s: некоректне розширення сертифіката базових обмежень"
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr "невідомий"
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr "пропущено атрибут CKA_HASH_OF_SUBJECT_PUBLIC_KEY"
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr "пропущено атрибут CKA_HASH_OF_ISSUER_PUBLIC_KEY"
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr "об'єкт є непридатним до внесення змін"
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr "неможливо створити об'єкт цього типу"
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr "не можна встановлювати атрибут %s"
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr "не можна вносити зміни до атрибута %s"
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr "атрибут %s має некоректне значення"
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr "атрибут %s не є коректним для об'єкта"
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr "пропущено атрибут %s"
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr "не знайдено атрибута CKA_CLASS"
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr "не вдалося створити об'єкт %s"
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr "ключ"
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr "не-жетон"
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr "пропущено %s для об'єкта"
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr "%s, непідтримуваний %s"
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr "%s, непідтримуваний клас об'єктів"
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr "некоректне розширення сертифіката використання ключів"
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr "некоректне розширення сертифіката розширеного використання ключів"
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr "некоректне розширення сертифіката відмови у використанні ключів"
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr "не вдалося створити дамп об'єкта"
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr "команді передано зайві аргументи"
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr "не вдалося обробити долучене розширення сертифіката: %s"
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr "не вдалося завантажити долучені розширення для сертифіката: %s"
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr "не вдалося обробити сертифікат: %s"
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr "не вдалося завантажити атрибути: %s"
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr "пропускаємо об'єкт, який не є сертифікатом"
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr "не вдалося завантажити список блокування: %s"
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr "адресу PKCS#11 вже вказано"
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr "не вдалося обробити фільтр адрес pkcs11: %s"
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr "у адресі містяться невідомі компоненти, нічого не буде видобуто"
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr "непідтримуваний або невідомий фільтр: %s"
+
+#: trust/enumerate.c:670
+#, fuzzy, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr "непідтримувана або невідома мета: %s"
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr "не зареєстровано модулів, які містять правила довіри"
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr "формат уже вказано"
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr "непідтримуваний або невідомий формат: %s"
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr "у форматі не передбачено підтримки правил довіри"
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+"формат потребує мети, вкажіть її за допомогою --purpose; використовуємо "
+"типову мету «server-auth»"
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+"у форматі не передбачено підтримки визначення декількох записів мети; "
+"використовуємо типову мету «server-auth»"
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr "вкажіть один файл або каталог призначення"
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr "не вказано формат виведення даних"
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr "не вдалося запустити команду %s"
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+"знайдено декілька сертифікатів, але запис можливий лише до одного файла"
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr "не вдалося знайти сертифікати: %s"
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr "не знайдено сертифікатів"
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr "не вдалося знайти сертифікат: %s"
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr "обрізаємо надто довгий рядок"
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr "Змінна середовища $SOURCE_DATE_EPOCH: strtoull"
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr "Змінна середовища $SOURCE_DATE_EPOCH: не знайдено цифр: %s\n"
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr "Змінна середовища $SOURCE_DATE_EPOCH: зайві кінцеві дані: %s\n"
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+"Змінна середовища $SOURCE_DATE_EPOCH: значення має бути меншим або рівним "
+"%lu. Втім, виявлено таке значення: %llu \n"
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr "не вдалося створити альтернативну назву сертифіката"
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr "пропускаємо об'єкт, не вдалося побудувати адресу"
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr "невідомий аргумент модуля: %s"
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr "сертифікат із недовірою у місці для прив'язок: %s"
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr "перевизначаємо довіру для прив'язки у списку блокувань: %s"
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr "Не вдалося обробити блок PEM типу %s"
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr "не вдалося відкрити і прив'язати файл: %s"
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr "некоректне значення oid: %s"
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr "не вдалося створити файл: %s%s"
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr "не вдалося записати дані до цього файла: %s"
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr "не вдалося завершити запис до файла: %s"
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr "не вдалося записати файл: %s"
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr "не вдалося встановити права доступу до файла: %s"
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr "не вдалося завершити запис до файла: %s"
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr "не вдалося вилучити початковий файл: %s"
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr "не вдалося створити каталог: %s"
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr "каталог вже існує: %s"
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "не вдалося створити каталог: %s"
+
+#: trust/save.c:374
+#, fuzzy, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr "не вдалося встановити права доступу до каталогу: %s"
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr "не вдалося зробити каталог придатним до запису: %s"
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr "не вдалося створити символічне посилання: %s"
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr "не вдалося вилучити файл: %s"
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr "не вдалося встановити права доступу до каталогу: %s"
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr "не вдалося завантажити файл до об'єктів: %s"
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr "не вдалося отримати статистичні дані щодо шляху: %d: %s"
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr "не вдалося отримати доступ до шляху довірених сертифікатів: %s"
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr "не вдалося отримати доступ до файла довіри: %s"
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr "не вдалося отримати доступ: %s"
+
+#: trust/trust.c:60
+#, fuzzy
+msgid "List trust or certificates"
+msgstr "не вдалося обробити сертифікат: %s"
+
+#: trust/trust.c:61
+#, fuzzy
+msgid "Extract certificates and trust"
+msgstr "не знайдено сертифікатів"
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Vietnamese (http://www.transifex.com/freedesktop/p11-kit/language/vi/)\n"
+"Language-Team: Vietnamese (http://www.transifex.com/freedesktop/p11-kit/"
+"language/vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1002 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
 "PO-Revision-Date: 2012-02-29 09:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Walloon (http://www.transifex.com/freedesktop/p11-kit/language/wa/)\n"
+"Language-Team: Walloon (http://www.transifex.com/freedesktop/p11-kit/"
+"language/wa/)\n"
+"Language: wa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: wa\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1003 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,23 +1,112 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
+# Boyuan Yang <073plan@gmail.com>, 2021
 # Michael Jay Tong <michaeljayt@gmail.com>, 2014
-# Wylmer Wang, 2013
+# e0c668032ced196bd60f2b6a070d982d_8f72ae0, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:08+0000\n"
-"Last-Translator: Michael Jay Tong <michaeljayt@gmail.com>\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/freedesktop/p11-kit/language/zh_CN/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Boyuan Yang <073plan@gmail.com>, 2021\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/freedesktop/p11-kit/"
+"language/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr "未指定命令"
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr "未知的全局选项：%s"
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr "未知的全局选项：-%c"
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr "无法初始化过滤器"
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -342,3 +431,1001 @@ msgstr "请求已被用户拒绝"
 #: p11-kit/messages.c:240
 msgid "Unknown error"
 msgstr "未知错误"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr "无法加载模块：%s: %s"
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, fuzzy, c-format
+msgid "couldn't open directory: %s"
+msgstr "无法加载模块：%s: %s"
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
+msgstr ""

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -1,21 +1,109 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
-# This file is distributed under the same license as the PACKAGE package.
-# 
+# This file is distributed under the same license as the p11-kit package.
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2015-02-20 21:29+0100\n"
-"PO-Revision-Date: 2013-11-20 10:27+0000\n"
-"Last-Translator: Stef Walter <stefw@gnome.org>\n"
-"Language-Team: Chinese (Hong Kong) (http://www.transifex.com/freedesktop/p11-kit/language/zh_HK/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese (Hong Kong) (http://www.transifex.com/freedesktop/p11-"
+"kit/language/zh_HK/)\n"
+"Language: zh_HK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_HK\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
@@ -339,4 +427,1002 @@ msgstr ""
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr ""
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,343 +1,1429 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Collabora Ltd.
 # This file is distributed under the same license as the p11-kit package.
-# 
+#
 # Translators:
 # Walter Cheuk <wwycheuk@gmail.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: p11-kit\n"
-"Report-Msgid-Bugs-To: https://bugs.freedesktop.org/enter_bug.cgi?product=p11-glue\n"
-"POT-Creation-Date: 2018-01-31 16:48+0100\n"
-"PO-Revision-Date: 2017-09-19 12:31+0000\n"
-"Last-Translator: Walter Cheuk <wwycheuk@gmail.com>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/freedesktop/p11-kit/language/zh_TW/)\n"
+"Report-Msgid-Bugs-To: https://github.com/p11-glue/p11-kit/issues\n"
+"POT-Creation-Date: 2022-10-19 03:26+0000\n"
+"PO-Revision-Date: 2012-02-29 09:23+0000\n"
+"Last-Translator: Walter Cheuk <wwycheuk@gmail.com>, 2013\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/freedesktop/p11-"
+"kit/language/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: common/tool.c:184
+#, c-format
+msgid "usage: %s command <args>...\n"
+msgstr ""
+
+#: common/tool.c:185
+#, c-format
+msgid ""
+"\n"
+"Common %s commands are:\n"
+msgstr ""
+
+#: common/tool.c:198
+#, c-format
+msgid ""
+"\n"
+"See '%s <command> --help' for more information\n"
+msgstr ""
+
+#: common/tool.c:261 common/tool.c:333
+msgid "no command specified"
+msgstr ""
+
+#: common/tool.c:277
+#, c-format
+msgid "unknown global option: %s"
+msgstr ""
+
+#: common/tool.c:306
+#, c-format
+msgid "unknown global option: -%c"
+msgstr ""
+
+#. At this point we have no command
+#: common/tool.c:358
+#, c-format
+msgid "'%s' is not a valid command. See '%s --help'"
+msgstr ""
+
+#: p11-kit/conf.c:161
+#, c-format
+msgid "%s: unexpected pem block"
+msgstr ""
+
+#: p11-kit/conf.c:165
+#, c-format
+msgid "%s: unexpected section header"
+msgstr ""
+
+#: p11-kit/conf.c:208
+#, c-format
+msgid "invalid mode for 'user-config': %s"
+msgstr ""
+
+#: p11-kit/conf.c:367
+#, c-format
+msgid "invalid config filename, will be ignored in the future: %s"
+msgstr ""
+
+#: p11-kit/conf.c:428 trust/save.c:573 trust/token.c:269
+#, c-format
+msgid "couldn't list directory: %s"
+msgstr ""
+
+#: p11-kit/conf.c:439
+#, c-format
+msgid "couldn't stat path: %s"
+msgstr ""
+
+#: p11-kit/conf.c:528
+#, c-format
+msgid "invalid setting '%s' defaulting to '%s'"
+msgstr ""
+
+#: p11-kit/filter.c:183
+msgid "filter cannot be initialized"
+msgstr ""
+
+#: p11-kit/lists.c:117 p11-kit/lists.c:184 p11-kit/lists.c:205
+#, c-format
+msgid "couldn't load module info: %s"
+msgstr ""
+
+#: p11-kit/lists.c:296
+msgid "extra arguments specified"
+msgstr ""
 
 #: p11-kit/messages.c:78
 msgid "The operation was cancelled"
-msgstr ""
+msgstr "操作已取消"
 
 #: p11-kit/messages.c:81
 msgid "Insufficient memory available"
-msgstr ""
+msgstr "可用的記憶體不足"
 
 #: p11-kit/messages.c:83
 msgid "The specified slot ID is not valid"
-msgstr ""
+msgstr "指定的槽 ID 無效"
 
 #: p11-kit/messages.c:85
 msgid "Internal error"
-msgstr "內部出錯"
+msgstr "內部錯誤"
 
 #: p11-kit/messages.c:87
 msgid "The operation failed"
-msgstr ""
+msgstr "操作失敗"
 
 #: p11-kit/messages.c:89
 msgid "Invalid arguments"
-msgstr ""
+msgstr "無效的引數"
 
 #: p11-kit/messages.c:91
 msgid "The module cannot create needed threads"
-msgstr ""
+msgstr "模組無法建立需要的執行緒"
 
 #: p11-kit/messages.c:93
 msgid "The module cannot lock data properly"
-msgstr ""
+msgstr "模組無法正確鎖定資料"
 
 #: p11-kit/messages.c:95
 msgid "The field is read-only"
-msgstr ""
+msgstr "欄位唯讀"
 
 #: p11-kit/messages.c:97
 msgid "The field is sensitive and cannot be revealed"
-msgstr ""
+msgstr "欄位敏感，無法揭示"
 
 #: p11-kit/messages.c:99
 msgid "The field is invalid or does not exist"
-msgstr ""
+msgstr "欄位無效或不存在"
 
 #: p11-kit/messages.c:101
 msgid "Invalid value for field"
-msgstr ""
+msgstr "欄位值無效"
 
 #: p11-kit/messages.c:103
 msgid "The data is not valid or unrecognized"
-msgstr ""
+msgstr "資料無效或無法辨識"
 
 #: p11-kit/messages.c:105
 msgid "The data is too long"
-msgstr ""
+msgstr "資料過長"
 
 #: p11-kit/messages.c:107
 msgid "An error occurred on the device"
-msgstr ""
+msgstr "裝置遭遇錯誤"
 
 #: p11-kit/messages.c:109
 msgid "Insufficient memory available on the device"
-msgstr ""
+msgstr "裝置上的記憶體不足"
 
 #: p11-kit/messages.c:111
 msgid "The device was removed or unplugged"
-msgstr ""
+msgstr "裝置已移除或拔除"
 
 #: p11-kit/messages.c:113
 msgid "The encrypted data is not valid or unrecognized"
-msgstr ""
+msgstr "加密的資料無效或無法辨識"
 
 #: p11-kit/messages.c:115
 msgid "The encrypted data is too long"
-msgstr ""
+msgstr "加密的資料過長"
 
 #: p11-kit/messages.c:117
 msgid "This operation is not supported"
-msgstr ""
+msgstr "不支援此操作"
 
 #: p11-kit/messages.c:119
 msgid "The key is missing or invalid"
-msgstr ""
+msgstr "金鑰遺失或無效"
 
 #: p11-kit/messages.c:121
 msgid "The key is the wrong size"
-msgstr ""
+msgstr "金鑰大小錯誤"
 
 #: p11-kit/messages.c:123
 msgid "The key is of the wrong type"
-msgstr ""
+msgstr "金鑰類型錯誤"
 
 #: p11-kit/messages.c:125
 msgid "No key is needed"
-msgstr ""
+msgstr "不需要金鑰"
 
 #: p11-kit/messages.c:127
 msgid "The key is different than before"
-msgstr ""
+msgstr "金鑰與之前不同"
 
 #: p11-kit/messages.c:129
 msgid "A key is needed"
-msgstr ""
+msgstr "需要金鑰"
 
 #: p11-kit/messages.c:131
 msgid "Cannot include the key in the digest"
-msgstr ""
+msgstr "無法將金鑰納入摘要中"
 
 #: p11-kit/messages.c:133
 msgid "This operation cannot be done with this key"
-msgstr ""
+msgstr "這個操作無法以此金鑰完成"
 
 #: p11-kit/messages.c:135
 msgid "The key cannot be wrapped"
-msgstr ""
+msgstr "這個金鑰無法包裝"
 
 #: p11-kit/messages.c:137
 msgid "Cannot export this key"
-msgstr ""
+msgstr "無法匯出此金鑰"
 
 #: p11-kit/messages.c:139
 msgid "The crypto mechanism is invalid or unrecognized"
-msgstr ""
+msgstr "密碼學機制無效或無法辨識"
 
 #: p11-kit/messages.c:141
 msgid "The crypto mechanism has an invalid argument"
-msgstr ""
+msgstr "密碼學機制有引數無效"
 
 #: p11-kit/messages.c:143
 msgid "The object is missing or invalid"
-msgstr ""
+msgstr "物件遺失或無效"
 
 #: p11-kit/messages.c:145
 msgid "Another operation is already taking place"
-msgstr ""
+msgstr "其他操作已經處理中"
 
 #: p11-kit/messages.c:147
 msgid "No operation is taking place"
-msgstr ""
+msgstr "沒有處理中的操作"
 
 #: p11-kit/messages.c:149
 msgid "The password or PIN is incorrect"
-msgstr ""
+msgstr "密碼或 PIN 不正確"
 
 #: p11-kit/messages.c:151
 msgid "The password or PIN is invalid"
-msgstr ""
+msgstr "密碼或 PIN 無效"
 
 #: p11-kit/messages.c:153
 msgid "The password or PIN is of an invalid length"
-msgstr ""
+msgstr "密碼或 PIN 的長度無效"
 
 #: p11-kit/messages.c:155
 msgid "The password or PIN has expired"
-msgstr ""
+msgstr "密碼或 PIN 已過期"
 
 #: p11-kit/messages.c:157
 msgid "The password or PIN is locked"
-msgstr ""
+msgstr "密碼或 PIN 已鎖定"
 
 #: p11-kit/messages.c:159
 msgid "The session is closed"
-msgstr ""
+msgstr "作業階段已關閉"
 
 #: p11-kit/messages.c:161
 msgid "Too many sessions are active"
-msgstr ""
+msgstr "過多作業階段作用中"
 
 #: p11-kit/messages.c:163
 msgid "The session is invalid"
-msgstr ""
+msgstr "作業階段無效"
 
 #: p11-kit/messages.c:165
 msgid "The session is read-only"
-msgstr ""
+msgstr "作業階段僅唯讀"
 
 #: p11-kit/messages.c:167
 msgid "An open session exists"
-msgstr ""
+msgstr "有一個開啟的作業階段"
 
 #: p11-kit/messages.c:169
 msgid "A read-only session exists"
-msgstr ""
+msgstr "有一個唯讀的作業階段"
 
 #: p11-kit/messages.c:171
 msgid "An administrator session exists"
-msgstr ""
+msgstr "有一個管理員作業階段"
 
 #: p11-kit/messages.c:173
 msgid "The signature is bad or corrupted"
-msgstr ""
+msgstr "簽章不良或損毀"
 
 #: p11-kit/messages.c:175
 msgid "The signature is unrecognized or corrupted"
-msgstr ""
+msgstr "簽章無法辨識或損毀"
 
 #: p11-kit/messages.c:177
 msgid "Certain required fields are missing"
-msgstr ""
+msgstr "遺失必要的特定欄位"
 
 #: p11-kit/messages.c:179
 msgid "Certain fields have invalid values"
-msgstr ""
+msgstr "特定欄位的值無效"
 
 #: p11-kit/messages.c:181
 msgid "The device is not present or unplugged"
-msgstr ""
+msgstr "裝置不在或已拔除"
 
 #: p11-kit/messages.c:183
 msgid "The device is invalid or unrecognizable"
-msgstr ""
+msgstr "裝置無效或無法辨識"
 
 #: p11-kit/messages.c:185
 msgid "The device is write protected"
-msgstr ""
+msgstr "裝置有寫入保護"
 
 #: p11-kit/messages.c:187
 msgid "Cannot import because the key is invalid"
-msgstr ""
+msgstr "無法匯入，因為金鑰無效"
 
 #: p11-kit/messages.c:189
 msgid "Cannot import because the key is of the wrong size"
-msgstr ""
+msgstr "無法匯入，因為金鑰大小錯誤"
 
 #: p11-kit/messages.c:191
 msgid "Cannot import because the key is of the wrong type"
-msgstr ""
+msgstr "無法匯入，因為金鑰類型錯誤"
 
 #: p11-kit/messages.c:193
 msgid "You are already logged in"
-msgstr ""
+msgstr "您已經登入"
 
 #: p11-kit/messages.c:195
 msgid "No user has logged in"
-msgstr ""
+msgstr "沒有使用者已登入"
 
 #: p11-kit/messages.c:197
 msgid "The user's password or PIN is not set"
-msgstr ""
+msgstr "使用者的密碼或 PIN 尚未設定"
 
 #: p11-kit/messages.c:199
 msgid "The user is of an invalid type"
-msgstr ""
+msgstr "使用者的類型無效"
 
 #: p11-kit/messages.c:201
 msgid "Another user is already logged in"
-msgstr ""
+msgstr "另一位使用者已經登入"
 
 #: p11-kit/messages.c:203
 msgid "Too many users of different types are logged in"
-msgstr ""
+msgstr "有過多不同類型的使用者登入"
 
 #: p11-kit/messages.c:205
 msgid "Cannot import an invalid key"
-msgstr ""
+msgstr "無法匯入無效的金鑰"
 
 #: p11-kit/messages.c:207
 msgid "Cannot import a key of the wrong size"
-msgstr ""
+msgstr "無法匯入錯誤大小的金鑰"
 
 #: p11-kit/messages.c:209
 msgid "Cannot export because the key is invalid"
-msgstr ""
+msgstr "無法匯入，因為金鑰無效"
 
 #: p11-kit/messages.c:211
 msgid "Cannot export because the key is of the wrong size"
-msgstr ""
+msgstr "無法匯出，因為金鑰大小錯誤"
 
 #: p11-kit/messages.c:213
 msgid "Cannot export because the key is of the wrong type"
-msgstr ""
+msgstr "無法匯出，因為金鑰類型錯誤"
 
 #: p11-kit/messages.c:215
 msgid "Unable to initialize the random number generator"
-msgstr ""
+msgstr "無法初始化隨機數字產生器"
 
 #: p11-kit/messages.c:217
 msgid "No random number generator available"
-msgstr ""
+msgstr "沒有可用的隨機數字產生器"
 
 #: p11-kit/messages.c:219
 msgid "The crypto mechanism has an invalid parameter"
-msgstr ""
+msgstr "密碼學機制有參數無效"
 
 #: p11-kit/messages.c:221
 msgid "Not enough space to store the result"
-msgstr ""
+msgstr "空間不足以儲存結果"
 
 #: p11-kit/messages.c:223
 msgid "The saved state is invalid"
-msgstr ""
+msgstr "儲存的狀態無效"
 
 #: p11-kit/messages.c:225
 msgid "The information is sensitive and cannot be revealed"
-msgstr ""
+msgstr "資訊敏感，無法揭示"
 
 #: p11-kit/messages.c:227
 msgid "The state cannot be saved"
-msgstr ""
+msgstr "無法儲存狀態"
 
 #: p11-kit/messages.c:229
 msgid "The module has not been initialized"
-msgstr ""
+msgstr "模組尚未初始化"
 
 #: p11-kit/messages.c:231
 msgid "The module has already been initialized"
-msgstr ""
+msgstr "模組已經初始化"
 
 #: p11-kit/messages.c:233
 msgid "Cannot lock data"
-msgstr ""
+msgstr "無法鎖定資料"
 
 #: p11-kit/messages.c:235
 msgid "The data cannot be locked"
-msgstr ""
+msgstr "資料無法上鎖"
 
 #: p11-kit/messages.c:237
 msgid "The request was rejected by the user"
-msgstr ""
+msgstr "請求遭使用者拒絕"
 
 #: p11-kit/messages.c:240
 msgid "Unknown error"
+msgstr "未知錯誤"
+
+#: p11-kit/modules.c:373
+#, c-format
+msgid "couldn't load module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:385
+#, c-format
+msgid "couldn't find C_GetFunctionList entry point in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:393
+#, c-format
+msgid "call to C_GetFunctiontList failed in module: %s: %s"
+msgstr ""
+
+#: p11-kit/modules.c:399
+msgid "refusing to load the p11-kit-proxy.so module as a registered module"
+msgstr ""
+
+#: p11-kit/modules.c:548
+#, c-format
+msgid "module '%s' has both enable-in and disable-in options"
+msgstr ""
+
+#: p11-kit/modules.c:698
+#, c-format
+msgid "aborting initialization because module '%s' was marked as critical"
+msgstr ""
+
+#: p11-kit/modules.c:723
+msgid "p11-kit initialization called recursively"
+msgstr ""
+
+#: p11-kit/modules.c:909
+#, c-format
+msgid "initialization of critical module '%s' failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:912
+#, c-format
+msgid "skipping module '%s' whose initialization failed: %s"
+msgstr ""
+
+#: p11-kit/modules.c:1687
+#, c-format
+msgid "couldn't close session: %s"
+msgstr ""
+
+#.
+#. * This is because the module is running in unmanaged mode, so turn off the
+#.
+#: p11-kit/modules.c:1864
+#, c-format
+msgid "the '%s' option for module '%s' is only supported for managed modules"
+msgstr ""
+
+#: p11-kit/modules.c:2173 p11-kit/modules.c:2649
+#, c-format
+msgid "%s: module failed to initialize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2176
+#, c-format
+msgid "%s: module failed to initialize, skipping: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2182
+#, c-format
+msgid "%s: module was already initialized"
+msgstr ""
+
+#: p11-kit/modules.c:2278 p11-kit/modules.c:2690
+#, c-format
+msgid "%s: module failed to finalize: %s"
+msgstr ""
+
+#: p11-kit/modules.c:2417
+#, c-format
+msgid "module initialization failed: %s"
+msgstr ""
+
+#: p11-kit/p11-kit.c:72
+msgid "List modules and tokens"
+msgstr ""
+
+#: p11-kit/p11-kit.c:73
+msgid "Run a specific PKCS#11 module remotely"
+msgstr ""
+
+#: p11-kit/p11-kit.c:74
+msgid "Run a server process that exposes PKCS#11 module remotely"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:95
+msgid "couldn't run trust tool"
+msgstr ""
+
+#. At this point we have no command
+#: p11-kit/p11-kit.c:137
+#, c-format
+msgid "'%s' is not a valid command. See 'p11-kit --help'"
+msgstr ""
+
+#: p11-kit/remote.c:108
+msgid "specify a module or tokens to remote"
+msgstr ""
+
+#: p11-kit/remote.c:113
+msgid "the 'remote' tool is not meant to be run from a terminal"
+msgstr ""
+
+#: p11-kit/remote.c:139
+msgid "only one module can be specified"
+msgstr ""
+
+#: p11-kit/rpc-client.c:146
+msgid "invalid rpc error response: too short"
+msgstr ""
+
+#: p11-kit/rpc-client.c:151
+msgid "invalid rpc error response: bad error code"
+msgstr ""
+
+#: p11-kit/rpc-client.c:161
+msgid "invalid rpc response: call mismatch"
+msgstr ""
+
+#: p11-kit/rpc-client.c:182
+msgid "invalid rpc response: bad argument data"
+msgstr ""
+
+#: p11-kit/rpc-client.c:229
+msgid "received an attribute array with wrong number of attributes"
+msgstr ""
+
+#: p11-kit/rpc-client.c:256
+msgid "returned attributes in invalid order"
+msgstr ""
+
+#: p11-kit/rpc-client.c:727 trust/module.c:382
+msgid "invalid set of mutex calls supplied"
+msgstr ""
+
+#: p11-kit/rpc-client.c:736 trust/module.c:391
+msgid "can't do without os locking"
+msgstr ""
+
+#: p11-kit/rpc-client.c:749
+msgid "C_Initialize called twice for same process"
+msgstr ""
+
+#: p11-kit/rpc-client.c:856
+#, c-format
+msgid "finalizing rpc module returned an error: %lu"
+msgstr ""
+
+#: p11-kit/rpc-message.c:190
+msgid "invalid message: couldn't read call identifier"
+msgstr ""
+
+#: p11-kit/rpc-message.c:199
+#, c-format
+msgid "invalid message: bad call id: %d"
+msgstr ""
+
+#: p11-kit/rpc-message.c:217
+msgid "invalid message: couldn't read signature"
+msgstr ""
+
+#: p11-kit/rpc-message.c:222
+msgid "invalid message: signature doesn't match"
+msgstr ""
+
+#: p11-kit/rpc-message.c:483
+#, c-format
+msgid "invalid length space padded string received: %d != %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:575
+msgid "invalid request from module, probably too short"
+msgstr ""
+
+#: p11-kit/rpc-server.c:585
+msgid "couldn't initialize rpc response"
+msgstr ""
+
+#: p11-kit/rpc-server.c:717
+msgid "invalid handshake received from connecting module"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1834
+msgid "couldn't parse pkcs11 rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1921
+msgid "out of memory error putting together message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1945
+msgid "out of memory responding with error"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1991
+#, c-format
+msgid "unsupported version received: %d"
+msgstr ""
+
+#: p11-kit/rpc-server.c:1997
+msgid "couldn't read credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2009
+msgid "couldn't write credential byte"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2032
+msgid "failed to read rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2037
+msgid "unexpected error handling rpc message"
+msgstr ""
+
+#: p11-kit/rpc-server.c:2055
+msgid "failed to write rpc message"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:208
+msgid "couldn't send data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:211
+msgid "couldn't send data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:234
+msgid "couldn't receive data: closed connection"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:238
+msgid "couldn't receive data"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:416
+msgid "received invalid rpc header values: perhaps wrong protocol"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:459
+msgid "couldn't use select to wait on rpc pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:648
+msgid "couldn't send socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:653
+msgid "couldn't receive socket credentials"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:659
+msgid "peer protocol version is too old"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:710 p11-kit/rpc-transport.c:716
+msgid "closing socket due to protocol failure"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:755
+#, c-format
+msgid "process %d did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:762
+#, c-format
+msgid "failed to wait for executed child: %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:769
+#, c-format
+msgid "process %d exited with status %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:773
+#, c-format
+msgid "process %d was terminated with signal %d"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:817 p11-kit/rpc-transport.c:953
+#: p11-kit/rpc-transport.c:960
+msgid "failed to create pipe for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:828
+msgid "failed to fork for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:888
+#, c-format
+msgid "process %p did not exit, terminating"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:890
+#, c-format
+msgid "couldn't terminate process %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:895
+#, c-format
+msgid "failed to wait for executed child: %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:898
+#, c-format
+msgid "failed to get the exit status of %p"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:902
+#, c-format
+msgid "process %p exited with status %lu"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:968
+msgid "failed to duplicate stdin"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:975
+msgid "failed to duplicate stdout"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:983
+msgid "failed to duplicate child end of pipe"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:993
+msgid "failed to spawn remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1006
+msgid "failed to restore file descriptors"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1075
+#, c-format
+msgid "invalid remote command line: %s"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1115 p11-kit/rpc-transport.c:1196
+msgid "failed to create socket for remote"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1293 p11-kit/server.c:165
+#, c-format
+msgid "failed to parse vsock address: '%s'"
+msgstr ""
+
+#: p11-kit/rpc-transport.c:1301
+#, c-format
+msgid "remote not supported: %s"
+msgstr ""
+
+#: p11-kit/server.c:243
+#, c-format
+msgid "child %u died with sigsegv"
+msgstr ""
+
+#: p11-kit/server.c:245
+#, c-format
+msgid "child %u died with signal %d"
+msgstr ""
+
+#: p11-kit/server.c:318
+#, c-format
+msgid "could not create socket %s"
+msgstr ""
+
+#: p11-kit/server.c:326
+#, c-format
+msgid "could not bind socket %s"
+msgstr ""
+
+#: p11-kit/server.c:333
+#, c-format
+msgid "could not listen to socket %s"
+msgstr ""
+
+#: p11-kit/server.c:341
+#, c-format
+msgid "could not chown socket %s"
+msgstr ""
+
+#: p11-kit/server.c:364
+#, c-format
+msgid "could not create socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:371
+#, c-format
+msgid "could not bind socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:378
+#, c-format
+msgid "could not listen to socket %u:%u"
+msgstr ""
+
+#: p11-kit/server.c:397
+msgid "could not check uid from socket"
+msgstr ""
+
+#: p11-kit/server.c:403
+#, c-format
+msgid "connecting uid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:410
+#, c-format
+msgid "connecting gid (%u) doesn't match expected (%u)"
+msgstr ""
+
+#: p11-kit/server.c:491
+msgid "could not fork() to daemonize"
+msgstr ""
+
+#: p11-kit/server.c:504
+msgid "could not create a new session"
+msgstr ""
+
+#: p11-kit/server.c:512
+msgid "too many file descriptors received"
+msgstr ""
+
+#: p11-kit/server.c:556
+#, c-format
+msgid "no connections to %s for %lu secs, exiting"
+msgstr ""
+
+#: p11-kit/server.c:565
+#, c-format
+msgid "could not accept from socket %s"
+msgstr ""
+
+#: p11-kit/server.c:576
+msgid "failed to fork for accept"
+msgstr ""
+
+#: p11-kit/server.c:721 p11-kit/server.c:737
+#, c-format
+msgid "unknown group: %s"
+msgstr ""
+
+#: p11-kit/server.c:729 p11-kit/server.c:745
+#, c-format
+msgid "unknown user: %s"
+msgstr ""
+
+#: p11-kit/server.c:828
+#, c-format
+msgid "cannot set gid to %u"
+msgstr ""
+
+#: p11-kit/server.c:834
+#, c-format
+msgid "cannot setgroups to %u"
+msgstr ""
+
+#: p11-kit/server.c:842
+#, c-format
+msgid "cannot set uid to %u"
+msgstr ""
+
+#: p11-kit/server.c:858
+msgid "cannot determine runtime directory"
+msgstr ""
+
+#: p11-kit/server.c:870
+#, c-format
+msgid "cannot create %s"
+msgstr ""
+
+#: p11-kit/server.c:1141
+msgid "couldn't initialize Windows security functions"
+msgstr ""
+
+#: p11-kit/server.c:1302 p11-kit/server.c:1314 p11-kit/server.c:1326
+#, c-format
+msgid "unable to construct SID for %s: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1369
+#, c-format
+msgid "unable to construct ACL: %d"
+msgstr ""
+
+#: p11-kit/server.c:1375
+#, c-format
+msgid "unable to allocate security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1381
+#, c-format
+msgid "unable to initialise security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1387
+#, c-format
+msgid "unable to set owner in security descriptor: %lu"
+msgstr ""
+
+#: p11-kit/server.c:1393
+#, c-format
+msgid "unable to set DACL in security descriptor: %lu"
+msgstr ""
+
+#: trust/anchor.c:126
+#, c-format
+msgid "invalid PKCS#11 uri: %s"
+msgstr ""
+
+#: trust/anchor.c:148 trust/anchor.c:204
+#, c-format
+msgid "unrecognized file format: %s"
+msgstr ""
+
+#: trust/anchor.c:151 trust/anchor.c:207
+#, c-format
+msgid "failed to parse file: %s"
+msgstr ""
+
+#: trust/anchor.c:246
+#, c-format
+msgid "%s: couldn't initialize: %s"
+msgstr ""
+
+#: trust/anchor.c:257
+#, c-format
+msgid "%s: couldn't enumerate slots: %s"
+msgstr ""
+
+#: trust/anchor.c:265
+#, c-format
+msgid "%s: couldn't get token info: %s"
+msgstr ""
+
+#: trust/anchor.c:277
+#, c-format
+msgid "%s: couldn't open session: %s"
+msgstr ""
+
+#: trust/anchor.c:325
+msgid "no configured writable location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:327
+msgid "no configured location to store anchors"
+msgstr ""
+
+#: trust/anchor.c:388 trust/anchor.c:435
+#, c-format
+msgid "couldn't create object: %s"
+msgstr ""
+
+#: trust/anchor.c:487
+msgid "specify at least one anchor input file"
+msgstr ""
+
+#: trust/anchor.c:570
+#, c-format
+msgid "couldn't remove read-only %s"
+msgstr ""
+
+#: trust/anchor.c:573
+#, c-format
+msgid "couldn't remove %s: %s"
+msgstr ""
+
+#: trust/anchor.c:599
+msgid "at least one file or uri must be specified"
+msgstr ""
+
+#: trust/anchor.c:665
+msgid "an action was already specified"
+msgstr ""
+
+#: trust/anchor.c:702
+#, c-format
+msgid "%u error while processing"
+msgid_plural "%u errors while processing"
+msgstr[0] ""
+
+#: trust/builder.c:155
+#, c-format
+msgid "%.*s: invalid certificate extension"
+msgstr ""
+
+#: trust/builder.c:674
+#, c-format
+msgid "%.*s: invalid basic constraints certificate extension"
+msgstr ""
+
+#: trust/builder.c:676
+msgid "unknown"
+msgstr ""
+
+#: trust/builder.c:865
+msgid "missing the CKA_HASH_OF_SUBJECT_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:870
+msgid "missing the CKA_HASH_OF_ISSUER_PUBLIC_KEY attribute"
+msgstr ""
+
+#: trust/builder.c:1084
+msgid "the object is not modifiable"
+msgstr ""
+
+#: trust/builder.c:1091
+msgid "objects of this type cannot be created"
+msgstr ""
+
+#: trust/builder.c:1111
+#, c-format
+msgid "the %s attribute cannot be set"
+msgstr ""
+
+#: trust/builder.c:1116
+#, c-format
+msgid "the %s attribute cannot be changed"
+msgstr ""
+
+#: trust/builder.c:1122
+#, c-format
+msgid "the %s attribute has an invalid value"
+msgstr ""
+
+#: trust/builder.c:1131
+#, c-format
+msgid "the %s attribute is not valid for the object"
+msgstr ""
+
+#: trust/builder.c:1154
+#, c-format
+msgid "missing the %s attribute"
+msgstr ""
+
+#: trust/builder.c:1194
+msgid "no CKA_CLASS attribute found"
+msgstr ""
+
+#: trust/builder.c:1200
+#, c-format
+msgid "cannot create a %s object"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "token"
+msgstr ""
+
+#: trust/builder.c:1200
+msgid "non-token"
+msgstr ""
+
+#: trust/builder.c:1208
+#, c-format
+msgid "missing %s on object"
+msgstr ""
+
+#: trust/builder.c:1213
+#, c-format
+msgid "%s unsupported %s"
+msgstr ""
+
+#: trust/builder.c:1234
+#, c-format
+msgid "%s unsupported object class"
+msgstr ""
+
+#: trust/builder.c:1300
+msgid "invalid key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1768
+msgid "invalid extended key usage certificate extension"
+msgstr ""
+
+#: trust/builder.c:1776
+msgid "invalid reject key usage certificate extension"
+msgstr ""
+
+#: trust/dump.c:113
+msgid "could not dump object"
+msgstr ""
+
+#: trust/dump.c:187 trust/list.c:256
+msgid "extra arguments passed to command"
+msgstr ""
+
+#: trust/enumerate.c:78
+#, c-format
+msgid "couldn't parse attached certificate extension: %s"
+msgstr ""
+
+#: trust/enumerate.c:151
+#, c-format
+msgid "couldn't load attached extensions for certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:275
+#, c-format
+msgid "couldn't parse certificate: %s"
+msgstr ""
+
+#: trust/enumerate.c:312
+#, c-format
+msgid "couldn't load attributes: %s"
+msgstr ""
+
+#: trust/enumerate.c:323
+msgid "skipping non-certificate object"
+msgstr ""
+
+#: trust/enumerate.c:480 trust/enumerate.c:508
+#, c-format
+msgid "couldn't load blocklist: %s"
+msgstr ""
+
+#: trust/enumerate.c:582
+msgid "a PKCS#11 URI has already been specified"
+msgstr ""
+
+#: trust/enumerate.c:589
+#, c-format
+msgid "couldn't parse pkcs11 uri filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:594
+msgid "uri contained unrecognized components, nothing will be extracted"
+msgstr ""
+
+#: trust/enumerate.c:621
+#, c-format
+msgid "unsupported or unrecognized filter: %s"
+msgstr ""
+
+#: trust/enumerate.c:670
+#, c-format
+msgid "unsupported or unrecognized purpose: %s"
+msgstr ""
+
+#: trust/enumerate.c:712
+msgid "no modules containing trust policy are registered"
+msgstr ""
+
+#: trust/extract.c:98
+msgid "a format was already specified"
+msgstr ""
+
+#: trust/extract.c:110
+#, c-format
+msgid "unsupported or unrecognized format: %s"
+msgstr ""
+
+#.
+#. * If we're extracting *both* anchors and blocklist, then we must have
+#. * a format that can represent the different types of information.
+#.
+#: trust/extract.c:148
+msgid "format does not support trust policy"
+msgstr ""
+
+#: trust/extract.c:159
+msgid ""
+"format requires a purpose, specify it with --purpose; defaulting to 'server-"
+"auth'"
+msgstr ""
+
+#: trust/extract.c:162
+msgid "format does not support multiple purposes, defaulting to 'server-auth'"
+msgstr ""
+
+#: trust/extract.c:283
+msgid "specify one destination file or directory"
+msgstr ""
+
+#: trust/extract.c:288
+msgid "no output format specified"
+msgstr ""
+
+#. At this point we have no command
+#: trust/extract.c:333
+#, c-format
+msgid "could not run %s command"
+msgstr ""
+
+#: trust/extract-cer.c:62
+msgid "multiple certificates found but could only write one to file"
+msgstr ""
+
+#: trust/extract-cer.c:75 trust/extract-cer.c:115 trust/extract-jks.c:331
+#: trust/extract-openssl.c:369 trust/extract-openssl.c:696
+#: trust/extract-pem.c:94 trust/extract-pem.c:161
+#, c-format
+msgid "failed to find certificates: %s"
+msgstr ""
+
+#: trust/extract-cer.c:80
+msgid "no certificate found"
+msgstr ""
+
+#: trust/extract-edk2.c:192
+#, c-format
+msgid "failed to find certificate: %s"
+msgstr ""
+
+#: trust/extract-jks.c:142
+msgid "truncating long string"
+msgstr ""
+
+#: trust/extract-jks.c:272
+msgid "Environment variable $SOURCE_DATE_EPOCH: strtoull"
+msgstr ""
+
+#: trust/extract-jks.c:276
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:280
+#, c-format
+msgid "Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"
+msgstr ""
+
+#: trust/extract-jks.c:284
+#, c-format
+msgid ""
+"Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal "
+"to %lu but was found to be: %llu \n"
+msgstr ""
+
+#: trust/extract-jks.c:312
+msgid "could not generate a certificate alias name"
+msgstr ""
+
+#: trust/list.c:122
+msgid "skipping object, couldn't build uri"
+msgstr ""
+
+#: trust/module.c:303
+#, c-format
+msgid "unrecognized module argument: %s"
+msgstr ""
+
+#: trust/parser.c:109
+#, c-format
+msgid "certificate with distrust in location for anchors: %s"
+msgstr ""
+
+#: trust/parser.c:123
+#, c-format
+msgid "overriding trust for anchor in blocklist: %s"
+msgstr ""
+
+#: trust/parser.c:596
+#, c-format
+msgid "Couldn't parse PEM block of type %s"
+msgstr ""
+
+#: trust/parser.c:766
+#, c-format
+msgid "couldn't open and map file: %s"
+msgstr ""
+
+#: trust/persist.c:493
+#, c-format
+msgid "invalid oid value: %s"
+msgstr ""
+
+#: trust/save.c:124
+#, c-format
+msgid "couldn't create file: %s%s"
+msgstr ""
+
+#: trust/save.c:172
+#, c-format
+msgid "couldn't write to file: %s"
+msgstr ""
+
+#. Continue trying other names
+#: trust/save.c:209 trust/save.c:227 trust/save.c:290
+#, c-format
+msgid "couldn't complete writing of file: %s"
+msgstr ""
+
+#: trust/save.c:260
+#, c-format
+msgid "couldn't write file: %s"
+msgstr ""
+
+#: trust/save.c:266
+#, c-format
+msgid "couldn't set file permissions: %s"
+msgstr ""
+
+#: trust/save.c:272 trust/save.c:315
+#, c-format
+msgid "couldn't complete writing file: %s"
+msgstr ""
+
+#: trust/save.c:309
+#, c-format
+msgid "couldn't remove original file: %s"
+msgstr ""
+
+#: trust/save.c:355 trust/token.c:635
+#, c-format
+msgid "couldn't create directory: %s"
+msgstr ""
+
+#: trust/save.c:359
+#, c-format
+msgid "directory already exists: %s"
+msgstr ""
+
+#: trust/save.c:370
+#, c-format
+msgid "couldn't open directory: %s"
+msgstr ""
+
+#: trust/save.c:374
+#, c-format
+msgid "couldn't check directory permissions: %s"
+msgstr ""
+
+#: trust/save.c:380
+#, c-format
+msgid "couldn't make directory writable: %s"
+msgstr ""
+
+#: trust/save.c:541
+#, c-format
+msgid "couldn't create symlink: %s"
+msgstr ""
+
+#: trust/save.c:603 trust/token.c:503
+#, c-format
+msgid "couldn't remove file: %s"
+msgstr ""
+
+#: trust/save.c:631
+#, c-format
+msgid "couldn't set directory permissions: %s"
+msgstr ""
+
+#: trust/token.c:227
+#, c-format
+msgid "couldn't load file into objects: %s"
+msgstr ""
+
+#: trust/token.c:243
+#, c-format
+msgid "couldn't stat path: %d: %s"
+msgstr ""
+
+#: trust/token.c:312
+#, c-format
+msgid "cannot access trust certificate path: %s"
+msgstr ""
+
+#: trust/token.c:426
+#, c-format
+msgid "cannot access trust file: %s"
+msgstr ""
+
+#: trust/token.c:475
+#, c-format
+msgid "couldn't access: %s"
+msgstr ""
+
+#: trust/trust.c:60
+msgid "List trust or certificates"
+msgstr ""
+
+#: trust/trust.c:61
+msgid "Extract certificates and trust"
+msgstr ""
+
+#: trust/trust.c:62
+msgid "Extract trust compatibility bundles"
+msgstr ""
+
+#: trust/trust.c:63
+msgid "Add, remove, change trust anchors"
+msgstr ""
+
+#: trust/trust.c:64
+msgid "Dump trust objects in internal format"
 msgstr ""


### PR DESCRIPTION
Fixes https://github.com/p11-glue/p11-kit/issues/378

Updates translations from Transifex using Transifex client and some magic command line commands :)

Before translation update:

```
ar.po: 0 translated messages, 81 untranslated messages.
as.po: 0 translated messages, 81 untranslated messages.
ast.po: 0 translated messages, 81 untranslated messages.
az.po: 0 translated messages, 81 untranslated messages.
bg.po: 0 translated messages, 81 untranslated messages.
bn_IN.po: 0 translated messages, 81 untranslated messages.
ca.po: 81 translated messages.
ca@valencia.po: 0 translated messages, 81 untranslated messages.
cy.po: 0 translated messages, 81 untranslated messages.
cs.po: 81 translated messages.
da.po: 81 translated messages.
de.po: 81 translated messages.
el.po: 81 translated messages.
en_GB.po: 81 translated messages.
eo.po: 14 translated messages, 67 untranslated messages.
es.po: 81 translated messages.
et.po: 0 translated messages, 81 untranslated messages.
eu.po: 0 translated messages, 81 untranslated messages.
fa.po: 0 translated messages, 81 untranslated messages.
fi.po: 81 translated messages.
fo.po: 0 translated messages, 81 untranslated messages.
fr.po: 81 translated messages.
fur.po: 81 translated messages.
ga.po: 0 translated messages, 81 untranslated messages.
gl.po: 81 translated messages.
gu.po: 0 translated messages, 81 untranslated messages.
he.po: 0 translated messages, 81 untranslated messages.
hi.po: 0 translated messages, 81 untranslated messages.
hr.po: 81 translated messages.
hu.po: 81 translated messages.
ia.po: 0 translated messages, 81 untranslated messages.
id.po: 81 translated messages.
it.po: 81 translated messages.
ja.po: 81 translated messages.
ka.po: 31 translated messages, 50 untranslated messages.
kk.po: 4 translated messages, 77 untranslated messages.
kn.po: 0 translated messages, 81 untranslated messages.
ko.po: 81 translated messages.
lt.po: 0 translated messages, 81 untranslated messages.
lv.po: 80 translated messages, 1 untranslated message.
ml.po: 0 translated messages, 81 untranslated messages.
mr.po: 0 translated messages, 81 untranslated messages.
ms.po: 0 translated messages, 81 untranslated messages.
nb.po: 0 translated messages, 81 untranslated messages.
nl.po: 80 translated messages, 1 untranslated message.
nn.po: 0 translated messages, 81 untranslated messages.
oc.po: 81 translated messages.
or.po: 0 translated messages, 81 untranslated messages.
pa.po: 74 translated messages, 7 untranslated messages.
pl.po: 81 translated messages.
pt_BR.po: 81 translated messages.
pt.po: 81 translated messages.
ro.po: 0 translated messages, 81 untranslated messages.
ru.po: 81 translated messages.
sk.po: 81 translated messages.
sl.po: 81 translated messages.
sq.po: 0 translated messages, 81 untranslated messages.
sr@latin.po: 0 translated messages, 81 untranslated messages.
sr.po: 81 translated messages.
sv.po: 81 translated messages.
ta.po: 0 translated messages, 81 untranslated messages.
te.po: 0 translated messages, 81 untranslated messages.
th.po: 0 translated messages, 81 untranslated messages.
tr.po: 81 translated messages.
uk.po: 81 translated messages.
vi.po: 0 translated messages, 81 untranslated messages.
wa.po: 0 translated messages, 81 untranslated messages.
zh_CN.po: 81 translated messages.
zh_HK.po: 0 translated messages, 81 untranslated messages.
zh_TW.po: 1 translated message, 80 untranslated messages.
```

After translation update:

```
ar.po: 0 translated messages, 313 untranslated messages.
as.po: 0 translated messages, 313 untranslated messages.
ast.po: 81 translated messages, 232 untranslated messages.
az.po: 0 translated messages, 313 untranslated messages.
bg.po: 0 translated messages, 313 untranslated messages.
bn_IN.po: 0 translated messages, 313 untranslated messages.
ca.po: 81 translated messages, 232 untranslated messages.
ca@valencia.po: 0 translated messages, 313 untranslated messages.
cy.po: 0 translated messages, 313 untranslated messages.
cs.po: 81 translated messages, 232 untranslated messages.
da.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
de.po: 192 translated messages, 8 fuzzy translations, 113 untranslated messages.
el.po: 81 translated messages, 232 untranslated messages.
en_GB.po: 81 translated messages, 232 untranslated messages.
eo.po: 14 translated messages, 299 untranslated messages.
es.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
et.po: 0 translated messages, 313 untranslated messages.
eu.po: 21 translated messages, 292 untranslated messages.
fa.po: 0 translated messages, 313 untranslated messages.
fi.po: 291 translated messages, 8 fuzzy translations, 14 untranslated messages.
fo.po: 0 translated messages, 313 untranslated messages.
fr.po: 81 translated messages, 232 untranslated messages.
fur.po: 81 translated messages, 232 untranslated messages.
ga.po: 0 translated messages, 313 untranslated messages.
gl.po: 81 translated messages, 232 untranslated messages.
gu.po: 0 translated messages, 313 untranslated messages.
he.po: 0 translated messages, 313 untranslated messages.
hi.po: 0 translated messages, 313 untranslated messages.
hr.po: 127 translated messages, 3 fuzzy translations, 183 untranslated messages.
hu.po: 313 translated messages.
ia.po: 0 translated messages, 313 untranslated messages.
id.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
it.po: 81 translated messages, 232 untranslated messages.
ja.po: 81 translated messages, 232 untranslated messages.
ka.po: 56 translated messages, 2 fuzzy translations, 255 untranslated messages.
kk.po: 4 translated messages, 309 untranslated messages.
kn.po: 0 translated messages, 313 untranslated messages.
ko.po: 196 translated messages, 5 fuzzy translations, 112 untranslated messages.
lt.po: 22 translated messages, 291 untranslated messages.
lv.po: 80 translated messages, 233 untranslated messages.
ml.po: 0 translated messages, 313 untranslated messages.
mr.po: 0 translated messages, 313 untranslated messages.
ms.po: 0 translated messages, 313 untranslated messages.
nb.po: 0 translated messages, 313 untranslated messages.
nl.po: 80 translated messages, 233 untranslated messages.
nn.po: 0 translated messages, 313 untranslated messages.
oc.po: 81 translated messages, 232 untranslated messages.
or.po: 0 translated messages, 313 untranslated messages.
pa.po: 81 translated messages, 232 untranslated messages.
pl.po: 98 translated messages, 1 fuzzy translation, 214 untranslated messages.
pt_BR.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
pt.po: 81 translated messages, 232 untranslated messages.
ro.po: 0 translated messages, 313 untranslated messages.
ru.po: 81 translated messages, 232 untranslated messages.
si.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
sk.po: 81 translated messages, 232 untranslated messages.
sl.po: 81 translated messages, 232 untranslated messages.
sq.po: 0 translated messages, 313 untranslated messages.
sr@latin.po: 0 translated messages, 313 untranslated messages.
sr.po: 81 translated messages, 232 untranslated messages.
sv.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
ta.po: 0 translated messages, 313 untranslated messages.
te.po: 0 translated messages, 313 untranslated messages.
th.po: 0 translated messages, 313 untranslated messages.
tr.po: 81 translated messages, 232 untranslated messages.
uk.po: 301 translated messages, 8 fuzzy translations, 4 untranslated messages.
vi.po: 0 translated messages, 313 untranslated messages.
wa.po: 0 translated messages, 313 untranslated messages.
zh_CN.po: 86 translated messages, 1 fuzzy translation, 226 untranslated messages.
zh_HK.po: 0 translated messages, 313 untranslated messages.
zh_TW.po: 81 translated messages, 232 untranslated messages.
```