### PR TITLE
Add command to print merged configuration

### DIFF
--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -237,13 +237,17 @@ EXTRA_DIST += \
 
 bin_PROGRAMS += p11-kit/p11-kit
 
+p11_kit_p11_kit_CFLAGS = $(COMMON_CFLAGS)
+
 p11_kit_p11_kit_SOURCES = \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \
+	p11-kit/print-config.c \
 	$(NULL)
 
 p11_kit_p11_kit_LDADD = \
 	libp11-kit.la \
+	libp11-kit-internal.la \
 	libp11-tool.la \
 	libp11-common.la \
 	$(LTLIBINTL) \

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -141,14 +141,15 @@ endif
 
 p11_kit_sources = [
   'lists.c',
-  'p11-kit.c'
+  'p11-kit.c',
+  'print-config.c'
 ]
 
 executable('p11-kit',
            p11_kit_sources,
-           c_args: common_c_args,
+           c_args: common_c_args + libp11_kit_internal_c_args,
            dependencies: [libp11_tool_dep] + libffi_deps + dlopen_deps,
-           link_with: libp11_kit,
+           link_with: [libp11_kit, libp11_kit_internal],
            install: true)
 
 executable('p11-kit-remote',

--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -62,6 +62,9 @@
 int       p11_kit_list_modules    (int argc,
                                    char *argv[]);
 
+int       p11_kit_print_config    (int argc,
+                                   char *argv[]);
+
 int       p11_kit_trust           (int argc,
                                    char *argv[]);
 
@@ -70,6 +73,7 @@ int       p11_kit_external        (int argc,
 
 static const p11_tool_command commands[] = {
 	{ "list-modules", p11_kit_list_modules, N_("List modules and tokens") },
+	{ "print-config", p11_kit_print_config, N_("Print merged configuration") },
 	{ "remote", p11_kit_external, N_("Run a specific PKCS#11 module remotely") },
 	{ "server", p11_kit_external, N_("Run a server process that exposes PKCS#11 module remotely") },
 	{ P11_TOOL_FALLBACK, p11_kit_external, NULL },

--- a/p11-kit/print-config.c
+++ b/p11-kit/print-config.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2022, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include "conf.h"
+#include "debug.h"
+#include "message.h"
+#include "tool.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
+
+int
+p11_kit_print_config (int argc,
+		      char *argv[]);
+
+static int
+print_config (void)
+{
+	p11_dict *global_conf, *modules_conf;
+	p11_dictiter i, j;
+	void *key, *value;
+	int mode;
+
+	global_conf = _p11_conf_load_globals (P11_SYSTEM_CONFIG_FILE,
+					      P11_USER_CONFIG_FILE,
+					      &mode);
+	if (global_conf == NULL)
+		return 1;
+
+	modules_conf = _p11_conf_load_modules (mode,
+					       P11_PACKAGE_CONFIG_MODULES,
+					       P11_SYSTEM_CONFIG_MODULES,
+					       P11_USER_CONFIG_MODULES);
+	if (modules_conf == NULL)
+		return 1;
+
+	printf ("[global]\n");
+	p11_dict_iterate (global_conf, &i);
+	while (p11_dict_next (&i, &key, &value))
+		printf ("%s = %s\n", (char *)key, (char *)value);
+
+	p11_dict_iterate (modules_conf, &i);
+	while (p11_dict_next (&i, &key, &value)) {
+		printf ("[%s]\n", (char *)key);
+		p11_dict_iterate ((p11_dict *)value, &j);
+		while (p11_dict_next (&j, &key, &value))
+			printf ("%s = %s\n", (char *)key, (char *)value);
+	}
+
+	p11_dict_free (global_conf);
+	p11_dict_free (modules_conf);
+        return 0;
+}
+
+int
+p11_kit_print_config (int argc,
+		      char *argv[])
+{
+	int opt;
+
+	enum {
+		opt_help = 'h',
+	};
+
+	struct option options[] = {
+		{ "help", no_argument, NULL, opt_help },
+		{ 0 },
+	};
+
+	p11_tool_desc usages[] = {
+		{ 0, "usage: p11-kit print-config" },
+		{ 0 },
+	};
+
+	while ((opt = p11_tool_getopt (argc, argv, options)) != -1) {
+		switch (opt) {
+		case opt_help:
+			p11_tool_usage (usages, options);
+			return 0;
+		case '?':
+			return 2;
+		default:
+			assert_not_reached ();
+			break;
+		}
+	}
+
+	if (argc - optind != 0) {
+		p11_message (_("extra arguments specified"));
+		return 2;
+	}
+
+	return print_config ();
+}


### PR DESCRIPTION
Add an option to dump merged configuration to standard output. Currently its a draft which uses test configs as an input.

Closes #395 

Signed-off-by: Zoltan Fridrich <zfridric@redhat.com>