### PR TITLE
Fix meson/configure _Thread_local checks for C99 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,7 +148,7 @@ if test "$os_unix" = "yes"; then
 		[ac_cv_tls_keyword=
 		for keyword in _Thread_local __thread; do
 		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],
-			[[static ]$keyword[ foo;]])],
+			[[static ]$keyword[ int foo;]])],
 			[ac_cv_tls_keyword=$keyword])
 		done])
 	if test -n "$ac_cv_tls_keyword"; then

--- a/meson.build
+++ b/meson.build
@@ -200,7 +200,7 @@ if host_system != 'windows'
   tls_test_code_template = '''
 #include <stdlib.h>
 int main (void) {
-static @0@ foo;
+static @0@ int foo;
 return 0;
 }
 '''


### PR DESCRIPTION
The type was missing from the definition, which happens to work in current compilers for historic reasons.  Implicit ints were actually removed from C in 1999.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
