### PR TITLE
rpc: Fix two off-by-one errors identified by asan

### DIFF
--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -406,9 +406,15 @@ mechanism_list_purge (CK_MECHANISM_TYPE_PTR mechs,
 	for (i = 0; i < (int)(*n_mechs); ++i) {
 		if (!p11_rpc_mechanism_is_supported (mechs[i])) {
 
-			/* Remove the mechanism from the list */
-			memmove (&mechs[i], &mechs[i + 1],
-			         (*n_mechs - i) * sizeof (CK_MECHANISM_TYPE));
+			/* If this is the last mechanism, don't try to access
+			 * &mechs[i + 1], as that's undefined behavior and will trip
+			 * AddressSanitizer */
+			if (i + 1 < *n_mechs) {
+				/* Remove the mechanism from the list */
+				memmove (&mechs[i], &mechs[i + 1],
+						 (*n_mechs - i - 1) * sizeof (CK_MECHANISM_TYPE));
+			}
+
 
 			--(*n_mechs);
 			--i;


### PR DESCRIPTION
Reads after the end of the array happen when removing elements as well as if the last element was removed. Note that the new if is required because memmove() expects a size_t as length, so we must ensure that it can not be negative.

The full AddressSanitizer report is:
```
| =================================================================
| ==27174==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x616000000bb0 at pc 0x00010f8b618d bp 0x7ff7b0b5c3c0 sp 0x7ff7b0b5bb80 | READ of size 560 at 0x616000000bb0 thread T0
|     #0 0x10f8b618c in wrap_memcpy+0x16c (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1f18c)
|     #1 0x111a9bac5 in rpc_C_GetMechanismList+0x18c (p11-kit-client.so:x86_64+0x18ac5)
|     #2 0x111823534 in p11prov_GetMechanismList interface.gen.c:138
|     #3 0x11184e404 in get_slot_mechanisms session.c:113
|     #4 0x11184c3ba in p11prov_init_slots session.c:226
|     #5 0x111843fed in p11prov_module_init provider.c:1035
|     #6 0x1118417a9 in OSSL_provider_init provider.c:1102
|     #7 0x11080ee97 in provider_activate+0x117 (libcrypto.3.dylib:x86_64+0x12be97)
|     #8 0x11080eced in ossl_provider_activate+0x42 (libcrypto.3.dylib:x86_64+0x12bced)
|     #9 0x11080db4a in provider_conf_init+0x2a2 (libcrypto.3.dylib:x86_64+0x12ab4a)
|     #10 0x11075ae36 in CONF_modules_load+0x37b (libcrypto.3.dylib:x86_64+0x77e36)
|     #11 0x11075b0c9 in CONF_modules_load_file_ex+0x78 (libcrypto.3.dylib:x86_64+0x780c9)
|     #12 0x11075b899 in ossl_config_int+0x36 (libcrypto.3.dylib:x86_64+0x78899)
|     #13 0x110806ac9 in ossl_init_config_ossl_+0xa (libcrypto.3.dylib:x86_64+0x123ac9)
|     #14 0x7ff818b4acc4 in __pthread_once_handler+0x40 (libsystem_pthread.dylib:x86_64+0x2cc4)
|     #15 0x7ff818b61725 in _os_once_callout+0x11 (libsystem_platform.dylib:x86_64+0x1725)
|     #16 0x7ff818b4ac72 in pthread_once+0x49 (libsystem_pthread.dylib:x86_64+0x2c72)
|     #17 0x11081126c in CRYPTO_THREAD_run_once+0x8 (libcrypto.3.dylib:x86_64+0x12e26c)
|     #18 0x11080691d in OPENSSL_init_crypto+0x446 (libcrypto.3.dylib:x86_64+0x12391d)
|     #19 0x10f6032dc in OPENSSL_init_ssl+0x79 (libssl.3.dylib:x86_64+0x102dc)
|     #20 0x10f3c6287 in main+0x62 (openssl:x86_64+0x100024287)
|     #21 0x115f5252d in start+0x1cd (dyld:x86_64+0x552d)
|
| 0x616000000bb0 is located 0 bytes to the right of 560-byte region [0x616000000980,0x616000000bb0)
| allocated by thread T0 here:
|     #0 0x10f8e1ed0 in wrap_malloc+0xa0 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4aed0)
|     #1 0x111f1432f in CRYPTO_malloc+0x8f (libcrypto.3.dylib:x86_64+0x16332f)
|     #2 0x11184e1a8 in get_slot_mechanisms session.c:107
|     #3 0x11184c3ba in p11prov_init_slots session.c:226
|     #4 0x111843fed in p11prov_module_init provider.c:1035
|     #5 0x1118417a9 in OSSL_provider_init provider.c:1102
|     #6 0x11080ee97 in provider_activate+0x117 (libcrypto.3.dylib:x86_64+0x12be97)
|     #7 0x11080eced in ossl_provider_activate+0x42 (libcrypto.3.dylib:x86_64+0x12bced)
|     #8 0x11080db4a in provider_conf_init+0x2a2 (libcrypto.3.dylib:x86_64+0x12ab4a)
|     #9 0x11075ae36 in CONF_modules_load+0x37b (libcrypto.3.dylib:x86_64+0x77e36)
|     #10 0x11075b0c9 in CONF_modules_load_file_ex+0x78 (libcrypto.3.dylib:x86_64+0x780c9)
|     #11 0x11075b899 in ossl_config_int+0x36 (libcrypto.3.dylib:x86_64+0x78899)
|     #12 0x110806ac9 in ossl_init_config_ossl_+0xa (libcrypto.3.dylib:x86_64+0x123ac9)
|     #13 0x7ff818b4acc4 in __pthread_once_handler+0x40 (libsystem_pthread.dylib:x86_64+0x2cc4)
|     #14 0x7ff818b61725 in _os_once_callout+0x11 (libsystem_platform.dylib:x86_64+0x1725)
|     #15 0x7ff818b4ac72 in pthread_once+0x49 (libsystem_pthread.dylib:x86_64+0x2c72)
|     #16 0x11081126c in CRYPTO_THREAD_run_once+0x8 (libcrypto.3.dylib:x86_64+0x12e26c)
|     #17 0x11080691d in OPENSSL_init_crypto+0x446 (libcrypto.3.dylib:x86_64+0x12391d)
|     #18 0x10f6032dc in OPENSSL_init_ssl+0x79 (libssl.3.dylib:x86_64+0x102dc)
|     #19 0x10f3c6287 in main+0x62 (openssl:x86_64+0x100024287)
|     #20 0x115f5252d in start+0x1cd (dyld:x86_64+0x552d)
|
| SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1f18c) in wrap_memcpy+0x16c
| Shadow bytes around the buggy address:
|   0x1c2c00000120: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
|   0x1c2c00000130: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
|   0x1c2c00000140: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
|   0x1c2c00000150: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
|   0x1c2c00000160: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
| =>0x1c2c00000170: 00 00 00 00 00 00[fa]fa fa fa fa fa fa fa fa fa
|   0x1c2c00000180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
|   0x1c2c00000190: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
|   0x1c2c000001a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
|   0x1c2c000001b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
|   0x1c2c000001c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
| Shadow byte legend (one shadow byte represents 8 application bytes):
|   Addressable:           00
|   Partially addressable: 01 02 03 04 05 06 07
|   Heap left redzone:       fa
|   Freed heap region:       fd
|   Stack left redzone:      f1
|   Stack mid redzone:       f2
|   Stack right redzone:     f3
|   Stack after return:      f5
|   Stack use after scope:   f8
|   Global redzone:          f9
|   Global init order:       f6
|   Poisoned by user:        f7
|   Container overflow:      fc
|   Array cookie:            ac
|   Intra object redzone:    bb
|   ASan internal:           fe
|   Left alloca redzone:     ca
|   Right alloca redzone:    cb
| ==27174==ABORTING
| Abort trap: 6
```

Signed-off-by: Clemens Lang <cllang@redhat.com>