### PR TITLE
test-modules: Remove duplicate test

### DIFF
--- a/common/pkcs11.h
+++ b/common/pkcs11.h
@@ -1118,7 +1118,7 @@ _CK_DECLARE_FUNCTION (C_SetOperationState,
 		       unsigned char *operation_state,
 		       unsigned long operation_state_len,
 		       ck_object_handle_t encryption_key,
-		       ck_object_handle_t authentiation_key));
+		       ck_object_handle_t authentication_key));
 _CK_DECLARE_FUNCTION (C_Login,
 		      (ck_session_handle_t session, ck_user_type_t user_type,
 		       unsigned char *pin, unsigned long pin_len));

--- a/p11-kit/test-modules.c
+++ b/p11-kit/test-modules.c
@@ -99,41 +99,6 @@ test_no_duplicates (void)
 	finalize_and_free_modules (modules);
 }
 
-static void
-test_exceed_max (void)
-{
-	CK_FUNCTION_LIST_PTR_PTR modules;
-	p11_dict *paths;
-	p11_dict *funcs;
-	char *path;
-	int i;
-
-	modules = initialize_and_get_modules ();
-	paths = p11_dict_new (p11_dict_str_hash, p11_dict_str_equal, NULL, NULL);
-	funcs = p11_dict_new (p11_dict_direct_hash, p11_dict_direct_equal, NULL, NULL);
-
-	/* The loaded modules should not contain duplicates */
-	for (i = 0; modules[i] != NULL; i++) {
-		path = p11_kit_config_option (modules[i], "module");
-
-		if (p11_dict_get (funcs, modules[i]))
-			assert_fail ("found duplicate function list pointer", NULL);
-		if (p11_dict_get (paths, path))
-			assert_fail ("found duplicate path name", NULL);
-
-		if (!p11_dict_set (funcs, modules[i], ""))
-			assert_not_reached ();
-		if (!p11_dict_set (paths, path, ""))
-			assert_not_reached ();
-
-		free (path);
-	}
-
-	p11_dict_free (paths);
-	p11_dict_free (funcs);
-	finalize_and_free_modules (modules);
-}
-
 static CK_FUNCTION_LIST_PTR
 lookup_module_with_name (CK_FUNCTION_LIST_PTR_PTR modules,
                          const char *name)
@@ -498,7 +463,6 @@ main (int argc,
 
 	p11_test (test_filename, "/modules/test_filename");
 	p11_test (test_no_duplicates, "/modules/test_no_duplicates");
-	p11_test (test_exceed_max, "/modules/test_exceed_max");
 	p11_test (test_disable, "/modules/test_disable");
 	p11_test (test_disable_later, "/modules/test_disable_later");
 	p11_test (test_enable, "/modules/test_enable");


### PR DESCRIPTION
test_exceed_max is a duplicate of test_no_duplicates.
This was introduced as part of https://github.com/p11-glue/p11-kit/commit/c01b59e5594b395cf084068e513a68f63c9b95a4 (Check exhaustion of fixed
closures ) which looks like it did not test the original issue.