### PR TITLE
rpc-server: Check pointer value returned by proto_read_byte_array

### DIFF
--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -720,7 +720,8 @@ rpc_C_Initialize (CK_X_FUNCTION_LIST *self,
 	if (ret == CKR_OK) {
 
 		/* Check to make sure the header matches */
-		if (n_handshake != P11_RPC_HANDSHAKE_LEN ||
+		if (!handshake ||
+		    n_handshake != P11_RPC_HANDSHAKE_LEN ||
 		    memcmp (handshake, P11_RPC_HANDSHAKE, n_handshake) != 0) {
 			p11_message (_("invalid handshake received from connecting module"));
 			ret = CKR_GENERAL_ERROR;


### PR DESCRIPTION
The commit b58b725f30ea833ce8ff08879f616b32be44cbdb added a case where proto_read_byte_array may return non-zero length while the pointer location is set to NULL.  This is to accommodate the change in rpc_C_Initialize.

Spotted by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56504