### PR TITLE
Add CodeQL workflow for GitHub code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "12 13 * * 4"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ cpp ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Install dependencies
+        run: sudo apt-get install -y meson
+
+      - name: Build
+        run: |
+          meson setup -Dstrict=true _build
+          meson compile -C _build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # p11-kit
 
-[![GitHub Build Status](https://github.com/p11-glue/p11-kit/workflows/test/badge.svg)](https://github.com/p11-glue/p11-kit/actions?query=workflow%3Atest) [![Coverage Status](https://img.shields.io/coveralls/p11-glue/p11-kit.svg)](https://coveralls.io/r/p11-glue/p11-kit) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1627/badge)](https://bestpractices.coreinfrastructure.org/en/projects/1627) [![Total alerts](https://img.shields.io/lgtm/alerts/g/p11-glue/p11-kit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/p11-glue/p11-kit/alerts/) [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/p11-glue/p11-kit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/p11-glue/p11-kit/context:cpp)
+[![GitHub Build Status](https://github.com/p11-glue/p11-kit/workflows/test/badge.svg)](https://github.com/p11-glue/p11-kit/actions?query=workflow%3Atest) [![Coverage Status](https://img.shields.io/coveralls/p11-glue/p11-kit.svg)](https://coveralls.io/r/p11-glue/p11-kit) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1627/badge)](https://bestpractices.coreinfrastructure.org/en/projects/1627)
 
 p11-kit aims to solve problems with coordinating the use of [PKCS #11]
 by different components or libraries living in the same process, by
@@ -18,7 +18,7 @@ way that they're discoverable.
 To build and install p11-kit, you can use the following commands:
 
 ```console
-$ meson _build
+$ meson setup _build
 $ meson compile -C _build
 $ meson test -C _build
 # meson install -C _build


### PR DESCRIPTION
This is based on the template except that it uses Meson explicitly instead of the autobuild action.

Supersedes: #449
Modified-by: Daiki Ueno <dueno@redhat.com>