### PR TITLE
Add PKCS#11 3.0 support to log

### DIFF
--- a/p11-kit/log.c
+++ b/p11-kit/log.c
@@ -1932,6 +1932,408 @@ log_C_GenerateRandom (CK_X_FUNCTION_LIST *self,
 	DONE_CALL
 }
 
+static CK_RV
+log_C_LoginUser (CK_X_FUNCTION_LIST *self,
+                 CK_SESSION_HANDLE session,
+                 CK_USER_TYPE user_type,
+                 CK_UTF8CHAR_PTR pin,
+                 CK_ULONG pin_len,
+                 CK_UTF8CHAR_PTR username,
+                 CK_ULONG username_len)
+{
+	BEGIN_CALL (LoginUser)
+		IN_SESSION (session)
+		IN_USER_TYPE (user_type)
+		IN_BYTE_ARRAY (pin, pin_len)
+		IN_BYTE_ARRAY (username, username_len)
+	PROCESS_CALL ((self, session, user_type, pin, pin_len, username, username_len))
+
+	DONE_CALL
+}
+
+static CK_RV
+log_C_SessionCancel (CK_X_FUNCTION_LIST *self,
+                     CK_SESSION_HANDLE session,
+                     CK_FLAGS flags)
+{
+	char temp[32];
+	int had = 0;
+
+	BEGIN_CALL (SessionCancel)
+		IN_SESSION (session)
+		p11_buffer_add (&_buf, "  IN: flags = ", -1);
+		snprintf (temp, sizeof (temp), "%lu", flags);
+		p11_buffer_add (&_buf, temp, -1);
+		LOG_FLAG (&_buf, flags, had, CKF_MESSAGE_ENCRYPT);
+		LOG_FLAG (&_buf, flags, had, CKF_MESSAGE_DECRYPT);
+		LOG_FLAG (&_buf, flags, had, CKF_MESSAGE_SIGN);
+		LOG_FLAG (&_buf, flags, had, CKF_MESSAGE_VERIFY);
+		LOG_FLAG (&_buf, flags, had, CKF_FIND_OBJECTS);
+		LOG_FLAG (&_buf, flags, had, CKF_ENCRYPT);
+		LOG_FLAG (&_buf, flags, had, CKF_DECRYPT);
+		LOG_FLAG (&_buf, flags, had, CKF_DIGEST);
+		LOG_FLAG (&_buf, flags, had, CKF_SIGN);
+		LOG_FLAG (&_buf, flags, had, CKF_SIGN_RECOVER);
+		LOG_FLAG (&_buf, flags, had, CKF_VERIFY);
+		LOG_FLAG (&_buf, flags, had, CKF_VERIFY_RECOVER);
+		LOG_FLAG (&_buf, flags, had, CKF_GENERATE);
+		LOG_FLAG (&_buf, flags, had, CKF_GENERATE_KEY_PAIR);
+		LOG_FLAG (&_buf, flags, had, CKF_WRAP);
+		LOG_FLAG (&_buf, flags, had, CKF_UNWRAP);
+		LOG_FLAG (&_buf, flags, had, CKF_DERIVE);
+		p11_buffer_add (&_buf, "\n", 1);
+	PROCESS_CALL ((self, session, flags))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageEncryptInit (CK_X_FUNCTION_LIST *self,
+                          CK_SESSION_HANDLE session,
+                          CK_MECHANISM_PTR mechanism,
+                          CK_OBJECT_HANDLE key)
+{
+	BEGIN_CALL (MessageEncryptInit)
+		IN_SESSION (session)
+		IN_MECHANISM (mechanism)
+		IN_HANDLE (key)
+	PROCESS_CALL ((self, session, mechanism, key))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_EncryptMessage (CK_X_FUNCTION_LIST *self,
+                      CK_SESSION_HANDLE session,
+                      CK_VOID_PTR parameter,
+                      CK_ULONG parameter_len,
+                      CK_BYTE_PTR associated_data,
+                      CK_ULONG associated_data_len,
+                      CK_BYTE_PTR plaintext,
+                      CK_ULONG plaintext_len,
+                      CK_BYTE_PTR ciphertext,
+                      CK_ULONG_PTR ciphertext_len)
+{
+	BEGIN_CALL (EncryptMessage)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (associated_data, associated_data_len)
+		IN_BYTE_ARRAY (plaintext, plaintext_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, associated_data, associated_data_len,
+	               plaintext, plaintext_len, ciphertext, ciphertext_len))
+		OUT_BYTE_ARRAY (ciphertext, ciphertext_len)
+	DONE_CALL
+}
+
+static CK_RV
+log_C_EncryptMessageBegin (CK_X_FUNCTION_LIST *self,
+                           CK_SESSION_HANDLE session,
+                           CK_VOID_PTR parameter,
+                           CK_ULONG parameter_len,
+                           CK_BYTE_PTR associated_data,
+                           CK_ULONG associated_data_len)
+{
+	BEGIN_CALL (EncryptMessageBegin)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (associated_data, associated_data_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, associated_data, associated_data_len))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_EncryptMessageNext (CK_X_FUNCTION_LIST *self,
+                          CK_SESSION_HANDLE session,
+                          CK_VOID_PTR parameter,
+                          CK_ULONG parameter_len,
+                          CK_BYTE_PTR plaintext_part,
+                          CK_ULONG plaintext_part_len,
+                          CK_BYTE_PTR ciphertext_part,
+                          CK_ULONG_PTR ciphertext_part_len,
+                          CK_FLAGS flags)
+{
+	char temp[32];
+	int had = 0;
+
+	BEGIN_CALL (EncryptMessageNext)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (plaintext_part, plaintext_part_len)
+		p11_buffer_add (&_buf, "  IN: flags = ", -1);
+		snprintf (temp, sizeof (temp), "%lu", flags);
+		p11_buffer_add (&_buf, temp, -1);
+		LOG_FLAG (&_buf, flags, had, CKF_END_OF_MESSAGE);
+		p11_buffer_add (&_buf, "\n", 1);
+	PROCESS_CALL ((self, session, parameter, parameter_len, plaintext_part, plaintext_part_len,
+	               ciphertext_part, ciphertext_part_len, flags))
+		OUT_BYTE_ARRAY (ciphertext_part, ciphertext_part_len)
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageEncryptFinal (CK_X_FUNCTION_LIST *self,
+                           CK_SESSION_HANDLE session)
+{
+	BEGIN_CALL (MessageEncryptFinal)
+		IN_SESSION (session)
+	PROCESS_CALL ((self, session))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageDecryptInit (CK_X_FUNCTION_LIST *self,
+                          CK_SESSION_HANDLE session,
+                          CK_MECHANISM_PTR mechanism,
+                          CK_OBJECT_HANDLE key)
+{
+	BEGIN_CALL (MessageDecryptInit)
+		IN_SESSION (session)
+		IN_MECHANISM (mechanism)
+		IN_HANDLE (key)
+	PROCESS_CALL ((self, session, mechanism, key))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_DecryptMessage (CK_X_FUNCTION_LIST *self,
+                      CK_SESSION_HANDLE session,
+                      CK_VOID_PTR parameter,
+                      CK_ULONG parameter_len,
+                      CK_BYTE_PTR associated_data,
+                      CK_ULONG associated_data_len,
+                      CK_BYTE_PTR ciphertext,
+                      CK_ULONG ciphertext_len,
+                      CK_BYTE_PTR plaintext,
+                      CK_ULONG_PTR plaintext_len)
+{
+	BEGIN_CALL (DecryptMessage)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (associated_data, associated_data_len)
+		IN_BYTE_ARRAY (ciphertext, ciphertext_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, associated_data, associated_data_len,
+	               ciphertext, ciphertext_len, plaintext, plaintext_len));
+		OUT_BYTE_ARRAY (plaintext, plaintext_len)
+	DONE_CALL
+}
+
+static CK_RV
+log_C_DecryptMessageBegin (CK_X_FUNCTION_LIST *self,
+                           CK_SESSION_HANDLE session,
+                           CK_VOID_PTR parameter,
+                           CK_ULONG parameter_len,
+                           CK_BYTE_PTR associated_data,
+                           CK_ULONG associated_data_len)
+{
+	BEGIN_CALL (DecryptMessageBegin)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (associated_data, associated_data_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, associated_data, associated_data_len))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_DecryptMessageNext (CK_X_FUNCTION_LIST *self,
+                          CK_SESSION_HANDLE session,
+                          CK_VOID_PTR parameter,
+                          CK_ULONG parameter_len,
+                          CK_BYTE_PTR ciphertext_part,
+                          CK_ULONG ciphertext_part_len,
+                          CK_BYTE_PTR plaintext_part,
+                          CK_ULONG_PTR plaintext_part_len,
+                          CK_FLAGS flags)
+{
+	char temp[32];
+	int had = 0;
+
+	BEGIN_CALL (DecryptMessageNext)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (ciphertext_part, ciphertext_part_len)
+		p11_buffer_add (&_buf, "  IN: flags = ", -1);
+		snprintf (temp, sizeof (temp), "%lu", flags);
+		p11_buffer_add (&_buf, temp, -1);
+		LOG_FLAG (&_buf, flags, had, CKF_END_OF_MESSAGE);
+		p11_buffer_add (&_buf, "\n", 1);
+	PROCESS_CALL ((self, session, parameter, parameter_len, ciphertext_part, ciphertext_part_len,
+	               plaintext_part, plaintext_part_len, flags))
+		OUT_BYTE_ARRAY (plaintext_part, plaintext_part_len)
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageDecryptFinal (CK_X_FUNCTION_LIST *self,
+                           CK_SESSION_HANDLE session)
+{
+	BEGIN_CALL (MessageDecryptFinal)
+		IN_SESSION (session)
+	PROCESS_CALL ((self, session))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageSignInit (CK_X_FUNCTION_LIST *self,
+                       CK_SESSION_HANDLE session,
+                       CK_MECHANISM_PTR mechanism,
+                       CK_OBJECT_HANDLE key)
+{
+	BEGIN_CALL (MessageSignInit)
+		IN_SESSION (session)
+		IN_MECHANISM (mechanism)
+		IN_HANDLE (key)
+	PROCESS_CALL ((self, session, mechanism, key))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_SignMessage (CK_X_FUNCTION_LIST *self,
+                   CK_SESSION_HANDLE session,
+                   CK_VOID_PTR parameter,
+                   CK_ULONG parameter_len,
+                   CK_BYTE_PTR data,
+                   CK_ULONG data_len,
+                   CK_BYTE_PTR signature,
+                   CK_ULONG_PTR signature_len)
+{
+	BEGIN_CALL (SignMessage)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (data, data_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, data, data_len, signature, signature_len))
+		OUT_BYTE_ARRAY (signature, signature_len)
+	DONE_CALL
+}
+
+static CK_RV
+log_C_SignMessageBegin (CK_X_FUNCTION_LIST *self,
+                        CK_SESSION_HANDLE session,
+                        CK_VOID_PTR parameter,
+                        CK_ULONG parameter_len)
+{
+	BEGIN_CALL (SignMessageBegin)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_SignMessageNext (CK_X_FUNCTION_LIST *self,
+                       CK_SESSION_HANDLE session,
+                       CK_VOID_PTR parameter,
+                       CK_ULONG parameter_len,
+                       CK_BYTE_PTR data,
+                       CK_ULONG data_len,
+                       CK_BYTE_PTR signature,
+                       CK_ULONG_PTR signature_len)
+{
+	BEGIN_CALL (SignMessageNext)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (data, data_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, data, data_len, signature, signature_len))
+		OUT_BYTE_ARRAY (signature, signature_len)
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageSignFinal (CK_X_FUNCTION_LIST *self,
+                        CK_SESSION_HANDLE session)
+{
+	BEGIN_CALL (MessageSignFinal)
+		IN_SESSION (session)
+	PROCESS_CALL ((self, session))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageVerifyInit (CK_X_FUNCTION_LIST *self,
+                         CK_SESSION_HANDLE session,
+                         CK_MECHANISM_PTR mechanism,
+                         CK_OBJECT_HANDLE key)
+{
+	BEGIN_CALL (MessageVerifyInit)
+		IN_SESSION (session)
+		IN_MECHANISM (mechanism)
+		IN_HANDLE (key)
+	PROCESS_CALL ((self, session, mechanism, key))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_VerifyMessage (CK_X_FUNCTION_LIST *self,
+                     CK_SESSION_HANDLE session,
+                     CK_VOID_PTR parameter,
+                     CK_ULONG parameter_len,
+                     CK_BYTE_PTR data,
+                     CK_ULONG data_len,
+                     CK_BYTE_PTR signature,
+                     CK_ULONG signature_len)
+{
+	BEGIN_CALL (VerifyMessage)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (data, data_len)
+		IN_BYTE_ARRAY (signature, signature_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, data, data_len,
+	               signature, signature_len))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_VerifyMessageBegin (CK_X_FUNCTION_LIST *self,
+                          CK_SESSION_HANDLE session,
+                          CK_VOID_PTR parameter,
+                          CK_ULONG parameter_len)
+{
+	BEGIN_CALL (VerifyMessageBegin)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_VerifyMessageNext (CK_X_FUNCTION_LIST *self,
+                         CK_SESSION_HANDLE session,
+                         CK_VOID_PTR parameter,
+                         CK_ULONG parameter_len,
+                         CK_BYTE_PTR data,
+                         CK_ULONG data_len,
+                         CK_BYTE_PTR signature,
+                         CK_ULONG signature_len)
+{
+	BEGIN_CALL (VerifyMessageNext)
+		IN_SESSION (session)
+		IN_POINTER (parameter)
+		IN_ULONG (parameter_len)
+		IN_BYTE_ARRAY (data, data_len)
+		IN_BYTE_ARRAY (signature, signature_len)
+	PROCESS_CALL ((self, session, parameter, parameter_len, data, data_len,
+	               signature, signature_len))
+	DONE_CALL
+}
+
+static CK_RV
+log_C_MessageVerifyFinal (CK_X_FUNCTION_LIST *self,
+                          CK_SESSION_HANDLE session)
+{
+	BEGIN_CALL (MessageVerifyFinal)
+		IN_SESSION (session)
+	PROCESS_CALL ((self, session))
+	DONE_CALL
+}
+
 static CK_X_FUNCTION_LIST log_functions = {
 	{ -1, -1 },
 	log_C_Initialize,
@@ -1999,6 +2401,29 @@ static CK_X_FUNCTION_LIST log_functions = {
 	log_C_SeedRandom,
 	log_C_GenerateRandom,
 	log_C_WaitForSlotEvent,
+	/* PKCS #11 3.0 */
+	log_C_LoginUser,
+	log_C_SessionCancel,
+	log_C_MessageEncryptInit,
+	log_C_EncryptMessage,
+	log_C_EncryptMessageBegin,
+	log_C_EncryptMessageNext,
+	log_C_MessageEncryptFinal,
+	log_C_MessageDecryptInit,
+	log_C_DecryptMessage,
+	log_C_DecryptMessageBegin,
+	log_C_DecryptMessageNext,
+	log_C_MessageDecryptFinal,
+	log_C_MessageSignInit,
+	log_C_SignMessage,
+	log_C_SignMessageBegin,
+	log_C_SignMessageNext,
+	log_C_MessageSignFinal,
+	log_C_MessageVerifyInit,
+	log_C_VerifyMessage,
+	log_C_VerifyMessageBegin,
+	log_C_VerifyMessageNext,
+	log_C_MessageVerifyFinal
 };
 
 void


### PR DESCRIPTION
Expands p11-kit/log.c with pkcs#11 3.0 functions.