### PR TITLE
trust: Use the same parser code for parsing and checking

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -941,6 +941,16 @@ strerror_r (int errnum,
 
 #endif /* HAVE_STRERROR_R */
 
+#ifndef HAVE_ISATTY
+
+int
+isatty (int fd)
+{
+	return 0;
+}
+
+#endif /* HAVE_ISATTY */
+
 void
 p11_dl_close (void *dl)
 {

--- a/common/compat.h
+++ b/common/compat.h
@@ -379,6 +379,16 @@ int        fdwalk           (int (* cb) (void *data, int fd),
 
 #endif
 
+#ifdef HAVE_ISATTY
+
+#include <unistd.h>
+
+#else
+
+int        isatty           (int fd);
+
+#endif /* HAVE_ISATTY */
+
 /* If either locale_t or newlocale() is not available, strerror_l()
  * cannot be used */
 #if !defined(HAVE_LOCALE_T) || !defined(HAVE_NEWLOCALE)

--- a/common/lexer.h
+++ b/common/lexer.h
@@ -39,20 +39,21 @@
 
 #include "compat.h"
 
-enum {
-	TOK_EOF = 0,
-	TOK_SECTION = 1,
+typedef enum _p11_lexer_token_type {
+	TOK_EOF,
+	TOK_SECTION,
 	TOK_FIELD,
 	TOK_PEM,
-};
+} p11_lexer_token_type;
 
 typedef struct {
 	char *filename;
+	size_t line;
 	const char *at;
-	int remaining;
-	int complained;
+	size_t remaining;
+	bool complained;
 
-	int tok_type;
+	p11_lexer_token_type tok_type;
 	union {
 		struct {
 			char *name;

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,7 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([getpeereid])
 	AC_CHECK_FUNCS([getpeerucred])
 	AC_CHECK_FUNCS([issetugid])
+	AC_CHECK_FUNCS([isatty])
 
 	AC_CACHE_CHECK([for thread-local storage class],
 		[ac_cv_tls_keyword],

--- a/meson.build
+++ b/meson.build
@@ -180,6 +180,7 @@ if host_system != 'windows'
     'getpeerucred',
     'getprogname',
     'getresuid',
+    'isatty',
     'issetugid',
     'mkdtemp',
     'mkstemp',

--- a/trust/check-format.c
+++ b/trust/check-format.c
@@ -47,7 +47,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #ifdef ENABLE_NLS
 #include <libintl.h>

--- a/trust/check-format.c
+++ b/trust/check-format.c
@@ -39,14 +39,14 @@
 #include "check-format.h"
 #include "debug.h"
 #include "message.h"
+#include "persist.h"
 #include "tool.h"
 
 #include <assert.h>
-#include <ctype.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #ifdef ENABLE_NLS
@@ -56,20 +56,12 @@
 #define _(x) (x)
 #endif
 
-#define IS_BASE64(C) (isalnum ((int)(C)) || (C) == '+' || (C) == '/')
-#define PEM_LABEL_MAX 256
-
 enum format_result {
 	FORMAT_OK,
 	FORMAT_FAIL,
 	FORMAT_ERROR
 };
 
-static char pem_label[PEM_LABEL_MAX];
-static int pem_label_length;
-static int inside_pem;
-static int inside_section;
-static size_t line_num;
 static bool color_out;
 static bool color_err;
 
@@ -89,366 +81,45 @@ print_result (enum format_result result,
 		printf (color_out ? "\033[1;31mERROR\033[0m\n" : "ERROR\n");
 		break;
 	default:
-	    assert_not_reached ();
-	    break;
-	}
-}
-
-static inline void
-fail (const char *msg)
-{
-	fprintf (stderr, color_err ? "\033[31mFailed\033[0m at line %lu: %s\n" :
-				     "Failed at line %lu: %s\n", line_num, msg);
-}
-
-static bool
-get_line (FILE *stream,
-	  char **line)
-{
-	char *buffer, *tmp;
-	int c, count, alloc_size;
-
-	count = 0;
-	alloc_size = 50;
-
-	buffer = malloc (alloc_size);
-	if (buffer == NULL) {
-		p11_message (_("failed to allocate memory"));
-		*line = NULL;
-		return false;
-	}
-
-	while ((c = getc (stream)) != EOF && c != '\n') {
-		if (count + 1 >= alloc_size) {
-			alloc_size *= 2;
-			tmp = realloc (buffer, alloc_size);
-			if (tmp == NULL) {
-				free (buffer);
-				p11_message (_("failed to allocate memory"));
-				*line = NULL;
-				return false;
-			}
-			buffer = tmp;
-		}
-		buffer[count++] = (char)c;
-	}
-
-	if (c == EOF) {
-		free (buffer);
-		*line = NULL;
-		return true;
-	}
-
-	buffer[count] = '\0';
-	*line = buffer;
-	return true;
-}
-
-/* Format is based on https://www.rfc-editor.org/rfc/rfc7468#section-3
- *
- * stricttextualmsg = preeb eol
- *                    strictbase64text
- *                    posteb eol
- * preeb            = "-----BEGIN " label "-----"
- * posteb           = "-----END " label "-----"
- * strictbase64text = *base64fullline strictbase64finl
- * base64fullline   = 64base64char eol
- * strictbase64finl = *15(4base64char) (4base64char / 3base64char base64pad / 2base64char 2base64pad) eol
- */
-static bool
-parse_pem (const char *line)
-{
-	const char *end;
-	size_t line_len;
-	int i;
-
-	switch (inside_pem) {
-	case 0: {
-		/* check whether line starts a new PEM block */
-		if (strncmp (line, "-----BEGIN ", 11) != 0)
-			return false;
-		line += 11;
-
-		/* start a new PEM block */
-		inside_pem = 1;
-
-		/* check the end of the BEGIN block */
-		end = line + strlen (line) - 5;
-		if (strncmp (end, "-----", 5) != 0) {
-			fail (_("couldn't find \"-----\" at the end of the BEGIN block"));
-			return false;
-		}
-
-		/* if label is not empty, it cannot start with '-' */
-		if (line != end && *line == '-') {
-			fail (_("label cannot start with \'-\'"));
-			return false;
-		}
-
-		/* check the label */
-		pem_label_length = end - line;
-		if (pem_label_length >= PEM_LABEL_MAX) {
-			fail (_("label is too long"));
-			return false;
-		}
-
-		for (i = 0; i < pem_label_length; ++i, ++line) {
-			if (!isprint (*line)) {
-				fail (_("label contains non-printable characters"));
-				return false;
-			}
-			pem_label[i] = *line;
-		}
-		pem_label[pem_label_length] = '\0';
-		break;
-	}
-	case 1:
-		/* there has to be at least one base64 line */
-		if (*line == '-') {
-			fail (_("base64 text is empty"));
-			return false;
-		}
-		inside_pem = 2;
-		/* fall-through */
-	case 2: {
-		/* if we reached the end of base64 text, parse the END block */
-		if (*line == '-')
-			goto end_pem;
-
-		line_len = strlen (line);
-
-		if (line_len == 0 || line_len > 64 || line_len % 4 != 0) {
-			fail (_("base64 line length must be multiple of 4 and within <4, 64> characters"));
-			return false;
-		}
-
-		/* check for the padding */
-		if (line[line_len - 1] == '=')
-			line_len = line[line_len - 2] == '=' ? line_len - 2 : line_len - 1;
-
-		/* check the base64 text */
-		for (i = 0; i < line_len; ++i) {
-			if (!IS_BASE64 (line[i])) {
-				fail (_("base64 line must contain only alpha-numeric, '+' and '/' characters"));
-				return false;
-			}
-		}
-
-		/* if there were less then 64 characters then its the final base64 line */
-		if (line_len < 64)
-			inside_pem = 3;
-
-		break;
-	}
-	case 3: {
-	end_pem:
-		/* check whether line starts with the END block */
-		if (strncmp (line, "-----END ", 9) != 0) {
-			fail (_("start of the END block expected but not found"));
-			return false;
-		}
-		line += 9;
-
-		/* label must match with the label in the BEGIN block */
-		if (strncmp (line, pem_label, pem_label_length) != 0) {
-			fail (_("label in the END block does not match the label in the BEGIN block"));
-			return false;
-		}
-		line += pem_label_length;
-
-		/* check the end of the END block */
-		if (strncmp (line, "-----", 5) != 0) {
-			fail (_("couldn't find \"-----\" at the end of the END block"));
-			return false;
-		}
-		line += 5;
-
-		/* only EOL is allowed */
-		if (*line != '\0') {
-			fail (_("characters found after the END block"));
-			return false;
-		}
-
-		/* end of the PEM block */
-		inside_pem = 0;
-		break;
-	}
-	default:
 		assert_not_reached ();
-		return false;
+		break;
 	}
-
-	return true;
-}
-
-static bool
-parse_section_header (const char *line)
-{
-	size_t i, line_len;
-
-	/* check the opening bracket */
-	if (line[0] != '[') {
-		fail (_("section header does not start with '['"));
-		return false;
-	}
-
-	line_len = strlen (line);
-
-	/* check the closing bracket */
-	if (line[line_len - 1] != ']') {
-		fail (_("section header does not end with ']'"));
-		return false;
-	}
-
-	/* check the section label */
-	for (i = 1; i < line_len - 1; ++i) {
-		if (!isprint (line[i])) {
-			fail (_("label contains non-printable characters"));
-			return false;
-		}
-	}
-
-	return true;
-}
-
-static bool
-parse_key_value_pair (const char *line)
-{
-	const char *colon;
-	size_t i, value_len;
-
-	/* find the key-value separator */
-	colon = strchr (line, ':');
-	if (colon == NULL) {
-		fail (_("key-value pair is missing a separator ':'"));
-		return false;
-	}
-
-	if (line == colon) {
-		fail (_("missing key in key-value pair"));
-		return false;
-	}
-
-	/* check the key */
-	while (line < colon) {
-		if (!isprint (*line)) {
-			fail (_("key contains non-printable characters"));
-			return false;
-		}
-		++line;
-	}
-	++line;
-
-	/* skip whitespace after colon */
-	while (isspace (*line))
-		++line;
-
-	if (*line == '\0') {
-		fail (_("missing value in key-value pair"));
-		return false;
-	}
-
-	/* check if value is a string */
-	value_len = strlen (line);
-	if ((line[0] == '"' && line[value_len - 1] != '"') ||
-	    (line[0] != '"' && line[value_len - 1] == '"')) {
-		fail (_("value string is missing '\"'"));
-		return false;
-	}
-
-	/* check the value */
-	for (i = 0; i < value_len; ++i) {
-		if (!isprint (line[i])) {
-			fail (_("value contains non-printable characters"));
-			return false;
-		}
-	}
-
-	return true;
-}
-
-static bool
-parse_line (char *line)
-{
-	bool ok;
-	char *end;
-
-	/* check for PEM block */
-	ok = parse_pem (line);
-	if (ok)
-		return true;
-	if (inside_pem)
-		return false;
-
-	/* trim whitespace from both ends */
-	while (isspace (*line))
-		++line;
-	end = line + strlen (line) - 1;
-	while (line < end && isspace (*end))
-		--end;
-	end[1] = '\0';
-
-	/* ignore empty lines and comments */
-	if (*line == '\0' || *line == '#')
-		return true;
-
-	/* check for section header */
-	if (*line == '[') {
-		ok = parse_section_header (line);
-		if (ok)
-			inside_section = 1;
-		return ok;
-	}
-
-	/* check for key-value pair */
-	ok = parse_key_value_pair (line);
-	if (ok && !inside_section) {
-		fail (_("key-value pair outside of section"));
-		return false;
-	}
-
-	return ok;
 }
 
 static enum format_result
 check_format (const char *filename)
 {
-	bool ok;
-	FILE *stream;
-	char *line;
+	p11_mmap *map;
+	void *data;
+	size_t size;
+	p11_persist *persist = NULL;
+	enum format_result result;
 
-	stream = fopen (filename, "r");
-	if (stream == NULL) {
-		p11_message (_("%s: failed to open file for reading"), filename);
+	map = p11_mmap_open (filename, NULL, &data, &size);
+	if (map == NULL) {
+		p11_message_err (errno, _("couldn't open and map file: %s"), filename);
 		return FORMAT_ERROR;
 	}
 
-	/* reset context */
-	inside_pem = 0;
-	inside_section = 0;
-
-	for (line_num = 1; (ok = get_line (stream, &line)) && line != NULL; ++line_num) {
-		ok = parse_line (line);
-		free (line);
-		if (!ok) {
-			fclose (stream);
-			return FORMAT_FAIL;
-		}
+	if (!p11_persist_magic (data, size)) {
+		p11_message (_("file is not recognized as .p11-kit format: %s"), filename);
+		result = FORMAT_FAIL;
+		goto error;
 	}
 
-	fclose (stream);
-
-	/* Fail if we received a reading error */
-	if (!ok)
-		return FORMAT_ERROR;
-
-	/* Fail if PEM block was left open after reaching EOF */
-	if (inside_pem) {
-		fail (_("PEM block not closed at EOF"));
-		return FORMAT_FAIL;
+	persist = p11_persist_new ();
+	if (!persist) {
+		result = FORMAT_ERROR;
+		goto error;
 	}
 
-	return FORMAT_OK;
+	result = p11_persist_check (persist, filename, data, size) ?
+		FORMAT_OK : FORMAT_FAIL;
+
+ error:
+	p11_persist_free (persist);
+	p11_mmap_close (map);
+	return result;
 }
 
 int
@@ -497,6 +168,11 @@ p11_trust_check_format (int argc,
 
 	argc -= optind;
 	argv += optind;
+
+	if (argc < 1) {
+		p11_message (_("specify a .p11-kit file"));
+		return 2;
+	}
 
 	color_out = isatty (fileno (stdout));
 	color_err = isatty (fileno (stderr));

--- a/trust/persist.c
+++ b/trust/persist.c
@@ -696,6 +696,8 @@ p11_persist_read (p11_persist *persist,
 				failed = !pem_to_attributes (&lexer, &attrs);
 			}
 			break;
+		default:
+			assert_not_reached ();
 		}
 
 		if (failed)
@@ -837,6 +839,8 @@ p11_persist_check (p11_persist *persist,
 				failed = true;
 			}
 			break;
+		default:
+			assert_not_reached ();
 		}
 	}
 

--- a/trust/persist.h
+++ b/trust/persist.h
@@ -36,8 +36,10 @@
 #define P11_PERSIST_H_
 
 #include "array.h"
+#include "buffer.h"
 #include "compat.h"
 #include "dict.h"
+#include "pkcs11.h"
 
 #include <sys/types.h>
 
@@ -53,6 +55,11 @@ bool             p11_persist_read   (p11_persist *persist,
                                      const unsigned char *data,
                                      size_t length,
                                      p11_array *objects);
+
+bool             p11_persist_check  (p11_persist *persist,
+                                     const char *filename,
+                                     const unsigned char *data,
+                                     size_t length);
 
 bool             p11_persist_write  (p11_persist *persist,
                                      CK_ATTRIBUTE *object,


### PR DESCRIPTION
The trust check-format command used a dedicated parsing code for the .p11-kit format, which behaves differently from the original parsing code: sometimes it is stricter (e.g., PEM block), while other times it is not (e.g., constant names and OIDs). This makes it use the same single parser to align with the original behavior.