### PR TITLE
virtual: Fix libffi type signatures for PKCS#11 3.0 functions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,3 +104,14 @@ jobs:
         run: |
           echo /usr/local/opt/gettext/bin >>${GITHUB_PATH}
       - uses: ./.github/actions/basic-autotools
+
+  libffi:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/p11-glue/p11-kit:master
+    env:
+      MESON_BUILD_OPTS: -Db_sanitize=address -Db_sanitize=undefined -Dclosures=0
+    steps:
+      # Checkout repo
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/basic-meson

--- a/configure.ac
+++ b/configure.ac
@@ -288,8 +288,8 @@ AC_ARG_WITH([closures],
 	    [closures=$withval],
 	    [closures=64])
 
-if test "$closures" -lt 1; then
-	AC_MSG_ERROR([at least one closure must be compiled in])
+if test "$with_libffi" != yes && test "$closures" -lt 1; then
+	AC_MSG_ERROR([libffi needs to be enabled or at least one closure must be compiled in])
 fi
 
 AC_DEFINE_UNQUOTED(P11_VIRTUAL_MAX_FIXED, [$closures], [the number of closures])

--- a/meson.build
+++ b/meson.build
@@ -320,8 +320,8 @@ if libffi.found()
 endif
 
 closures = get_option('closures')
-if closures < 1
-  error('at least one closure must be compiled in')
+if not libffi.found() and closures < 1
+  error('libffi needs to be enabled or at least one closure must be compiled in')
 endif
 
 conf.set('P11_VIRTUAL_MAX_FIXED', closures)

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -19,7 +19,7 @@ libp11_kit_internal_sources += custom_target('generate virtual-fixed-generated.h
                                              output: 'virtual-fixed-generated.h',
                                              command: [
                                                meson.current_source_dir() / 'gen-virtual-fixed.sh',
-                                               '@OUTPUT@', '64'
+                                               '@OUTPUT@', '@0@'.format(closures)
                                              ])
 libp11_kit_internal_sources += 'virtual.c'
 

--- a/p11-kit/virtual.c
+++ b/p11-kit/virtual.c
@@ -1009,6 +1009,11 @@ binding_C_GetInterface (ffi_cif *cif,
 	CK_INTERFACE_PTR *interface = *(CK_INTERFACE_PTR_PTR *)args[2];
 	CK_FLAGS flags = *(CK_FLAGS *)args[3];
 
+	if (interface == NULL) {
+		*ret = CKR_ARGUMENTS_BAD;
+		return;
+	}
+
 	if (interface_name == NULL) {
 		virtual_interfaces[0].pFunctionList = &wrapper->bound;
 		*interface = &virtual_interfaces[0];
@@ -3742,27 +3747,27 @@ static const BindingInfo binding_info[] = {
         { binding_C_WaitForSlotEvent, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
         /* PKCS #11 3.0 */
         { binding_C_LoginUser, { &ffi_type_ulong, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_SessionCancel, { &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_SessionCancel, { &ffi_type_ulong, &ffi_type_ulong, NULL } },
         { binding_C_MessageEncryptInit, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_EncryptMessage, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
-        { binding_C_EncryptMessageBegin, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_EncryptMessageNext, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_MessageEncryptFinal, { &ffi_type_pointer, NULL } },
-        { binding_C_MessageDecryptInit, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_DecryptMessage, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
-        { binding_C_DecryptMessageBegin, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_DecryptMessageNext, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_MessageDecryptFinal, { &ffi_type_pointer, NULL } },
-        { binding_C_MessageSignInit, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_SignMessage, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
-        { binding_C_SignMessageBegin, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_SignMessageNext, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
-        { binding_C_MessageSignFinal, { &ffi_type_pointer, NULL } },
-        { binding_C_MessageVerifyInit, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_VerifyMessage, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_VerifyMessageBegin, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_VerifyMessageNext, { &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
-        { binding_C_MessageVerifyFinal, { &ffi_type_pointer, NULL } },
+        { binding_C_EncryptMessage, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
+        { binding_C_EncryptMessageBegin, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_EncryptMessageNext, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_MessageEncryptFinal, { &ffi_type_ulong, NULL } },
+        { binding_C_MessageDecryptInit, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_DecryptMessage, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
+        { binding_C_DecryptMessageBegin, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_DecryptMessageNext, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_MessageDecryptFinal, { &ffi_type_ulong, NULL } },
+        { binding_C_MessageSignInit, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_SignMessage, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
+        { binding_C_SignMessageBegin, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_SignMessageNext, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_pointer, NULL } },
+        { binding_C_MessageSignFinal, { &ffi_type_ulong, NULL } },
+        { binding_C_MessageVerifyInit, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_VerifyMessage, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_VerifyMessageBegin, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_VerifyMessageNext, { &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, &ffi_type_pointer, &ffi_type_ulong, NULL } },
+        { binding_C_MessageVerifyFinal, { &ffi_type_ulong, NULL } },
         { 0, }
 };
 


### PR DESCRIPTION
There were some mismatches between the type signatures of `binding_*`
functions and the `BindingInfo` definitions, causing test failures
when compiled without fixed closures.