### PR TITLE
build: Fix meson build & tests on macOS

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -33,6 +33,9 @@ libp11_library = static_library('p11-library', 'library.c',
 libp11_library_dep = declare_dependency(link_with: libp11_library,
                                         dependencies: [libp11_common_dep] + thread_deps)
 
+libp11_library_whole_dep = declare_dependency(link_whole: libp11_library,
+                                              dependencies: [libp11_common_dep] + thread_deps)
+
 if get_option('test')
   libp11_test_sources = [
     'mock.c',

--- a/p11-kit/conf.c
+++ b/p11-kit/conf.c
@@ -408,7 +408,6 @@ load_configs_from_directory (const char *directory,
 	int error = 0;
 	bool is_dir;
 	char *path;
-	int count = 0;
 
 	p11_debug ("loading module configs in: %s", directory);
 
@@ -450,7 +449,6 @@ load_configs_from_directory (const char *directory,
 		}
 
 		free (path);
-		count ++;
 	}
 
 	closedir (dir);

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -162,7 +162,7 @@ if get_option('test')
              'remote.c',
              c_args: common_c_args,
              dependencies: [libp11_tool_dep] + libffi_deps + dlopen_deps,
-             link_with: libp11_kit_testable)
+             link_whole: libp11_kit_testable)
 endif
 
 executable('p11-kit-server',
@@ -184,7 +184,7 @@ if get_option('test')
              ],
              implicit_include_directories: false,
              dependencies: [libp11_tool_dep] + libsystemd_deps + libffi_deps + dlopen_deps,
-             link_with: libp11_kit_testable)
+             link_whole: libp11_kit_testable)
 endif
 
 if with_systemd
@@ -246,16 +246,31 @@ if get_option('test')
     'test-transport3'
   ]
 
+  # Some tests fail to link on macOS because they need p11_library_mutex, but
+  # it isn't included unless libp11_kit_testable is linked with
+  # -Wl,--whole-archive or -Wl,-force_load.
+  p11_kit_tests_whole = [
+    'test-uri',
+    'test-util'
+  ]
+
   if host_system != 'windows'
     p11_kit_tests += 'test-server'
   endif
 
   foreach name : p11_kit_tests
+    link_whole = []
+    link_with = [libp11_kit_testable]
+    if p11_kit_tests_whole.contains(name)
+      link_whole = [libp11_kit_testable]
+      link_with = []
+    endif
     t = executable(name, '@0@.c'.format(name),
                    c_args: tests_c_args + libp11_kit_testable_c_args,
                    include_directories: [configinc, commoninc],
                    dependencies: [libp11_test_dep] + libffi_deps + dlopen_deps,
-                   link_with: libp11_kit_testable)
+                   link_with: link_with,
+                   link_whole: link_whole)
     test(name, t)
   endforeach
 

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -92,10 +92,19 @@ p11_module_ldflags = cc.get_supported_link_arguments([
   '-Wl,--version-script,' + p11_module_symbol_map
 ])
 
+# On macOS, the default suffix for loadable modules is .so, but meson uses
+# .dylib by default. Since the code expects .so and autotools was using .so,
+# make meson do the same.
+module_suffix = []
+if ['darwin', 'ios'].contains(host_system)
+  module_suffix = 'so'
+endif
+
 if host_system != 'windows'
   shared_module('p11-kit-client',
                 'client.c', 'client-init.c',
                 name_prefix: '',
+                name_suffix: module_suffix,
                 include_directories: [configinc, commoninc],
                 dependencies: dlopen_deps,
                 link_args: p11_module_ldflags,
@@ -324,6 +333,7 @@ if get_option('test')
     shared_module(name,
                   sources,
                   name_prefix: '',
+                  name_suffix: module_suffix,
                   link_args: p11_module_ldflags,
                   link_depends: [p11_module_symbol_map],
                   dependencies: [libp11_test_dep])

--- a/trust/meson.build
+++ b/trust/meson.build
@@ -142,12 +142,23 @@ if get_option('test')
     'test-jks'
   ]
 
+  # Some tests fail to link on macOS because they need p11_library_mutex, but
+  # it isn't included unless libp11_kit_testable is linked with
+  # -Wl,--whole-archive or -Wl,-force_load.
+  trust_tests_whole = [
+    'test-index',
+    'test-builder',
+    'test-token'
+  ]
+
   foreach name : trust_tests
     t = executable(name, '@0@.c'.format(name),
                    c_args: common_c_args + tests_c_args + libtrust_testable_c_args,
                    dependencies: [asn_h_dep,
                                   libp11_kit_dep,
-                                  libp11_library_dep,
+                                  trust_tests_whole.contains(name) ?
+                                    libp11_library_whole_dep :
+                                    libp11_library_dep,
                                   libp11_test_dep] + libtasn1_deps + dlopen_deps,
                    link_with: [libtrust_testable, libtrust_data, libtrust_test])
     test(name, t)
@@ -165,12 +176,21 @@ if get_option('test')
     'frob-oid'
   ]
 
+  # Some tests fail to link on macOS because they need p11_library_mutex, but
+  # it isn't included unless libp11_kit_testable is linked with
+  # -Wl,--whole-archive or -Wl,-force_load.
+  trust_progs_whole = [
+    'frob-token'
+  ]
+
   foreach name : trust_progs
     t = executable(name, '@0@.c'.format(name),
                    c_args: tests_c_args,
                    dependencies: [asn_h_dep,
                                   libp11_kit_dep,
-                                  libp11_library_dep,
+                                  trust_progs_whole.contains(name) ?
+                                    libp11_library_whole_dep :
+                                    libp11_library_dep,
                                   libp11_test_dep] + libtasn1_deps + libffi_deps + dlopen_deps,
                    link_with: [libtrust_testable, libtrust_data, libtrust_test])
   endforeach


### PR DESCRIPTION
This PR consists of two parts:

- Fixing linker errors when building with meson on macOS
- Ensuring loadable modules used for tests are correctly built with an `.so` filename extension on macOS

### build: Fix linker errors on macOS
This fixes a few linker errors on macOS due to an undefined `p11_library_mutex` symbol:

```
cc  -o p11-kit/p11-kit-server-testable p11-kit/p11-kit-server-testable.p/server.c.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -Wl,-rpath,/opt/local/lib p11-kit/libp11-kit-testable.a common/libp11-library.a common/libp11-common.a common/libp11-tool.a /opt/local/lib/libffi.dylib
Undefined symbols for architecture x86_64:
  "_p11_library_mutex", referenced from:
      _p11_kit_be_quiet in libp11-kit-testable.a(util.c.o)
      _p11_kit_be_loud in libp11-kit-testable.a(util.c.o)
      _p11_kit_set_progname in libp11-kit-testable.a(util.c.o)
ld: symbol(s) not found for architecture x86_64
```

### build: Use .so as module suffix on macOS

macOS uses `.so` as filename extension for loadable modules. For some reason, meson does not use this by default, but uses `.dylib`. This inconsistency between the autoconf build system (which uses `.so`) and the meson build system caused the tests to fail, because the mock modules would not be found by the tests.

This is a bug in meson, as loadable modules (filetype `BUNDLE` in `otool -hv` output) should have an `.so` extension on macOS. See [[1][1],[2][2]] for discussion in meson.

Port the same fix that was used by the GNOME developers in gtk [[3][3],[4][4]] and glib-networking [\[5\]][5]. See also a similar fix in glib [\[6\]][6].

[1]: https://github.com/mesonbuild/meson/issues/1160
[2]: https://github.com/mesonbuild/meson/issues/3053
[3]: https://gitlab.gnome.org/GNOME/gtk/-/issues/3645
[4]: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3162
[5]: https://gitlab.gnome.org/GNOME/glib-networking/-/merge_requests/1
[6]: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/280
