### PR TITLE
Add list-profiles sub-command to p11-kit cmd tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ frob-*
 /p11-kit/virtual-fixed-generated.h
 /p11-kit/*.gnu.c
 
+/p11-kit/p11-kit-testable
 /p11-kit/p11-kit-remote
 /p11-kit/p11-kit-server
 /p11-kit/p11-kit-remote-testable

--- a/bash-completion/p11-kit
+++ b/bash-completion/p11-kit
@@ -10,7 +10,7 @@ _p11-kit()
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     elif [[ $cword -eq 1 ]]; then
-        local commands='list-modules print-config extract server remote'
+        local commands='list-profiles list-modules print-config extract server remote'
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     fi
 } &&

--- a/common/constants.c
+++ b/common/constants.c
@@ -636,6 +636,15 @@ const p11_constant p11_constant_mechanisms[] = {
 	{ CKA_INVALID },
 };
 
+const p11_constant p11_constant_profiles[] = {
+	CT (CKP_BASELINE_PROVIDER, "baseline-provider")
+	CT (CKP_EXTENDED_PROVIDER, "extended-provider")
+	CT (CKP_AUTHENTICATION_TOKEN, "authentication-token")
+	CT (CKP_PUBLIC_CERTIFICATES_TOKEN, "public-certificates-token")
+	CT (CKP_VENDOR_DEFINED, "vendor-defined")
+	{ CKA_INVALID },
+};
+
 #undef CT
 
 struct {
@@ -653,6 +662,7 @@ struct {
 	{ p11_constant_states, ELEMS (p11_constant_states) - 1 },
 	{ p11_constant_users, ELEMS (p11_constant_users) - 1 },
 	{ p11_constant_returns, ELEMS (p11_constant_returns) - 1 },
+	{ p11_constant_profiles, ELEMS (p11_constant_profiles) - 1 },
 };
 
 static int

--- a/common/constants.h
+++ b/common/constants.h
@@ -79,4 +79,6 @@ extern const p11_constant    p11_constant_users[];
 
 extern const p11_constant    p11_constant_returns[];
 
+extern const p11_constant    p11_constant_profiles[];
+
 #endif /* P11_CONSTANTS_H_ */

--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -33,6 +33,9 @@
 		<command>p11-kit list-modules</command>
 	</cmdsynopsis>
 	<cmdsynopsis>
+		<command>p11-kit list-profiles</command> ...
+	</cmdsynopsis>
+	<cmdsynopsis>
 		<command>p11-kit print-config</command>
 	</cmdsynopsis>
 	<cmdsynopsis>
@@ -78,6 +81,20 @@ $ p11-kit list-modules
 
 	<para>The modules, information about them and the tokens present in
 	the PKCS#11 modules will be displayed.</para>
+
+</refsect1>
+
+<refsect1 id="p11-kit-list-profiles">
+	<title>List Profiles</title>
+
+	<para>List PKCS#11 profiles supported by the token.</para>
+
+<programlisting>
+$ p11-kit list-profiles pkcs11:token
+</programlisting>
+
+	<para>This searches the given token for profile objects that contain profile IDs
+	which are then displayed in human-readable form.</para>
 
 </refsect1>
 

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -257,6 +257,24 @@ if WITH_BASH_COMPLETION
 bashcomp_DATA += bash-completion/p11-kit
 endif
 
+check_PROGRAMS += p11-kit/p11-kit-testable
+p11_kit_p11_kit_testable_SOURCES = \
+	p11-kit/list-profiles.c \
+	p11-kit/lists.c \
+	p11-kit/p11-kit.c \
+	p11-kit/print-config.c \
+	$(NULL)
+
+p11_kit_p11_kit_testable_LDADD = \
+	libp11-tool.la \
+	libp11-common.la \
+	libp11-kit-testable.la \
+	$(NULL)
+
+p11_kit_p11_kit_testable_CFLAGS = \
+	$(COMMON_CFLAGS) \
+	$(NULL)
+
 private_PROGRAMS += p11-kit/p11-kit-remote
 
 p11_kit_p11_kit_remote_SOURCES = \
@@ -355,7 +373,10 @@ c_tests += \
 
 if !OS_WIN32
 c_tests += test-server
-sh_tests += p11-kit/test-server.sh
+sh_tests += \
+	p11-kit/test-profiles.sh \
+	p11-kit/test-server.sh \
+	$(NULL)
 endif
 
 test_conf_SOURCES = p11-kit/test-conf.c
@@ -461,7 +482,8 @@ check_LTLIBRARIES += \
 	mock-seven.la \
 	mock-eight.la \
 	mock-nine.la \
-	mock-ten.la
+	mock-ten.la \
+	mock-eleven.la
 
 mock_one_la_SOURCES = p11-kit/mock-module-ep.c
 mock_one_la_LIBADD = libp11-test.la libp11-common.la
@@ -522,10 +544,15 @@ mock_ten_la_SOURCES = p11-kit/mock-module-ep8.c
 mock_ten_la_LDFLAGS = $(mock_one_la_LDFLAGS)
 mock_ten_la_LIBADD = $(mock_one_la_LIBADD)
 
+mock_eleven_la_SOURCES = p11-kit/mock-module-ep9.c
+mock_eleven_la_LDFLAGS = $(mock_one_la_LDFLAGS)
+mock_eleven_la_LIBADD = $(mock_one_la_LIBADD)
+
 EXTRA_DIST += \
 	p11-kit/fixtures \
 	p11-kit/test-mock.c \
 	p11-kit/test-transport-base.c \
+	p11-kit/test-profiles.sh \
 	p11-kit/test-messages.sh \
 	p11-kit/test-server.sh \
 	$(NULL)

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -239,6 +239,7 @@ bin_PROGRAMS += p11-kit/p11-kit
 p11_kit_p11_kit_CFLAGS = $(COMMON_CFLAGS)
 
 p11_kit_p11_kit_SOURCES = \
+	p11-kit/list-profiles.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \
 	p11-kit/print-config.c \

--- a/p11-kit/fixtures/package-modules/eleven.module
+++ b/p11-kit/fixtures/package-modules/eleven.module
@@ -1,0 +1,4 @@
+
+module: mock-eleven.so
+managed: yes
+enable-in: p11-kit-testable

--- a/p11-kit/list-profiles.c
+++ b/p11-kit/list-profiles.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include "constants.h"
+#include "debug.h"
+#include "iter.h"
+#include "message.h"
+#include "tool.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
+
+int
+p11_kit_list_profiles (int argc,
+		       char *argv[]);
+
+static int
+list_profiles (const char *token_str)
+{
+	int ret = 1;
+	const char *profile_nick = NULL;
+	CK_FUNCTION_LIST **modules = NULL;
+	P11KitUri *uri = NULL;
+	P11KitIter *iter = NULL;
+	CK_OBJECT_CLASS klass = CKO_PROFILE;
+	CK_PROFILE_ID profile_id = CKP_INVALID_ID;
+	CK_ATTRIBUTE matching = { CKA_CLASS, &klass, sizeof (klass) };
+	CK_ATTRIBUTE attr = { CKA_PROFILE_ID, &profile_id, sizeof (profile_id) };
+	CK_RV rv;
+
+	uri = p11_kit_uri_new ();
+	if (uri == NULL) {
+		p11_message (_("failed to allocate memory for URI"));
+		goto cleanup;
+	}
+
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
+		p11_message (_("failed to parse the token URI"));
+		goto cleanup;
+	}
+
+	modules = p11_kit_modules_load_and_initialize (0);
+	if (modules == NULL) {
+		p11_message (_("failed to load and initialize modules"));
+		goto cleanup;
+	}
+
+	iter = p11_kit_iter_new (uri, 0);
+	if (iter == NULL) {
+		p11_message (_("failed to initialize iterator"));
+		goto cleanup;
+	}
+
+	p11_kit_iter_add_filter (iter, &matching, 1);
+	p11_kit_iter_begin (iter, modules);
+	while ((rv = p11_kit_iter_next (iter)) == CKR_OK) {
+		rv = p11_kit_iter_get_attributes (iter, &attr, 1);
+		if (rv != CKR_OK) {
+			p11_message (_("failed to retrieve attribute of an object"));
+			goto cleanup;
+		}
+
+		profile_nick = p11_constant_nick (p11_constant_profiles, profile_id);
+		if (profile_nick == NULL)
+			printf ("0x%lX (unknown)\n", profile_id);
+		else
+			printf ("%s\n", profile_nick);
+	}
+
+	ret = 0;
+
+cleanup:
+	p11_kit_iter_free (iter);
+	p11_kit_modules_finalize (modules);
+	p11_kit_modules_release (modules);
+	p11_kit_uri_free (uri);
+
+	return ret;
+}
+
+int
+p11_kit_list_profiles (int argc,
+		       char *argv[])
+{
+	int opt;
+
+	enum {
+		opt_verbose = 'v',
+		opt_quiet = 'q',
+		opt_help = 'h',
+	};
+
+	struct option options[] = {
+		{ "verbose", no_argument, NULL, opt_verbose },
+		{ "quiet", no_argument, NULL, opt_quiet },
+		{ "help", no_argument, NULL, opt_help },
+		{ 0 },
+	};
+
+	p11_tool_desc usages[] = {
+		{ 0, "usage: p11-kit list-profiles pkcs11:token" },
+		{ 0 },
+	};
+
+	while ((opt = p11_tool_getopt (argc, argv, options)) != -1) {
+		switch (opt) {
+		case opt_verbose:
+			p11_kit_be_loud ();
+			break;
+		case opt_quiet:
+			p11_kit_be_quiet ();
+			break;
+		case opt_help:
+			p11_tool_usage (usages, options);
+			return 0;
+		case '?':
+			return 2;
+		default:
+			assert_not_reached ();
+			break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 1) {
+		p11_tool_usage (usages, options);
+		return 2;
+	}
+
+	return list_profiles (*argv);
+}

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -146,6 +146,7 @@ if get_option('test')
 endif
 
 p11_kit_sources = [
+  'list-profiles.c',
   'lists.c',
   'p11-kit.c',
   'print-config.c'

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -159,6 +159,14 @@ executable('p11-kit',
            link_with: [libp11_kit, libp11_kit_internal],
            install: true)
 
+if get_option('test')
+  executable('p11-kit-testable',
+             p11_kit_sources,
+             c_args: common_c_args + libp11_kit_internal_c_args,
+             dependencies: [libp11_tool_dep] + libffi_deps + dlopen_deps,
+             link_whole: libp11_kit_testable)
+endif
+
 executable('p11-kit-remote',
            'remote.c',
            c_args: common_c_args,
@@ -302,6 +310,10 @@ if get_option('test')
   p11_kit_tests_env.set('P11_MODULE_PATH', meson.current_build_dir())
 
   if host_system != 'windows'
+    test('test-profiles.sh',
+         find_program('test-profiles.sh'),
+         env: p11_kit_tests_env)
+
     test('test-messages.sh',
          find_program('test-messages.sh'),
          env: p11_kit_tests_env)
@@ -323,7 +335,8 @@ if get_option('test')
                    'mock-seven': ['mock-module-ep5.c'],
                    'mock-eight': ['mock-module-ep6.c'],
                    'mock-nine': ['mock-module-ep7.c'],
-                   'mock-ten': ['mock-module-ep8.c']
+                   'mock-ten': ['mock-module-ep8.c'],
+                   'mock-eleven': ['mock-module-ep9.c']
                  }
 
   if host_system != 'windows'

--- a/p11-kit/mock-module-ep9.c
+++ b/p11-kit/mock-module-ep9.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#define CRYPTOKI_EXPORTS 1
+#include "pkcs11.h"
+
+#include "mock.h"
+
+static CK_RV
+override_initialize (CK_VOID_PTR init_args)
+{
+	CK_RV rv = mock_C_Initialize (init_args);
+	mock_module_add_profile (MOCK_SLOT_ONE_ID, CKP_PUBLIC_CERTIFICATES_TOKEN);
+	return rv;
+}
+
+#ifdef OS_WIN32
+__declspec(dllexport)
+#endif
+CK_RV
+C_GetFunctionList (CK_FUNCTION_LIST_PTR_PTR list)
+{
+	mock_module_init ();
+	mock_module.C_GetFunctionList = C_GetFunctionList;
+	mock_module.C_Initialize = override_initialize;
+	if (list == NULL)
+		return CKR_ARGUMENTS_BAD;
+	*list = &mock_module;
+	return CKR_OK;
+}

--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -62,6 +62,9 @@
 int       p11_kit_list_modules    (int argc,
                                    char *argv[]);
 
+int       p11_kit_list_profiles   (int argc,
+                                   char *argv[]);
+
 int       p11_kit_print_config    (int argc,
                                    char *argv[]);
 
@@ -73,6 +76,7 @@ int       p11_kit_external        (int argc,
 
 static const p11_tool_command commands[] = {
 	{ "list-modules", p11_kit_list_modules, N_("List modules and tokens") },
+	{ "list-profiles", p11_kit_list_profiles, N_("List PKCS#11 profiles supported by the token") },
 	{ "print-config", p11_kit_print_config, N_("Print merged configuration") },
 	{ "remote", p11_kit_external, N_("Run a specific PKCS#11 module remotely") },
 	{ "server", p11_kit_external, N_("Run a server process that exposes PKCS#11 module remotely") },

--- a/p11-kit/test-profiles.sh
+++ b/p11-kit/test-profiles.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+testdir=$PWD/test-profiles-$$
+test -d "$testdir" || mkdir "$testdir"
+
+cleanup () {
+	rm -rf "$testdir"
+}
+trap cleanup 0
+
+cd "$testdir"
+
+cat > list.exp <<EOF
+public-certificates-token
+EOF
+
+"$abs_top_builddir"/p11-kit/p11-kit-testable list-profiles -q pkcs11: > list.out
+
+echo 1..1
+
+: ${DIFF=diff}
+if ${DIFF} list.exp list.out > list.diff; then
+	echo "ok 1 /profiles/list"
+else
+	echo "not ok 1 /profiles/list"
+	sed 's/^/# /' list.diff
+	exit 1
+fi

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,6 +2,7 @@
 common/tool.c
 p11-kit/conf.c
 p11-kit/filter.c
+p11-kit/list-profiles.c
 p11-kit/lists.c
 p11-kit/messages.c
 p11-kit/modules.c


### PR DESCRIPTION
Adds list-profiles command for listing profiles that are supported by a token
usage: p11-kit list-profiles pkcs11:token