### PR TITLE
Add command to delete profiles from a token

### DIFF
--- a/bash-completion/p11-kit
+++ b/bash-completion/p11-kit
@@ -10,7 +10,7 @@ _p11-kit()
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     elif [[ $cword -eq 1 ]]; then
-        local commands='list-profiles list-modules print-config extract server remote'
+        local commands='delete-profile list-profiles list-modules print-config extract server remote'
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     fi
 } &&

--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -36,6 +36,9 @@
 		<command>p11-kit list-profiles</command> ...
 	</cmdsynopsis>
 	<cmdsynopsis>
+		<command>p11-kit delete-profile</command> ...
+	</cmdsynopsis>
+	<cmdsynopsis>
 		<command>p11-kit print-config</command>
 	</cmdsynopsis>
 	<cmdsynopsis>
@@ -95,6 +98,20 @@ $ p11-kit list-profiles pkcs11:token
 
 	<para>This searches the given token for profile objects that contain profile IDs
 	which are then displayed in human-readable form.</para>
+
+</refsect1>
+
+<refsect1 id="p11-kit-delete-profile">
+	<title>Delete Profile</title>
+
+	<para>Delete PKCS#11 profile from the token.</para>
+
+<programlisting>
+$ p11-kit delete-profile --profile profile pkcs11:token
+</programlisting>
+
+	<para>Searches the token for profile object that matches given PKCS#11
+	profile ID and attempts to destroy it.</para>
 
 </refsect1>
 

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -239,6 +239,7 @@ bin_PROGRAMS += p11-kit/p11-kit
 p11_kit_p11_kit_CFLAGS = $(COMMON_CFLAGS)
 
 p11_kit_p11_kit_SOURCES = \
+	p11-kit/delete-profile.c \
 	p11-kit/list-profiles.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \
@@ -259,6 +260,7 @@ endif
 
 check_PROGRAMS += p11-kit/p11-kit-testable
 p11_kit_p11_kit_testable_SOURCES = \
+	p11-kit/delete-profile.c \
 	p11-kit/list-profiles.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include "constants.h"
+#include "debug.h"
+#include "iter.h"
+#include "message.h"
+#include "tool.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
+
+int
+p11_kit_delete_profile (int argc,
+			char *argv[]);
+
+static int
+delete_profile (const char *token_str,
+		CK_PROFILE_ID profile)
+{
+	int ret = 1;
+	CK_FUNCTION_LIST **modules = NULL;
+	P11KitUri *uri = NULL;
+	P11KitIter *iter = NULL;
+	CK_OBJECT_CLASS klass = CKO_PROFILE;
+	CK_PROFILE_ID profile_id = CKP_INVALID_ID;
+	CK_ATTRIBUTE matching = { CKA_CLASS, &klass, sizeof (klass) };
+	CK_ATTRIBUTE attr = { CKA_PROFILE_ID, &profile_id, sizeof (profile_id) };
+	CK_RV rv;
+
+	uri = p11_kit_uri_new ();
+	if (uri == NULL) {
+		p11_message (_("failed to allocate memory for URI"));
+		goto cleanup;
+	}
+
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
+		p11_message (_("failed to parse the token URI"));
+		goto cleanup;
+	}
+
+	modules = p11_kit_modules_load_and_initialize (0);
+	if (modules == NULL) {
+		p11_message (_("failed to load and initialize modules"));
+		goto cleanup;
+	}
+
+	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WANT_WRITABLE);
+	if (iter == NULL) {
+		p11_message (_("failed to initialize iterator"));
+		goto cleanup;
+	}
+
+	p11_kit_iter_add_filter (iter, &matching, 1);
+	p11_kit_iter_begin (iter, modules);
+	while ((rv = p11_kit_iter_next (iter)) == CKR_OK) {
+		rv = p11_kit_iter_get_attributes (iter, &attr, 1);
+		if (rv != CKR_OK) {
+			p11_message (_("failed to retrieve attribute of an object"));
+			goto cleanup;
+		}
+
+		if (profile_id == profile) {
+			rv = p11_kit_iter_destroy_object (iter);
+			if (rv != CKR_OK)
+				p11_message (_("failed to delete the profile"));
+		}
+	}
+
+	ret = 0;
+
+cleanup:
+	p11_kit_iter_free (iter);
+	p11_kit_modules_finalize (modules);
+	p11_kit_modules_release (modules);
+	p11_kit_uri_free (uri);
+
+	return ret;
+}
+
+int
+p11_kit_delete_profile (int argc,
+			char *argv[])
+{
+	int opt, ret = 2;
+	CK_PROFILE_ID profile = CKP_INVALID_ID;
+	p11_dict *profile_nicks = NULL;
+
+	enum {
+		opt_verbose = 'v',
+		opt_quiet = 'q',
+		opt_help = 'h',
+		opt_profile = 'p',
+	};
+
+	struct option options[] = {
+		{ "verbose", no_argument, NULL, opt_verbose },
+		{ "quiet", no_argument, NULL, opt_quiet },
+		{ "help", no_argument, NULL, opt_help },
+		{ "profile", required_argument, NULL, opt_profile },
+		{ 0 },
+	};
+
+	p11_tool_desc usages[] = {
+		{ 0, "usage: p11-kit delete-profile --profile profile pkcs11:token" },
+		{ opt_profile, "specify the profile to delete" },
+		{ 0 },
+	};
+
+	profile_nicks = p11_constant_reverse (true);
+	if (profile_nicks == NULL) {
+		p11_message (_("failed to allocate memory"));
+		goto cleanup;
+	}
+
+	while ((opt = p11_tool_getopt (argc, argv, options)) != -1) {
+		switch (opt) {
+		case opt_verbose:
+			p11_kit_be_loud ();
+			break;
+		case opt_quiet:
+			p11_kit_be_quiet ();
+			break;
+		case opt_help:
+			p11_tool_usage (usages, options);
+			ret = 0;
+			goto cleanup;
+		case opt_profile:
+			if (profile != CKP_INVALID_ID) {
+				p11_message (_("multiple profiles specified"));
+				goto cleanup;
+			}
+
+			profile = p11_constant_resolve (profile_nicks, optarg);
+			if (profile == CKP_INVALID_ID)
+				profile = strtol (optarg, NULL, 0);
+			if (profile == CKP_INVALID_ID) {
+				p11_message (_("failed to convert profile argument: %s"), optarg);
+				goto cleanup;
+			}
+			break;
+		case '?':
+			goto cleanup;
+		default:
+			assert_not_reached ();
+			break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 1) {
+		p11_tool_usage (usages, options);
+		goto cleanup;
+	}
+
+	if (profile == CKP_INVALID_ID) {
+		p11_message (_("no profile specified"));
+		goto cleanup;
+	}
+
+	ret = delete_profile (*argv, profile);
+
+cleanup:
+	p11_dict_free (profile_nicks);
+
+	return ret;
+}

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -146,6 +146,7 @@ if get_option('test')
 endif
 
 p11_kit_sources = [
+  'delete-profile.c',
   'list-profiles.c',
   'lists.c',
   'p11-kit.c',

--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -65,6 +65,9 @@ int       p11_kit_list_modules    (int argc,
 int       p11_kit_list_profiles   (int argc,
                                    char *argv[]);
 
+int       p11_kit_delete_profile  (int argc,
+                                   char *argv[]);
+
 int       p11_kit_print_config    (int argc,
                                    char *argv[]);
 
@@ -77,6 +80,7 @@ int       p11_kit_external        (int argc,
 static const p11_tool_command commands[] = {
 	{ "list-modules", p11_kit_list_modules, N_("List modules and tokens") },
 	{ "list-profiles", p11_kit_list_profiles, N_("List PKCS#11 profiles supported by the token") },
+	{ "delete-profile", p11_kit_delete_profile, N_("Delete PKCS#11 profile from the token") },
 	{ "print-config", p11_kit_print_config, N_("Print merged configuration") },
 	{ "remote", p11_kit_external, N_("Run a specific PKCS#11 module remotely") },
 	{ "server", p11_kit_external, N_("Run a server process that exposes PKCS#11 module remotely") },

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,7 @@
 # List of source files which contain translatable strings.
 common/tool.c
 p11-kit/conf.c
+p11-kit/delete-profile.c
 p11-kit/filter.c
 p11-kit/list-profiles.c
 p11-kit/lists.c


### PR DESCRIPTION
Adds the ability to delete profile objects from given PKCS#11 token.

$ p11-kit delete-profile --profile public-certificates-token 'pkcs11:token=MyToken'