### PR TITLE
Add command to add profiles to a token

### DIFF
--- a/bash-completion/p11-kit
+++ b/bash-completion/p11-kit
@@ -10,7 +10,7 @@ _p11-kit()
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     elif [[ $cword -eq 1 ]]; then
-        local commands='delete-profile list-profiles list-modules print-config extract server remote'
+        local commands='add-profile delete-profile list-profiles list-modules print-config extract server remote'
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     fi
 } &&

--- a/common/test-constants.c
+++ b/common/test-constants.c
@@ -97,6 +97,7 @@ main (int argc,
 	p11_testx (test_constants, (void *)p11_constant_users, "/constants/users");
 	p11_testx (test_constants, (void *)p11_constant_states, "/constants/states");
 	p11_testx (test_constants, (void *)p11_constant_returns, "/constants/returns");
+	p11_testx (test_constants, (void *)p11_constant_profiles, "/constants/profiles");
 
 	return p11_test_run (argc, argv);
 }

--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -36,6 +36,9 @@
 		<command>p11-kit list-profiles</command> ...
 	</cmdsynopsis>
 	<cmdsynopsis>
+		<command>p11-kit add-profile</command> ...
+	</cmdsynopsis>
+	<cmdsynopsis>
 		<command>p11-kit delete-profile</command> ...
 	</cmdsynopsis>
 	<cmdsynopsis>
@@ -98,6 +101,19 @@ $ p11-kit list-profiles pkcs11:token
 
 	<para>This searches the given token for profile objects that contain profile IDs
 	which are then displayed in human-readable form.</para>
+
+</refsect1>
+
+<refsect1 id="p11-kit-add-profile">
+	<title>Add Profile</title>
+
+	<para>Add PKCS#11 profile to the token.</para>
+
+<programlisting>
+$ p11-kit add-profile --profile profile pkcs11:token
+</programlisting>
+
+	<para>Creates a new PKCS#11 profile object on the token if it doesn't already exist.</para>
 
 </refsect1>
 

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -239,6 +239,7 @@ bin_PROGRAMS += p11-kit/p11-kit
 p11_kit_p11_kit_CFLAGS = $(COMMON_CFLAGS)
 
 p11_kit_p11_kit_SOURCES = \
+	p11-kit/add-profile.c \
 	p11-kit/delete-profile.c \
 	p11-kit/list-profiles.c \
 	p11-kit/lists.c \
@@ -260,6 +261,7 @@ endif
 
 check_PROGRAMS += p11-kit/p11-kit-testable
 p11_kit_p11_kit_testable_SOURCES = \
+	p11-kit/add-profile.c \
 	p11-kit/delete-profile.c \
 	p11-kit/list-profiles.c \
 	p11-kit/lists.c \

--- a/p11-kit/add-profile.c
+++ b/p11-kit/add-profile.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include "attrs.h"
+#include "constants.h"
+#include "debug.h"
+#include "iter.h"
+#include "message.h"
+#include "tool.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
+
+int
+p11_kit_add_profile (int argc,
+		     char *argv[]);
+
+static bool
+profile_exists (CK_FUNCTION_LIST *module,
+		CK_PROFILE_ID profile)
+{
+	CK_RV rv;
+	P11KitIter *iter = NULL;
+	CK_OBJECT_CLASS klass = CKO_PROFILE;
+	CK_PROFILE_ID profile_id = CKP_INVALID_ID;
+	CK_ATTRIBUTE matching = { CKA_CLASS, &klass, sizeof (klass) };
+	CK_ATTRIBUTE attr = { CKA_PROFILE_ID, &profile_id, sizeof (profile_id) };
+	CK_FUNCTION_LIST *modules[] = { module, NULL };
+
+	iter = p11_kit_iter_new (NULL, 0);
+	if (iter == NULL) {
+		p11_message (_("failed to initialize iterator"));
+		return false;
+	}
+
+	p11_kit_iter_add_filter (iter, &matching, 1);
+	p11_kit_iter_begin (iter, modules);
+	while ((rv = p11_kit_iter_next (iter)) == CKR_OK) {
+		rv = p11_kit_iter_get_attributes (iter, &attr, 1);
+		if (rv != CKR_OK) {
+			p11_message (_("failed to retrieve attribute of an object"));
+			p11_kit_iter_free (iter);
+			return false;
+		}
+
+		if (profile_id == profile) {
+			p11_kit_iter_free (iter);
+			return true;
+		}
+	}
+	p11_kit_iter_free (iter);
+
+	return false;
+}
+
+static int
+add_profile (const char *token_str,
+	     CK_PROFILE_ID profile)
+{
+	int ret = 1;
+	CK_RV rv;
+	CK_OBJECT_HANDLE object = 0;
+	CK_SESSION_HANDLE session = 0;
+	CK_FUNCTION_LIST *prev_module = NULL;
+	CK_FUNCTION_LIST *module = NULL;
+	CK_FUNCTION_LIST **modules = NULL;
+	P11KitUri *uri = NULL;
+	P11KitIter *iter = NULL;
+	CK_OBJECT_CLASS klass = CKO_PROFILE;
+	CK_ATTRIBUTE template[] = {
+	    { CKA_CLASS, &klass, sizeof (klass) },
+	    { CKA_PROFILE_ID, &profile, sizeof (profile) }
+	};
+	CK_ULONG template_len = sizeof (template) / sizeof (template[0]);
+
+	uri = p11_kit_uri_new ();
+	if (uri == NULL) {
+		p11_message (_("failed to allocate memory for URI"));
+		goto cleanup;
+	}
+
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
+		p11_message (_("failed to parse the token URI"));
+		goto cleanup;
+	}
+
+	modules = p11_kit_modules_load_and_initialize (0);
+	if (modules == NULL) {
+		p11_message (_("failed to load and initialize modules"));
+		goto cleanup;
+	}
+
+	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WANT_WRITABLE);
+	if (iter == NULL) {
+		p11_message (_("failed to initialize iterator"));
+		goto cleanup;
+	}
+
+	p11_kit_iter_begin (iter, modules);
+	while ((rv = p11_kit_iter_next (iter)) == CKR_OK) {
+		module = p11_kit_iter_get_module (iter);
+		if (module == prev_module || profile_exists (module, profile)) {
+			prev_module = module;
+			continue;
+		}
+
+		session = p11_kit_iter_get_session (iter);
+		rv = module->C_CreateObject (session, template, template_len, &object);
+		if (rv != CKR_OK) {
+			p11_message (_("failed to create the profile object: %s"), p11_kit_strerror (rv));
+			goto cleanup;
+		}
+
+		prev_module = module;
+	}
+
+	ret = 0;
+
+cleanup:
+	p11_kit_iter_free (iter);
+	p11_kit_modules_finalize (modules);
+	p11_kit_modules_release (modules);
+	p11_kit_uri_free (uri);
+
+	return ret;
+}
+
+int
+p11_kit_add_profile (int argc,
+		     char *argv[])
+{
+	int opt, ret = 2;
+	CK_ULONG profile = CKA_INVALID;
+	p11_dict *profile_nicks = NULL;
+
+	enum {
+		opt_verbose = 'v',
+		opt_quiet = 'q',
+		opt_help = 'h',
+		opt_profile = 'p',
+	};
+
+	struct option options[] = {
+		{ "verbose", no_argument, NULL, opt_verbose },
+		{ "quiet", no_argument, NULL, opt_quiet },
+		{ "help", no_argument, NULL, opt_help },
+		{ "profile", required_argument, NULL, opt_profile },
+		{ 0 },
+	};
+
+	p11_tool_desc usages[] = {
+		{ 0, "usage: p11-kit add-profile --profile profile pkcs11:token" },
+		{ opt_profile, "specify the profile to add" },
+		{ 0 },
+	};
+
+	profile_nicks = p11_constant_reverse (true);
+	if (profile_nicks == NULL) {
+		p11_message (_("failed to allocate memory"));
+		goto cleanup;
+	}
+
+	while ((opt = p11_tool_getopt (argc, argv, options)) != -1) {
+		switch (opt) {
+		case opt_verbose:
+			p11_kit_be_loud ();
+			break;
+		case opt_quiet:
+			p11_kit_be_quiet ();
+			break;
+		case opt_help:
+			p11_tool_usage (usages, options);
+			ret = 0;
+			goto cleanup;
+		case opt_profile:
+			if (profile != CKA_INVALID) {
+				p11_message (_("multiple profiles specified"));
+				goto cleanup;
+			}
+
+			profile = p11_constant_resolve (profile_nicks, optarg);
+			if (profile == CKA_INVALID)
+				profile = strtol (optarg, NULL, 0);
+			if (profile == 0) {
+				p11_message (_("failed to convert profile argument: %s"), optarg);
+				goto cleanup;
+			}
+			break;
+		case '?':
+			goto cleanup;
+		default:
+			assert_not_reached ();
+			break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 1) {
+		p11_tool_usage (usages, options);
+		goto cleanup;
+	}
+
+	if (profile == CKA_INVALID) {
+		p11_message (_("no profile specified"));
+		goto cleanup;
+	}
+
+	ret = add_profile (*argv, profile);
+
+cleanup:
+	p11_dict_free (profile_nicks);
+
+	return ret;
+}

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -36,6 +36,7 @@
 
 #include "config.h"
 
+#include "attrs.h"
 #include "constants.h"
 #include "debug.h"
 #include "iter.h"
@@ -125,7 +126,7 @@ p11_kit_delete_profile (int argc,
 			char *argv[])
 {
 	int opt, ret = 2;
-	CK_PROFILE_ID profile = CKP_INVALID_ID;
+	CK_ULONG profile = CKA_INVALID;
 	p11_dict *profile_nicks = NULL;
 
 	enum {
@@ -168,15 +169,15 @@ p11_kit_delete_profile (int argc,
 			ret = 0;
 			goto cleanup;
 		case opt_profile:
-			if (profile != CKP_INVALID_ID) {
+			if (profile != CKA_INVALID) {
 				p11_message (_("multiple profiles specified"));
 				goto cleanup;
 			}
 
 			profile = p11_constant_resolve (profile_nicks, optarg);
-			if (profile == CKP_INVALID_ID)
+			if (profile == CKA_INVALID)
 				profile = strtol (optarg, NULL, 0);
-			if (profile == CKP_INVALID_ID) {
+			if (profile == 0) {
 				p11_message (_("failed to convert profile argument: %s"), optarg);
 				goto cleanup;
 			}
@@ -197,7 +198,7 @@ p11_kit_delete_profile (int argc,
 		goto cleanup;
 	}
 
-	if (profile == CKP_INVALID_ID) {
+	if (profile == CKA_INVALID) {
 		p11_message (_("no profile specified"));
 		goto cleanup;
 	}

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -146,6 +146,7 @@ if get_option('test')
 endif
 
 p11_kit_sources = [
+  'add-profile.c',
   'delete-profile.c',
   'list-profiles.c',
   'lists.c',

--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -65,6 +65,9 @@ int       p11_kit_list_modules    (int argc,
 int       p11_kit_list_profiles   (int argc,
                                    char *argv[]);
 
+int       p11_kit_add_profile     (int argc,
+                                   char *argv[]);
+
 int       p11_kit_delete_profile  (int argc,
                                    char *argv[]);
 
@@ -80,6 +83,7 @@ int       p11_kit_external        (int argc,
 static const p11_tool_command commands[] = {
 	{ "list-modules", p11_kit_list_modules, N_("List modules and tokens") },
 	{ "list-profiles", p11_kit_list_profiles, N_("List PKCS#11 profiles supported by the token") },
+	{ "add-profile", p11_kit_add_profile, N_("Add PKCS#11 profile to the token") },
 	{ "delete-profile", p11_kit_delete_profile, N_("Delete PKCS#11 profile from the token") },
 	{ "print-config", p11_kit_print_config, N_("Print merged configuration") },
 	{ "remote", p11_kit_external, N_("Run a specific PKCS#11 module remotely") },

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,5 +1,6 @@
 # List of source files which contain translatable strings.
 common/tool.c
+p11-kit/add-profile.c
 p11-kit/conf.c
 p11-kit/delete-profile.c
 p11-kit/filter.c


### PR DESCRIPTION
Adds the ability to add profile objects to given PKCS#11 token.

$ p11-kit add-profile --profile public-certificates-token 'pkcs11:token=MyToken'
