### PR TITLE
Fix memory leak inside p11_kit_remote_serve_tokens

### DIFF
--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -2761,7 +2761,7 @@ p11_kit_remote_serve_tokens (const char **tokens,
 				goto out;
 			}
 			p11_virtual_init (lower, &p11_virtual_base, module, NULL);
-			filter = p11_filter_subclass (lower, NULL);
+			filter = p11_filter_subclass (lower, free);
 			if (filter == NULL) {
 				error = EINVAL;
 				p11_message_err (error, "couldn't subclass filter");
@@ -2786,8 +2786,7 @@ p11_kit_remote_serve_tokens (const char **tokens,
 	filtered = p11_array_new ((p11_destroyer)module_unwrap);
 	p11_dict_iterate (filters, &filters_iter);
 	while (p11_dict_next (&filters_iter, NULL, &value)) {
-		module = p11_virtual_wrap ((p11_virtual *)value,
-					   (p11_destroyer)p11_virtual_uninit);
+		module = p11_virtual_wrap ((p11_virtual *)value, NULL);
 		if (module == NULL) {
 			error = EINVAL;
 			p11_message_err (error, "couldn't wrap filter module");


### PR DESCRIPTION
The address sanitizer reports a memory leak in the log when running test-server. At first I thought it was related to the test-server.sh failure but it didn't fix the test. The test-server.sh fails immediately after running p11tool and the log does not say anything.

This patch fixes the memory leak reported in the log even though the address sanitizer does not seem to care about it.

Closes #522 