### PR TITLE
Improve GNU/XSI strerror_r check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,19 +146,14 @@ if test "$os_unix" = "yes"; then
 
 	AC_CHECK_FUNC(
 		[strerror_r],
-		[AC_RUN_IFELSE(
-			[AC_LANG_SOURCE([[
-				#include <errno.h>
-				#include <string.h>
-
-				int main (void)
-				{
-					char buf[32];
-					return strerror_r (EINVAL, buf, 32);
-				}
-			]])],
-                        [AC_DEFINE([HAVE_XSI_STRERROR_R], 1, [Whether XSI-compliant strerror_r() is available])],
+		[AC_COMPILE_IFELSE(
+			[AC_LANG_PROGRAM([[#include <errno.h>
+					   #include <string.h>]],
+					 [[/* GNU strerror_r returns char *, XSI returns int */
+					    char buf[32];
+					    return *strerror_r (EINVAL, buf, 32);]])],
 			[AC_DEFINE([HAVE_GNU_STRERROR_R], 1, [Whether GNU-specific strerror_r() is available])],
+                        [AC_DEFINE([HAVE_XSI_STRERROR_R], 1, [Whether XSI-compliant strerror_r() is available])],
 			[])],
 		[])
 

--- a/meson.build
+++ b/meson.build
@@ -306,15 +306,15 @@ if cc.has_function('strerror_r', prefix: '#include <string.h>')
 
 int main (void)
 {
+    /* GNU strerror_r returns char *, XSI returns int */
     char buf[32];
-    return strerror_r (EINVAL, buf, 32);
+    return *strerror_r (EINVAL, buf, 32);
 }
 '''
-  strerror_r_check = cc.run(strerror_r_code, name : 'strerror_r check')
-  if strerror_r_check.returncode() == 0
-    conf.set('HAVE_XSI_STRERROR_R', 1)
-  else
+  if cc.compiles(strerror_r_code, name : 'GNU strerror_r check')
     conf.set('HAVE_GNU_STRERROR_R', 1)
+  else
+    conf.set('HAVE_XSI_STRERROR_R', 1)
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -301,6 +301,7 @@ endforeach
 
 if cc.has_function('strerror_r', prefix: '#include <string.h>')
   strerror_r_code = '''
+#define _GNU_SOURCE
 #include <errno.h>
 #include <string.h>
 


### PR DESCRIPTION
The new test that was added to distinguish GNU/XSI strerror_r ran a compiled program, which doesn't work when cross-compiling. The only difference at compile time is that the GNU version returns char * and the XSI version returns int, so detect it by compiling a program that dereferences the return value.

Testing this revealed that the autoconf and meson version of the checks produce different results, because the meson version doesn't define _GNU_SOURCE (even though the rest of the code is compiled with it) - the second commit fixes that.