### PR TITLE
p11-kit: extend the list-modules sub-command of p11-kit cmd tool to print URIs for modules and tokens

### DIFF
--- a/p11-kit/lists.c
+++ b/p11-kit/lists.c
@@ -269,7 +269,7 @@ p11_kit_list_modules (int argc,
 	};
 
 	p11_tool_desc usages[] = {
-		{ 0, "usage: p11-kit list" },
+		{ 0, "usage: p11-kit list-modules" },
 		{ opt_verbose, "show verbose debug output", },
 		{ opt_quiet, "suppress command output", },
 		{ 0 },


### PR DESCRIPTION
Adds URIs into list-modules command output.
```
$ p11-kit list-modules
module: ...
  uri: ...
  ...
  token: ...
    uri: ...
```