### PR TITLE
Add command to list objects of a token

### DIFF
--- a/bash-completion/p11-kit
+++ b/bash-completion/p11-kit
@@ -10,7 +10,7 @@ _p11-kit()
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     elif [[ $cword -eq 1 ]]; then
-        local commands='add-profile delete-profile list-profiles list-modules print-config extract server remote'
+        local commands='list-objects add-profile delete-profile list-profiles list-modules print-config extract server remote'
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     fi
 } &&

--- a/common/constants.c
+++ b/common/constants.c
@@ -138,6 +138,7 @@ const p11_constant p11_constant_types[] = {
 	CT (CKA_REQUIRED_CMS_ATTRIBUTES, "required-cms-attributes")
 	CT (CKA_DEFAULT_CMS_ATTRIBUTES, "default-cms-attributes")
 	CT (CKA_SUPPORTED_CMS_ATTRIBUTES, "supported-cms-attributes")
+	CT (CKA_PROFILE_ID, "profile-id")
 	CT (CKA_WRAP_TEMPLATE, "wrap-template")
 	CT (CKA_UNWRAP_TEMPLATE, "unwrap-template")
 	CT (CKA_ALLOWED_MECHANISMS, "allowed-mechanisms")
@@ -215,6 +216,7 @@ const p11_constant p11_constant_classes[] = {
 	CT (CKO_HW_FEATURE, "hw-feature")
 	CT (CKO_DOMAIN_PARAMETERS, "domain-parameters")
 	CT (CKO_MECHANISM, "mechanism")
+	CT (CKO_PROFILE, "profile")
 	CT (CKO_NSS_CRL, "nss-crl")
 	CT (CKO_NSS_SMIME, "nss-smime")
 	CT (CKO_NSS_TRUST, "nss-trust")
@@ -636,6 +638,14 @@ const p11_constant p11_constant_mechanisms[] = {
 	{ CKA_INVALID },
 };
 
+const p11_constant p11_constant_hw_features[] = {
+	CT (CKH_MONOTONIC_COUNTER, "monotonic-counter")
+	CT (CKH_CLOCK, "clock")
+	CT (CKH_USER_INTERFACE, "user-interface")
+	CT (CKH_VENDOR_DEFINED, "vendor-defined")
+	{ CKA_INVALID },
+};
+
 const p11_constant p11_constant_profiles[] = {
 	CT (CKP_BASELINE_PROVIDER, "baseline-provider")
 	CT (CKP_EXTENDED_PROVIDER, "extended-provider")
@@ -662,6 +672,7 @@ struct {
 	{ p11_constant_states, ELEMS (p11_constant_states) - 1 },
 	{ p11_constant_users, ELEMS (p11_constant_users) - 1 },
 	{ p11_constant_returns, ELEMS (p11_constant_returns) - 1 },
+	{ p11_constant_hw_features, ELEMS (p11_constant_hw_features) - 1 },
 	{ p11_constant_profiles, ELEMS (p11_constant_profiles) - 1 },
 };
 

--- a/common/constants.h
+++ b/common/constants.h
@@ -79,6 +79,8 @@ extern const p11_constant    p11_constant_users[];
 
 extern const p11_constant    p11_constant_returns[];
 
+extern const p11_constant    p11_constant_hw_features[];
+
 extern const p11_constant    p11_constant_profiles[];
 
 #endif /* P11_CONSTANTS_H_ */

--- a/common/test-constants.c
+++ b/common/test-constants.c
@@ -97,6 +97,7 @@ main (int argc,
 	p11_testx (test_constants, (void *)p11_constant_users, "/constants/users");
 	p11_testx (test_constants, (void *)p11_constant_states, "/constants/states");
 	p11_testx (test_constants, (void *)p11_constant_returns, "/constants/returns");
+	p11_testx (test_constants, (void *)p11_constant_hw_features, "/constants/hw-features");
 	p11_testx (test_constants, (void *)p11_constant_profiles, "/constants/profiles");
 
 	return p11_test_run (argc, argv);

--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -33,6 +33,9 @@
 		<command>p11-kit list-modules</command>
 	</cmdsynopsis>
 	<cmdsynopsis>
+		<command>p11-kit list-objects</command> ...
+	</cmdsynopsis>
+	<cmdsynopsis>
 		<command>p11-kit list-profiles</command> ...
 	</cmdsynopsis>
 	<cmdsynopsis>
@@ -87,6 +90,20 @@ $ p11-kit list-modules
 
 	<para>The modules, information about them and the tokens present in
 	the PKCS#11 modules will be displayed.</para>
+
+</refsect1>
+
+<refsect1 id="p11-kit-list-objects">
+	<title>List Objects</title>
+
+	<para>List objects of a token.</para>
+
+<programlisting>
+$ p11-kit list-objects pkcs11:token
+</programlisting>
+
+	<para>This retrieves all objects of the given token and displays
+	some of their common attributes.</para>
 
 </refsect1>
 

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -241,6 +241,7 @@ p11_kit_p11_kit_CFLAGS = $(COMMON_CFLAGS)
 p11_kit_p11_kit_SOURCES = \
 	p11-kit/add-profile.c \
 	p11-kit/delete-profile.c \
+	p11-kit/list-objects.c \
 	p11-kit/list-profiles.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \
@@ -263,6 +264,7 @@ check_PROGRAMS += p11-kit/p11-kit-testable
 p11_kit_p11_kit_testable_SOURCES = \
 	p11-kit/add-profile.c \
 	p11-kit/delete-profile.c \
+	p11-kit/list-objects.c \
 	p11-kit/list-profiles.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \

--- a/p11-kit/iter.h
+++ b/p11-kit/iter.h
@@ -73,6 +73,7 @@ typedef enum {
 	P11_KIT_ITER_WITH_SLOTS = 1 << 4,
 	P11_KIT_ITER_WITH_TOKENS = 1 << 5,
 	P11_KIT_ITER_WITHOUT_OBJECTS = 1 << 6,
+	P11_KIT_ITER_WITH_LOGIN = 1 << 7,
 } P11KitIterBehavior;
 
 typedef CK_RV      (* p11_kit_iter_callback)                (P11KitIter *iter,

--- a/p11-kit/list-objects.c
+++ b/p11-kit/list-objects.c
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include "constants.h"
+#include "debug.h"
+#include "iter.h"
+#include "message.h"
+#include "print.h"
+#include "tool.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
+
+int
+p11_kit_list_objects (int argc,
+		      char *argv[]);
+
+static inline void
+print_ulong_attribute (p11_list_printer *printer,
+		       CK_ATTRIBUTE attr,
+		       const p11_constant *constants)
+{
+	const char *type_str;
+	const char *value_str;
+
+	if (attr.ulValueLen == CK_UNAVAILABLE_INFORMATION)
+		return;
+
+	type_str = p11_constant_nick (p11_constant_types, attr.type);
+	if (type_str == NULL)
+		type_str = "(unknown)";
+
+	value_str = p11_constant_nick (constants, *((CK_ULONG *)attr.pValue));
+	if (value_str == NULL)
+		p11_list_printer_write_value (printer, type_str, "0x%lX (unknown)", attr.pValue);
+	else
+		p11_list_printer_write_value (printer, type_str, "%s", value_str);
+}
+
+static inline void
+print_string_attribute (p11_list_printer *printer,
+			CK_ATTRIBUTE attr)
+{
+	const char *type_str;
+
+	if (attr.ulValueLen == CK_UNAVAILABLE_INFORMATION)
+		return;
+
+	type_str = p11_constant_nick (p11_constant_types, attr.type);
+	if (type_str == NULL)
+		type_str = "(unknown)";
+
+	p11_list_printer_write_value (printer, type_str, "%s", attr.pValue);
+}
+
+static inline void
+print_date_attribute (p11_list_printer *printer,
+		      CK_ATTRIBUTE attr)
+{
+	const char *type_str;
+	char year[5] = { '\0' };
+	char month[3] = { '\0' };
+	char day[3] = { '\0' };
+
+	if (attr.ulValueLen == CK_UNAVAILABLE_INFORMATION)
+		return;
+
+	type_str = p11_constant_nick (p11_constant_types, attr.type);
+	if (type_str == NULL)
+		type_str = "(unknown)";
+
+	memcpy (year, ((CK_DATE *)attr.pValue)->year, 4);
+	memcpy (month, ((CK_DATE *)attr.pValue)->month, 2);
+	memcpy (day, ((CK_DATE *)attr.pValue)->day, 2);
+
+	p11_list_printer_write_value (printer, type_str, "%s.%s.%s", year, month, day);
+}
+
+static inline void
+print_bool_attribute (p11_list_printer *printer,
+		      CK_ATTRIBUTE attr)
+{
+	const char *type_str;
+
+	if (attr.ulValueLen == CK_UNAVAILABLE_INFORMATION)
+		return;
+
+	type_str = p11_constant_nick (p11_constant_types, attr.type);
+	if (type_str == NULL)
+		type_str = "(unknown)";
+
+	p11_list_printer_write_value (printer, type_str, "%s",
+				      *((CK_BBOOL *)attr.pValue) ? "true" : "false");
+}
+
+static void
+print_object (p11_list_printer *printer,
+	      P11KitIter *iter,
+	      size_t index)
+{
+	CK_OBJECT_CLASS klass;
+	CK_HW_FEATURE_TYPE hw_feature_type;
+	CK_KEY_TYPE key_type;
+	CK_PROFILE_ID profile_id;
+	CK_CERTIFICATE_TYPE cert_type;
+	CK_ULONG cert_category;
+	CK_MECHANISM_TYPE mechanism_type;
+	CK_BBOOL trusted, local, token, private, modifiable, copyable, destroyable;
+	CK_DATE start_date, end_date;
+	char label[128] = { '\0' };
+	char application[128] = { '\0' };
+	char id[128] = { '\0' };
+
+	CK_ATTRIBUTE attrs[] = {
+		/* ulong attributes */
+		{ CKA_CLASS, &klass, sizeof (klass) },
+		{ CKA_HW_FEATURE_TYPE, &hw_feature_type, sizeof (hw_feature_type) },
+		{ CKA_MECHANISM_TYPE, &mechanism_type, sizeof (mechanism_type) },
+		{ CKA_CERTIFICATE_TYPE, &cert_type, sizeof (cert_type) },
+		{ CKA_CERTIFICATE_CATEGORY, &cert_category, sizeof (cert_category) },
+		{ CKA_KEY_TYPE, &key_type, sizeof (key_type) },
+		{ CKA_PROFILE_ID, &profile_id, sizeof (profile_id) },
+		/* string attributes */
+		{ CKA_LABEL, label, sizeof (label) - 1 },
+		{ CKA_APPLICATION, application, sizeof (application) - 1 },
+		{ CKA_ID, id, sizeof (id) - 1 },
+		/* date attributes */
+		{ CKA_START_DATE, &start_date, sizeof (start_date) },
+		{ CKA_END_DATE, &end_date, sizeof (end_date) },
+		/* bool attributes */
+		{ CKA_TRUSTED, &trusted, sizeof (trusted) },
+		{ CKA_LOCAL, &local, sizeof (local) },
+		{ CKA_TOKEN, &token, sizeof (token) },
+		{ CKA_PRIVATE, &private, sizeof (private) },
+		{ CKA_MODIFIABLE, &modifiable, sizeof (modifiable) },
+		{ CKA_COPYABLE, &copyable, sizeof (copyable) },
+		{ CKA_DESTROYABLE, &destroyable, sizeof (destroyable) }
+	};
+	CK_ULONG n_attrs = sizeof (attrs) / sizeof (attrs[0]);
+
+	p11_kit_iter_get_attributes (iter, attrs, n_attrs);
+	p11_list_printer_start_section (printer, "Object", "#%lu", index);
+	print_ulong_attribute (printer, attrs[0], p11_constant_classes);
+	print_ulong_attribute (printer, attrs[1], p11_constant_hw_features);
+	print_ulong_attribute (printer, attrs[2], p11_constant_mechanisms);
+	print_ulong_attribute (printer, attrs[3], p11_constant_certs);
+	print_ulong_attribute (printer, attrs[4], p11_constant_categories);
+	print_ulong_attribute (printer, attrs[5], p11_constant_keys);
+	print_ulong_attribute (printer, attrs[6], p11_constant_profiles);
+	print_string_attribute (printer, attrs[7]);
+	print_string_attribute (printer, attrs[8]);
+	print_string_attribute (printer, attrs[9]);
+	print_date_attribute (printer, attrs[10]);
+	print_date_attribute (printer, attrs[11]);
+	print_bool_attribute (printer, attrs[12]);
+	print_bool_attribute (printer, attrs[13]);
+	print_bool_attribute (printer, attrs[14]);
+	print_bool_attribute (printer, attrs[15]);
+	print_bool_attribute (printer, attrs[16]);
+	print_bool_attribute (printer, attrs[17]);
+	print_bool_attribute (printer, attrs[18]);
+	p11_list_printer_end_section (printer);
+}
+
+static int
+list_objects (const char *token_str)
+{
+	int ret = 1;
+	size_t i;
+	CK_FUNCTION_LIST **modules = NULL;
+	P11KitUri *uri = NULL;
+	P11KitIter *iter = NULL;
+	p11_list_printer printer;
+
+	uri = p11_kit_uri_new ();
+	if (uri == NULL) {
+		p11_message (_("failed to allocate memory for URI"));
+		goto cleanup;
+	}
+
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
+		p11_message (_("failed to parse the token URI"));
+		goto cleanup;
+	}
+
+	modules = p11_kit_modules_load_and_initialize (0);
+	if (modules == NULL) {
+		p11_message (_("failed to load and initialize modules"));
+		goto cleanup;
+	}
+
+	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WITH_LOGIN);
+	if (iter == NULL) {
+		p11_message (_("failed to initialize iterator"));
+		goto cleanup;
+	}
+
+	p11_list_printer_init (&printer, stdout, 0);
+	p11_kit_iter_begin (iter, modules);
+	for (i = 0; p11_kit_iter_next (iter) == CKR_OK; ++i)
+		print_object (&printer, iter, i);
+
+	ret = 0;
+
+cleanup:
+	p11_kit_iter_free (iter);
+	p11_kit_modules_finalize (modules);
+	p11_kit_modules_release (modules);
+	p11_kit_uri_free (uri);
+
+	return ret;
+}
+
+int
+p11_kit_list_objects (int argc,
+		      char *argv[])
+{
+	int opt;
+
+	enum {
+		opt_verbose = 'v',
+		opt_quiet = 'q',
+		opt_help = 'h',
+	};
+
+	struct option options[] = {
+		{ "verbose", no_argument, NULL, opt_verbose },
+		{ "quiet", no_argument, NULL, opt_quiet },
+		{ "help", no_argument, NULL, opt_help },
+		{ 0 },
+	};
+
+	p11_tool_desc usages[] = {
+		{ 0, "usage: p11-kit list-objects pkcs11:token" },
+		{ 0 },
+	};
+
+	while ((opt = p11_tool_getopt (argc, argv, options)) != -1) {
+		switch (opt) {
+		case opt_verbose:
+			p11_kit_be_loud ();
+			break;
+		case opt_quiet:
+			p11_kit_be_quiet ();
+			break;
+		case opt_help:
+			p11_tool_usage (usages, options);
+			return 0;
+		case '?':
+			return 2;
+		default:
+			assert_not_reached ();
+			break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 1) {
+		p11_tool_usage (usages, options);
+		return 2;
+	}
+
+	return list_objects (*argv);
+}

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -148,6 +148,7 @@ endif
 p11_kit_sources = [
   'add-profile.c',
   'delete-profile.c',
+  'list-objects.c',
   'list-profiles.c',
   'lists.c',
   'p11-kit.c',

--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -62,6 +62,9 @@
 int       p11_kit_list_modules    (int argc,
                                    char *argv[]);
 
+int       p11_kit_list_objects    (int argc,
+                                   char *argv[]);
+
 int       p11_kit_list_profiles   (int argc,
                                    char *argv[]);
 
@@ -82,6 +85,7 @@ int       p11_kit_external        (int argc,
 
 static const p11_tool_command commands[] = {
 	{ "list-modules", p11_kit_list_modules, N_("List modules and tokens") },
+	{ "list-objects", p11_kit_list_objects, N_("List objects of a token") },
 	{ "list-profiles", p11_kit_list_profiles, N_("List PKCS#11 profiles supported by the token") },
 	{ "add-profile", p11_kit_add_profile, N_("Add PKCS#11 profile to the token") },
 	{ "delete-profile", p11_kit_delete_profile, N_("Delete PKCS#11 profile from the token") },

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,6 +4,7 @@ p11-kit/add-profile.c
 p11-kit/conf.c
 p11-kit/delete-profile.c
 p11-kit/filter.c
+p11-kit/list-objects.c
 p11-kit/list-profiles.c
 p11-kit/lists.c
 p11-kit/messages.c


### PR DESCRIPTION
The following is the example output from p11-kit list-objects:
`$ p11-kit list-objects 'pkcs11:token=MyToken'`
By default, the results would only contain objects visible without authentication. To start an authenticated session before listing, the pin-value attribute could be added to the PKCS#11 URI.
`$ p11-kit list-objects 'pkcs11:token=MyToken?pin-value=123456'`