### PR TITLE
Print CKA_ID in hexadecimal format

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -24,6 +24,7 @@ libp11_common_la_SOURCES = \
 	common/debug.c common/debug.h \
 	common/dict.c common/dict.h \
 	common/hash.c common/hash.h \
+	common/hex.c common/hex.h \
 	common/lexer.c common/lexer.h \
 	common/message.c common/message.h \
 	common/path.c common/path.h \

--- a/common/hex.c
+++ b/common/hex.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2011, Collabora Ltd.
  * Copyright (C) 2023 Red Hat Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,10 +29,13 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
  * DAMAGE.
+ *
+ * Author: Stef Walter <stefw@collabora.co.uk>, Daiki Ueno
  */
 
 #include "config.h"
 #include "hex.h"
+#include <stdint.h>
 #include <stdlib.h>
 
 static const char HEXC_LOWER[] = "0123456789abcdef";

--- a/common/hex.c
+++ b/common/hex.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Red Hat Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "config.h"
+#include "hex.h"
+#include <stdlib.h>
+
+static const char HEXC_LOWER[] = "0123456789abcdef";
+
+char *
+hex_encode (const unsigned char *data,
+            size_t n_data)
+{
+	char *result;
+	size_t i;
+	size_t o;
+
+	if ((SIZE_MAX - 1) / 3 < n_data)
+		return NULL;
+	result = malloc (n_data * 3 + 1);
+	if (result == NULL)
+		return NULL;
+
+	for (i = 0, o = 0; i < n_data; i++) {
+		if (i > 0)
+			result[o++] = ':';
+		result[o++] = HEXC_LOWER[data[i] >> 4 & 0xf];
+		result[o++] = HEXC_LOWER[data[i] & 0xf];
+	}
+
+	result[o] = 0;
+	return result;
+}

--- a/common/hex.h
+++ b/common/hex.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Red Hat Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef P11_HEX_H
+#define P11_HEX_H
+
+#include "compat.h"
+
+char *hex_encode (const unsigned char *data,
+		  size_t n_data);
+
+#endif /* P11_HEX_H */

--- a/common/hex.h
+++ b/common/hex.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2011, Collabora Ltd.
  * Copyright (c) 2023 Red Hat Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,12 +29,14 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
  * DAMAGE.
+ *
+ * Author: Stef Walter <stefw@collabora.co.uk>, Daiki Ueno
  */
 
 #ifndef P11_HEX_H
 #define P11_HEX_H
 
-#include "compat.h"
+#include <stddef.h>
 
 char *hex_encode (const unsigned char *data,
 		  size_t n_data);

--- a/common/meson.build
+++ b/common/meson.build
@@ -10,6 +10,7 @@ libp11_common_sources = [
   'debug.c',
   'dict.c',
   'hash.c',
+  'hex.c',
   'lexer.c',
   'message.c',
   'path.c',

--- a/p11-kit/list-objects.c
+++ b/p11-kit/list-objects.c
@@ -38,6 +38,7 @@
 
 #include "constants.h"
 #include "debug.h"
+#include "hex.h"
 #include "iter.h"
 #include "message.h"
 #include "print.h"
@@ -94,6 +95,25 @@ print_string_attribute (p11_list_printer *printer,
 		type_str = "(unknown)";
 
 	p11_list_printer_write_value (printer, type_str, "%s", attr.pValue);
+}
+
+static inline void
+print_byte_array_attribute (p11_list_printer *printer,
+			    CK_ATTRIBUTE attr)
+{
+	const char *type_str;
+	char *value;
+
+	if (attr.ulValueLen == CK_UNAVAILABLE_INFORMATION)
+		return;
+
+	type_str = p11_constant_nick (p11_constant_types, attr.type);
+	if (type_str == NULL)
+		type_str = "(unknown)";
+
+	value = hex_encode (attr.pValue, attr.ulValueLen);
+	p11_list_printer_write_value (printer, type_str, "%s", value);
+	free (value);
 }
 
 static inline void
@@ -166,6 +186,7 @@ print_object (p11_list_printer *printer,
 		/* string attributes */
 		{ CKA_LABEL, label, sizeof (label) - 1 },
 		{ CKA_APPLICATION, application, sizeof (application) - 1 },
+		/* byte array attributes */
 		{ CKA_ID, id, sizeof (id) - 1 },
 		/* date attributes */
 		{ CKA_START_DATE, &start_date, sizeof (start_date) },
@@ -192,7 +213,7 @@ print_object (p11_list_printer *printer,
 	print_ulong_attribute (printer, attrs[6], p11_constant_profiles);
 	print_string_attribute (printer, attrs[7]);
 	print_string_attribute (printer, attrs[8]);
-	print_string_attribute (printer, attrs[9]);
+	print_byte_array_attribute (printer, attrs[9]);
 	print_date_attribute (printer, attrs[10]);
 	print_date_attribute (printer, attrs[11]);
 	print_bool_attribute (printer, attrs[12]);

--- a/p11-kit/lists.c
+++ b/p11-kit/lists.c
@@ -36,6 +36,7 @@
 
 #include "compat.h"
 #include "debug.h"
+#include "hex.h"
 
 #include <assert.h>
 #include <ctype.h>
@@ -63,33 +64,6 @@ int p11_kit_list_modules (int argc,
                           char *argv[]);
 
 bool verbose = false;
-
-static const char HEXC_LOWER[] = "0123456789abcdef";
-
-static char *
-hex_encode (const unsigned char *data,
-            size_t n_data)
-{
-	char *result;
-	size_t i;
-	size_t o;
-
-	if ((SIZE_MAX - 1) / 3 < n_data)
-		return NULL;
-	result = malloc (n_data * 3 + 1);
-	if (result == NULL)
-		return NULL;
-
-	for (i = 0, o = 0; i < n_data; i++) {
-		if (i > 0)
-			result[o++] = ':';
-		result[o++] = HEXC_LOWER[data[i] >> 4 & 0xf];
-		result[o++] = HEXC_LOWER[data[i] & 0xf];
-	}
-
-	result[o] = 0;
-	return result;
-}
 
 static bool
 is_ascii_string (const unsigned char *data,


### PR DESCRIPTION
`p11-kit list-objects` currently prints CKA_ID in a binary form, which does not render correctly on terminal. This is to print the attribute in hexadecimal, as p11tool does.