### PR TITLE
Fix probing of C_GetInterface

### DIFF
--- a/p11-kit/modules.c
+++ b/p11-kit/modules.c
@@ -383,6 +383,12 @@ dlopen_and_get_function_list (Module *mod,
 	mod->loaded_module = dl;
 
 	gi = p11_dl_symbol (dl, "C_GetInterface");
+
+#ifndef OS_WIN32
+	if (gi == C_GetInterface)
+		gi = NULL;
+#endif
+
 	if (gi) {
 		/* Get the default standard interface */
 		rv = gi ((unsigned char *)"PKCS 11", NULL, &interface, 0);


### PR DESCRIPTION
`p11_dl_symbol (dl, "C_GetInterface")` uses dlsym() to find C_GetInterface in the loaded pkcs11 module.  For legacy (pre-3.0) pkcs11 modules, C_GetInterface is not defined in the module.  But according to the documentation of dlsym():

    The search performed by dlsym() is breadth first through the
    dependency tree of these shared objects.

So if a pkcs11 module links to libp11-kit.so, the C_GetInterface implementation in libp11-kit.so itself will be found.  This C_GetInterface will return the metadata of p11-kit-trust.so, causing "Refuse to load the p11-kit-proxy.so as a registered module".

To solve the issue, if p11_dl_symbol() returns the C_GetInterface in libp11-kit.so itself, we should ignore it and continue trying C_GetFunctionList.