### PR TITLE
Enable static compilation of libp11-kit

### DIFF
--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -63,20 +63,20 @@ libp11_kit_ldflags += cc.get_supported_link_arguments([
   '-Wl,-z,nodelete'
 ])
 
-libp11_kit = shared_library('p11-kit',
-                            libp11_kit_sources,
-                            install: true,
-                            version: library_version,
-                            soversion: soversion,
-                            dependencies: libffi_deps + dlopen_deps,
-                            include_directories: [configinc, commoninc],
-                            implicit_include_directories: false,
-                            c_args: libp11_kit_internal_c_args,
-                            link_args: libp11_kit_ldflags,
-                            link_depends: [libp11_kit_symbol_map,
-                                           libp11_kit_symbol_def],
-                            link_with: libp11_kit_internal,
-                            vs_module_defs: libp11_kit_symbol_def)
+libp11_kit = library('p11-kit',
+                     libp11_kit_sources,
+                     install: true,
+                     version: library_version,
+                     soversion: soversion,
+                     dependencies: libffi_deps + dlopen_deps,
+                     include_directories: [configinc, commoninc],
+                     implicit_include_directories: false,
+                     c_args: libp11_kit_internal_c_args,
+                     link_args: libp11_kit_ldflags,
+                     link_depends: [libp11_kit_symbol_map,
+                                    libp11_kit_symbol_def],
+                     link_with: libp11_kit_internal,
+                     vs_module_defs: libp11_kit_symbol_def)
 
 libp11_kit_dep = declare_dependency(link_with: libp11_kit,
                                     include_directories: [configinc, commoninc])


### PR DESCRIPTION
I'm not a meson expert, but this enables static compilation if using the `default_library` feature in meson, as documented [here](https://mesonbuild.com/Build-targets.html) and [here](https://mesonbuild.com/Build-targets.html).

```
meson --default-library=static _build 
meson compile -C _build
```

produces static library `_build/p11-kit/libp11-kit.a`

(for some reason, the first command cannot be `meson setup --default-library=static -C build` -- I don't understand how meson parses the default library args, but something's messed up there. anyway.)