### PR TITLE
common: Avoid naming clash on MinGW

### DIFF
--- a/common/pkcs11.h
+++ b/common/pkcs11.h
@@ -1442,7 +1442,7 @@ _CK_DECLARE_FUNCTION (C_GetInterfaceList,
 _CK_DECLARE_FUNCTION (C_GetInterface,
 		      (unsigned char *interface_name,
 		       struct ck_version *version,
-		       struct ck_interface **interface,
+		       struct ck_interface **interface_,
 		       ck_flags_t flags));
 
 _CK_DECLARE_FUNCTION (C_LoginUser,


### PR DESCRIPTION
The symbol "interface" is defined differently in a header included by default on MinGW, which prevents the use of it in a function signature in pkcs11.h.  To mitigate that, this renames it to "interface_".

In the source there are more places where "interface" is used, though it shouldn't be a problem as WIN32_LEAN_AND_MEAN is set in compat.h.

Fixes: #539 