### PR TITLE
Update pkcs11-json submodule

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -441,7 +441,8 @@ if not python_version.version_compare(python_version_req)
 endif
 
 pkcs11_json_project = subproject('pkcs11-json')
-pkcs11_json = pkcs11_json_project.get_variable('pkcs11_json')
+pkcs11_json_gen = pkcs11_json_project.get_variable('pkcs11_json_gen')
+pkcs11_json = pkcs11_json_gen.process('common/pkcs11.h')
 
 subdir('common')
 subdir('p11-kit')


### PR DESCRIPTION
This fixes the issue when running meson setup with "castxml" installed:
```console
  Executing subproject pkcs11-json

  pkcs11-json| Project name: pkcs11-json
  pkcs11-json| Project version: undefined
  pkcs11-json| Program castxml found: YES (/usr/bin/castxml)

  subprojects/pkcs11-json/meson.build:6:2: ERROR: Unknown variable "pkcs11_json_input".
```