### PR TITLE
list-modules: Do not embed module-name and module-path in URL

### DIFF
--- a/common/print.c
+++ b/common/print.c
@@ -176,9 +176,9 @@ p11_list_printer_write_array (p11_list_printer *printer,
 	print_indent (printer->fp, printer->depth);
 
 	if (printer->use_color) {
-		fprintf (printer->fp, "\033[0;1m%s\033[0m: \n", name);
+		fprintf (printer->fp, "\033[0;1m%s\033[0m:\n", name);
 	} else {
-		fprintf (printer->fp, "%s: \n", name);
+		fprintf (printer->fp, "%s:\n", name);
 	}
 
 	for (i = 0; i < array->num; i++) {

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -413,6 +413,7 @@ c_tests += test-server
 sh_tests += \
 	p11-kit/test-profiles.sh \
 	p11-kit/test-objects.sh \
+	p11-kit/test-lists.sh \
 	p11-kit/test-server.sh \
 	$(NULL)
 endif
@@ -593,6 +594,7 @@ EXTRA_DIST += \
 	p11-kit/test-transport-base.c \
 	p11-kit/test-profiles.sh \
 	p11-kit/test-objects.sh \
+	p11-kit/test-lists.sh \
 	p11-kit/test-messages.sh \
 	p11-kit/test-server.sh \
 	$(NULL)

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -390,6 +390,10 @@ if get_option('test')
          find_program('test-objects.sh'),
          env: p11_kit_tests_env)
 
+    test('test-lists.sh',
+         find_program('test-lists.sh'),
+         env: p11_kit_tests_env)
+
     test('test-messages.sh',
          find_program('test-messages.sh'),
          env: p11_kit_tests_env)

--- a/p11-kit/test-lists.sh
+++ b/p11-kit/test-lists.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+test "${abs_top_builddir+set}" = set || {
+	echo "set abs_top_builddir" 1>&2
+	exit 1
+}
+
+. "$abs_top_builddir/common/test-init.sh"
+
+setup() {
+	testdir=$PWD/test-objects-$$
+	test -d "$testdir" || mkdir "$testdir"
+	cd "$testdir"
+}
+
+teardown() {
+	rm -rf "$testdir"
+}
+
+test_list_modules() {
+	cat > list.exp <<EOF
+module: four
+    uri: pkcs11:library-description=MOCK%20LIBRARY;library-manufacturer=MOCK%20MANUFACTURER
+    library-description: MOCK LIBRARY
+    library-manufacturer: MOCK MANUFACTURER
+    library-version: 45.145
+    token: TEST LABEL
+        uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL
+        manufacturer: TEST MANUFACTURER
+        model: TEST MODEL
+        serial-number: TEST SERIAL
+        hardware-version: 75.175
+        firmware-version: 85.185
+        flags:
+              login-required
+              user-pin-initialized
+              clock-on-token
+              token-initialized
+module: eleven
+    uri: pkcs11:library-description=MOCK%20LIBRARY;library-manufacturer=MOCK%20MANUFACTURER
+    library-description: MOCK LIBRARY
+    library-manufacturer: MOCK MANUFACTURER
+    library-version: 45.145
+    token: TEST LABEL
+        uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL
+        manufacturer: TEST MANUFACTURER
+        model: TEST MODEL
+        serial-number: TEST SERIAL
+        hardware-version: 75.175
+        firmware-version: 85.185
+        flags:
+              login-required
+              user-pin-initialized
+              clock-on-token
+              token-initialized
+module: one
+    uri: pkcs11:library-description=MOCK%20LIBRARY;library-manufacturer=MOCK%20MANUFACTURER
+    library-description: MOCK LIBRARY
+    library-manufacturer: MOCK MANUFACTURER
+    library-version: 45.145
+    token: TEST LABEL
+        uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL
+        manufacturer: TEST MANUFACTURER
+        model: TEST MODEL
+        serial-number: TEST SERIAL
+        hardware-version: 75.175
+        firmware-version: 85.185
+        flags:
+              login-required
+              user-pin-initialized
+              clock-on-token
+              token-initialized
+module: two-duplicate
+    uri: pkcs11:library-description=MOCK%20LIBRARY;library-manufacturer=MOCK%20MANUFACTURER
+    library-description: MOCK LIBRARY
+    library-manufacturer: MOCK MANUFACTURER
+    library-version: 45.145
+    token: TEST LABEL
+        uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL
+        manufacturer: TEST MANUFACTURER
+        model: TEST MODEL
+        serial-number: TEST SERIAL
+        hardware-version: 75.175
+        firmware-version: 85.185
+        flags:
+              login-required
+              user-pin-initialized
+              clock-on-token
+              token-initialized
+EOF
+
+	# Since the path is absolute, it may contain user's current working
+	# directory; strip it before taking a diff.
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-modules -q | sed '/^ *path: /d' > list.out; then
+		assert_fail "unable to run: p11-kit list-modules"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains incorrect result"
+	fi
+}
+
+run test_list_modules

--- a/p11-kit/test-objects.sh
+++ b/p11-kit/test-objects.sh
@@ -90,7 +90,9 @@ Object: #14
     private: false
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:" > list.out; then
+		assert_fail "unable to run: p11-kit list-objects"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then
@@ -119,7 +121,9 @@ Object: #3
     label: TEST LABEL
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:type=data" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:type=data" > list.out; then
+		assert_fail "unable to run: p11-kit list-objects"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then
@@ -137,7 +141,9 @@ Object: #0
     label: TEST CERTIFICATE
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20CERTIFICATE;type=cert" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20CERTIFICATE;type=cert" > list.out; then
+		assert_fail "unable to run: p11-kit list-objects"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then
@@ -150,7 +156,9 @@ test_list_nonexistent() {
 	cat > list.exp <<EOF
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:model=NONEXISTENT" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:model=NONEXISTENT" > list.out; then
+		assert_fail "unable to run: p11-kit list-objects"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then
@@ -173,7 +181,9 @@ X4wmG2aWDmRSHACW+4F3ojodSQwD1RnyagEpMfv1
 -----END CERTIFICATE-----
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20CERTIFICATE;type=cert" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20CERTIFICATE;type=cert" > list.out; then
+		assert_fail "unable to run: p11-kit export-object"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then
@@ -191,7 +201,9 @@ Nkn3Eos8EiZByi9DVsyfy9eejh+8AXgp
 -----END PUBLIC KEY-----
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20PUBLIC%20KEY;type=public" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20PUBLIC%20KEY;type=public" > list.out; then
+		assert_fail "unable to run: p11-kit export-object"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then
@@ -204,7 +216,9 @@ test_generate_keypair() {
 	cat > list.exp <<EOF
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair -q --type=mock "pkcs11:" > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair -q --type=mock "pkcs11:" > list.out; then
+		assert_fail "unable to run: p11-kit generate-keypair"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then

--- a/p11-kit/test-profiles.sh
+++ b/p11-kit/test-profiles.sh
@@ -22,7 +22,9 @@ test_list_profiles() {
 public-certificates-token
 EOF
 
-	"$abs_top_builddir"/p11-kit/p11-kit-testable list-profiles -q pkcs11: > list.out
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-profiles -q pkcs11: > list.out; then
+		assert_fail "unable to run: p11-kit list-profiles"
+	fi
 
 	: ${DIFF=diff}
 	if ! ${DIFF} list.exp list.out > list.diff; then


### PR DESCRIPTION
module-name and module-path are query attributes, which are to modify
the default settings (RFC 7512 section 2.4).  As p11-kit manages the
default configuration, it shouldn't print them as part of the token
URL.  This instead prints the absolute path of each module in a
separate field of the output.
