### PR TITLE
Make delete-profile/object to match only one token

### DIFF
--- a/p11-kit/delete-object.c
+++ b/p11-kit/delete-object.c
@@ -88,10 +88,16 @@ delete_object (const char *token_str)
 	}
 
 	p11_kit_iter_begin (iter, modules);
-	while (p11_kit_iter_next (iter) == CKR_OK) {
-		rv = p11_kit_iter_destroy_object (iter);
-		if (rv != CKR_OK)
-			p11_message (_("failed to destroy an object: %s"), p11_kit_strerror (rv));
+	rv = p11_kit_iter_next (iter);
+	if (rv != CKR_OK) {
+		p11_message (_("failed to find the object: %s"), p11_kit_strerror (rv));
+		goto cleanup;
+	}
+
+	rv = p11_kit_iter_destroy_object (iter);
+	if (rv != CKR_OK) {
+		p11_message (_("failed to destroy an object: %s"), p11_kit_strerror (rv));
+		goto cleanup;
 	}
 
 	ret = 0;

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -80,7 +80,7 @@ delete_profile (const char *token_str,
 		goto cleanup;
 	}
 
-	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_OBJECT_ON_TOKEN, uri) != P11_KIT_URI_OK) {
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
 		p11_message (_("failed to parse URI"));
 		goto cleanup;
 	}

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -88,7 +88,7 @@ delete_profile (const char *token_str,
 		goto cleanup;
 	}
 
-	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WANT_WRITABLE);
+	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_LOGIN);
 	if (iter == NULL) {
 		p11_message (_("failed to initialize iterator"));
 		goto cleanup;

--- a/p11-kit/list-profiles.c
+++ b/p11-kit/list-profiles.c
@@ -76,7 +76,7 @@ list_profiles (const char *token_str)
 		goto cleanup;
 	}
 
-	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_OBJECT_ON_TOKEN, uri) != P11_KIT_URI_OK) {
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
 		p11_message (_("failed to parse URI"));
 		goto cleanup;
 	}

--- a/p11-kit/list-profiles.c
+++ b/p11-kit/list-profiles.c
@@ -87,7 +87,7 @@ list_profiles (const char *token_str)
 		goto cleanup;
 	}
 
-	iter = p11_kit_iter_new (uri, 0);
+	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WITH_LOGIN);
 	if (iter == NULL) {
 		p11_message (_("failed to initialize iterator"));
 		goto cleanup;


### PR DESCRIPTION
- delete-profile: we want to delete all matching profiles on the first matched token
- delete-object: we want to delete only the first matched object on the first matched token
- allow user to login in list-profiles and delete-profile