### PR TITLE
list-objects: nicer printing of flags

### DIFF
--- a/common/constants.c
+++ b/common/constants.c
@@ -114,6 +114,8 @@ const p11_constant p11_constant_types[] = {
 	CT (CKA_ALWAYS_SENSITIVE, "always-sensitive")
 	CT (CKA_KEY_GEN_MECHANISM, "key-gen-mechanism")
 	CT (CKA_MODIFIABLE, "modifiable")
+	CT (CKA_COPYABLE, "copyable")
+	CT (CKA_DESTROYABLE, "destroyable")
 	CT (CKA_ECDSA_PARAMS, "ecdsa-params")
 	/* CT (CKA_EC_PARAMS) */
 	CT (CKA_EC_POINT, "ec-point")

--- a/p11-kit/mock-module-ep9.c
+++ b/p11-kit/mock-module-ep9.c
@@ -48,6 +48,7 @@ override_initialize (CK_VOID_PTR init_args)
 	CK_OBJECT_CLASS cert_klass = CKO_CERTIFICATE;
 	char *cert_label = "TEST CERTIFICATE";
 	CK_CERTIFICATE_TYPE cert_type = CKC_X_509;
+	CK_BBOOL ck_true = CK_TRUE;
 	char cert_data[] = {
 		0x30, 0x82, 0x01, 0x6a, 0x30, 0x82, 0x01, 0x14, 0xa0, 0x03,
 		0x02, 0x01, 0x02, 0x02, 0x02, 0x03, 0xe7, 0x30, 0x0d, 0x06,
@@ -90,6 +91,9 @@ override_initialize (CK_VOID_PTR init_args)
 	CK_ATTRIBUTE cert_attrs[] = {
 		{ CKA_CLASS, &cert_klass, sizeof (cert_klass) },
 		{ CKA_LABEL, cert_label, strlen (cert_label) },
+		{ CKA_TRUSTED, &ck_true, sizeof (ck_true) },
+		{ CKA_COPYABLE, &ck_true, sizeof (ck_true) },
+		{ CKA_DESTROYABLE, &ck_true, sizeof (ck_true) },
 		{ CKA_CERTIFICATE_TYPE, &cert_type, sizeof (cert_type) },
 		{ CKA_VALUE, cert_data, sizeof (cert_data) },
 		{ CKA_INVALID, NULL, 0 },

--- a/p11-kit/test-objects.sh
+++ b/p11-kit/test-objects.sh
@@ -27,12 +27,10 @@ Object: #1
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20Capitalize%20Key;type=public
     class: public-key
     label: Public Capitalize Key
-    private: false
 Object: #2
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20prefix%20key;type=public
     class: public-key
     label: Public prefix key
-    private: false
 Object: #3
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20LABEL;type=data
     class: data
@@ -41,12 +39,10 @@ Object: #4
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20Capitalize%20Key;type=public
     class: public-key
     label: Public Capitalize Key
-    private: false
 Object: #5
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20prefix%20key;type=public
     class: public-key
     label: Public prefix key
-    private: false
 Object: #6
     class: profile
     profile-id: public-certificates-token
@@ -55,6 +51,10 @@ Object: #7
     class: certificate
     certificate-type: x-509
     label: TEST CERTIFICATE
+    flags:
+          trusted
+          copyable
+          destroyable
 Object: #8
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20PUBLIC%20KEY;type=public
     class: public-key
@@ -68,12 +68,10 @@ Object: #10
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20Capitalize%20Key;type=public
     class: public-key
     label: Public Capitalize Key
-    private: false
 Object: #11
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20prefix%20key;type=public
     class: public-key
     label: Public prefix key
-    private: false
 Object: #12
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20LABEL;type=data
     class: data
@@ -82,12 +80,10 @@ Object: #13
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20Capitalize%20Key;type=public
     class: public-key
     label: Public Capitalize Key
-    private: false
 Object: #14
     uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Public%20prefix%20key;type=public
     class: public-key
     label: Public prefix key
-    private: false
 EOF
 
 	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:" > list.out; then
@@ -139,6 +135,10 @@ Object: #0
     class: certificate
     certificate-type: x-509
     label: TEST CERTIFICATE
+    flags:
+          trusted
+          copyable
+          destroyable
 EOF
 
 	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=TEST%20CERTIFICATE;type=cert" > list.out; then


### PR DESCRIPTION
- make the printing of flag attributes nicer
- add missing flags into constants like copyable and destroyable

Closes #562 