### PR TITLE
p11-kit tool: make "no matching object/token" error user friendly 

### DIFF
--- a/common/test-init.sh.in
+++ b/common/test-init.sh.in
@@ -32,14 +32,14 @@ assert_fail()
 
 assert_contains()
 {
-	if ! grep -qF $2 $1; then
+	if ! grep -qF "$2" "$1"; then
 		assert_fail "$1 does not contain $2"
 	fi
 }
 
 assert_not_contains()
 {
-	if grep -qF $2 $1; then
+	if grep -qF "$2" "$1"; then
 		assert_fail "$1 contains $2"
 	fi
 }

--- a/p11-kit/add-profile.c
+++ b/p11-kit/add-profile.c
@@ -117,12 +117,7 @@ add_profile (const char *token_str,
 		p11_message (_("failed to obtain module"));
 		goto cleanup;
 	}
-
 	slot = p11_kit_iter_get_slot (iter);
-	if (slot == 0) {
-		p11_message (_("failed to obtain slot"));
-		goto cleanup;
-	}
 
 	rv = module->C_OpenSession (slot, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL, NULL, &session);
 	if (rv != CKR_OK) {

--- a/p11-kit/add-profile.c
+++ b/p11-kit/add-profile.c
@@ -108,7 +108,10 @@ add_profile (const char *token_str,
 	p11_kit_iter_begin (iter, modules);
 	rv = p11_kit_iter_next (iter);
 	if (rv != CKR_OK) {
-		p11_message (_("failed to find the token: %s"), p11_kit_strerror (rv));
+		if (rv == CKR_CANCEL)
+			p11_message (_("no matching token"));
+		else
+			p11_message (_("failed to find token: %s"), p11_kit_strerror (rv));
 		goto cleanup;
 	}
 

--- a/p11-kit/delete-object.c
+++ b/p11-kit/delete-object.c
@@ -90,7 +90,10 @@ delete_object (const char *token_str)
 	p11_kit_iter_begin (iter, modules);
 	rv = p11_kit_iter_next (iter);
 	if (rv != CKR_OK) {
-		p11_message (_("failed to find the object: %s"), p11_kit_strerror (rv));
+		if (rv == CKR_CANCEL)
+			p11_message (_("no matching object"));
+		else
+			p11_message (_("failed to find object: %s"), p11_kit_strerror (rv));
 		goto cleanup;
 	}
 

--- a/p11-kit/generate-keypair.c
+++ b/p11-kit/generate-keypair.c
@@ -301,12 +301,7 @@ generate_keypair (const char *token_str,
 		p11_message (_("failed to obtain module"));
 		goto cleanup;
 	}
-
 	slot = p11_kit_iter_get_slot (iter);
-	if (slot == 0) {
-		p11_message (_("failed to obtain slot"));
-		goto cleanup;
-	}
 
 	rv = module->C_OpenSession (slot, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL, NULL, &session);
 	if (rv != CKR_OK) {

--- a/p11-kit/generate-keypair.c
+++ b/p11-kit/generate-keypair.c
@@ -292,7 +292,10 @@ generate_keypair (const char *token_str,
 	p11_kit_iter_begin (iter, modules);
 	rv = p11_kit_iter_next (iter);
 	if (rv != CKR_OK) {
-		p11_message (_("failed to find the token: %s"), p11_kit_strerror (rv));
+		if (rv == CKR_CANCEL)
+			p11_message (_("no matching token"));
+		else
+			p11_message (_("failed to find token: %s"), p11_kit_strerror (rv));
 		goto cleanup;
 	}
 

--- a/p11-kit/test-objects.sh
+++ b/p11-kit/test-objects.sh
@@ -258,5 +258,38 @@ EOF
 	fi
 }
 
+test_generate_keypair_nonexistent_token() {
+	cat > list.exp <<EOF
+EOF
+
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --type=mock "pkcs11:token=NONEXISTENT" > list.out 2> err.out; then
+		assert_fail "expected to fail: p11-kit generate-keypair"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains wrong result"
+	fi
+	assert_contains err.out "no matching token"
+}
+
+test_delete_nonexistent_token() {
+	cat > list.exp <<EOF
+EOF
+
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable delete-object "pkcs11:token=NONEXISTENT" > list.out 2> err.out; then
+		assert_fail "expected to fail: p11-kit delete-object"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains wrong result"
+	fi
+	assert_contains err.out "no matching object"
+}
+
 run test_list_all test_list_with_type test_list_exact test_list_nonexistent \
-    test_export_cert test_export_pubkey test_generate_keypair
+    test_export_cert test_export_pubkey test_generate_keypair test_generate_keypair_nonexistent_token \
+    test_delete_nonexistent_token

--- a/p11-kit/test-profiles.sh
+++ b/p11-kit/test-profiles.sh
@@ -33,4 +33,21 @@ EOF
 	fi
 }
 
-run test_list_profiles
+test_add_profile_nonexistent_token() {
+	cat > list.exp <<EOF
+EOF
+
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable add-profile --profile=baseline-provider "pkcs11:token=NONEXISTENT" > list.out 2> err.out; then
+		assert_fail "expected to fail: p11-kit add-profile"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains wrong results"
+	fi
+	assert_contains err.out "no matching token"
+}
+
+run test_list_profiles \
+    test_add_profile_nonexistent_token


### PR DESCRIPTION
- don't check slot == 0 as 0 is a valid slot ID
-  make the error message human friendly when no token/object is matched

Closes #574 