### PR TITLE
p11-kit list-tokens: New subcommand

### DIFF
--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -33,6 +33,9 @@
 		<command>p11-kit list-modules</command>
 	</cmdsynopsis>
 	<cmdsynopsis>
+		<command>p11-kit list-tokens</command> ...
+	</cmdsynopsis>
+	<cmdsynopsis>
 		<command>p11-kit list-objects</command> ...
 	</cmdsynopsis>
 	<cmdsynopsis>
@@ -102,6 +105,22 @@ $ p11-kit list-modules
 
 	<para>The modules, information about them and the tokens present in
 	the PKCS#11 modules will be displayed.</para>
+
+</refsect1>
+
+<refsect1 id="p11-kit-list-tokens">
+	<title>List Tokens</title>
+
+	<para>List all tokens available in system configured PKCS#11 modules.</para>
+
+<programlisting>
+$ p11-kit list-tokens pkcs11:token
+$ p11-kit list-tokens --only-uris pkcs11:token
+</programlisting>
+
+	<para>This retrieves all tokens and displays some of their
+	common attributes. If <option>--only-uris</option> is given,
+	only the matching token URIs are printed.</para>
 
 </refsect1>
 

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -269,6 +269,7 @@ p11_kit_p11_kit_SOURCES = \
 	p11-kit/list-objects.c \
 	p11-kit/list-profiles.c \
 	p11-kit/list-mechanisms.c \
+	p11-kit/list-tokens.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \
 	p11-kit/print-config.c \
@@ -304,6 +305,7 @@ p11_kit_p11_kit_testable_SOURCES = \
 	p11-kit/list-objects.c \
 	p11-kit/list-profiles.c \
 	p11-kit/list-mechanisms.c \
+	p11-kit/list-tokens.c \
 	p11-kit/lists.c \
 	p11-kit/p11-kit.c \
 	p11-kit/print-config.c \
@@ -431,6 +433,7 @@ sh_tests += \
 	p11-kit/test-lists.sh \
 	p11-kit/test-server.sh \
 	p11-kit/test-list-mechanisms.sh \
+	p11-kit/test-list-tokens.sh \
 	$(NULL)
 
 if WITH_ASN1
@@ -635,6 +638,7 @@ EXTRA_DIST += \
 	p11-kit/test-lists.sh \
 	p11-kit/test-messages.sh \
 	p11-kit/test-server.sh \
+	p11-kit/test-list-tokens.sh \
 	p11-kit/test-export-public.sh \
 	p11-kit/test-list-mechanisms.sh \
 	$(NULL)

--- a/p11-kit/list-tokens.c
+++ b/p11-kit/list-tokens.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Daiki Ueno
+ */
+
+#include "config.h"
+
+#define P11_DEBUG_FLAG P11_DEBUG_TOOL
+#include "debug.h"
+#include "iter.h"
+#include "message.h"
+#include "print.h"
+#include "tool.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
+
+void  print_token_info    (p11_list_printer *printer,
+                           CK_TOKEN_INFO    *info);
+
+char *format_token_uri    (CK_TOKEN_INFO    *info);
+
+int   p11_kit_list_tokens (int               argc,
+                           char             *argv[]);
+
+static int
+list_tokens (const char *token_str,
+	     bool only_uris)
+{
+	int ret = 1;
+	CK_FUNCTION_LIST **modules = NULL;
+	P11KitUri *uri = NULL;
+	P11KitIter *iter = NULL;
+	p11_list_printer printer;
+
+	p11_list_printer_init (&printer, stdout, 0);
+
+	uri = p11_kit_uri_new ();
+	if (uri == NULL) {
+		p11_message (_("failed to allocate memory"));
+		goto cleanup;
+	}
+
+	if (p11_kit_uri_parse (token_str, P11_KIT_URI_FOR_TOKEN, uri) != P11_KIT_URI_OK) {
+		p11_message (_("failed to parse URI"));
+		goto cleanup;
+	}
+
+	modules = p11_kit_modules_load_and_initialize (0);
+	if (modules == NULL) {
+		p11_message (_("failed to load and initialize modules"));
+		goto cleanup;
+	}
+
+	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WITH_TOKENS |
+				 P11_KIT_ITER_WITHOUT_OBJECTS);
+	if (iter == NULL) {
+		p11_debug ("failed to initialize iterator");
+		goto cleanup;
+	}
+
+	p11_kit_iter_begin (iter, modules);
+	while (p11_kit_iter_next (iter) == CKR_OK) {
+		CK_TOKEN_INFO *info = p11_kit_iter_get_token (iter);
+		char *value;
+
+		if (only_uris) {
+			value = format_token_uri (info);
+			if (value)
+				printf ("%s\n", value);
+			free (value);
+		} else {
+			value = p11_kit_space_strdup (info->label, sizeof (info->label));
+			p11_list_printer_start_section (&printer, "token", "%s", value);
+			free (value);
+
+			print_token_info (&printer, info);
+			p11_list_printer_end_section (&printer);
+		}
+	}
+
+	ret = 0;
+
+cleanup:
+	p11_kit_iter_free (iter);
+	p11_kit_uri_free (uri);
+	if (modules != NULL)
+		p11_kit_modules_finalize_and_release (modules);
+
+	return ret;
+}
+
+int
+p11_kit_list_tokens (int argc,
+		     char *argv[])
+{
+	int opt;
+	bool only_uris = false;
+
+	enum {
+		opt_verbose = 'v',
+		opt_quiet = 'q',
+		opt_help = 'h',
+		opt_only_urls = CHAR_MAX + 1,
+	};
+
+	struct option options[] = {
+		{ "verbose", no_argument, NULL, opt_verbose },
+		{ "quiet", no_argument, NULL, opt_quiet },
+		{ "only-uris", no_argument, NULL, opt_only_urls },
+		{ "help", no_argument, NULL, opt_help },
+		{ 0 },
+	};
+
+	p11_tool_desc usages[] = {
+		{ 0, "usage: p11-kit list-tokens" },
+		{ opt_verbose, "show verbose debug output", },
+		{ opt_quiet, "suppress command output", },
+		{ opt_only_urls, "only print token URIs", },
+		{ 0 },
+	};
+
+	while ((opt = p11_tool_getopt (argc, argv, options)) != -1) {
+		switch (opt) {
+
+		case opt_verbose:
+			p11_kit_be_loud ();
+			break;
+
+		case opt_quiet:
+			p11_kit_be_quiet ();
+			break;
+
+		case opt_only_urls:
+			only_uris = true;
+			break;
+
+		case opt_help:
+			p11_tool_usage (usages, options);
+			return 0;
+		case '?':
+			return 2;
+		default:
+			assert_not_reached ();
+			break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 1) {
+		p11_tool_usage (usages, options);
+		return 2;
+	}
+
+	return list_tokens (*argv, only_uris);
+}

--- a/p11-kit/lists.c
+++ b/p11-kit/lists.c
@@ -80,7 +80,12 @@ is_ascii_string (const unsigned char *data,
 	return true;
 }
 
-static char *
+char *format_token_uri (CK_TOKEN_INFO    *info);
+
+void  print_token_info (p11_list_printer *printer,
+                        CK_TOKEN_INFO    *info);
+
+char *
 format_token_uri (CK_TOKEN_INFO *info)
 {
 	char *value;
@@ -105,7 +110,7 @@ format_token_uri (CK_TOKEN_INFO *info)
 	return value;
 }
 
-static void
+void
 print_token_info (p11_list_printer *printer,
 		  CK_TOKEN_INFO *info)
 {

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -218,6 +218,7 @@ p11_kit_sources = [
   'list-objects.c',
   'list-profiles.c',
   'list-mechanisms.c',
+  'list-tokens.c',
   'lists.c',
   'p11-kit.c',
   'print-config.c'
@@ -401,6 +402,10 @@ if get_option('test')
 
     test('test-list-mechanisms.sh',
          find_program('test-list-mechanisms.sh'),
+         env: p11_kit_tests_env)
+
+    test('test-list-tokens.sh',
+         find_program('test-list-tokens.sh'),
          env: p11_kit_tests_env)
   endif
 

--- a/p11-kit/p11-kit.c
+++ b/p11-kit/p11-kit.c
@@ -62,6 +62,9 @@
 int       p11_kit_list_modules     (int argc,
                                     char *argv[]);
 
+int       p11_kit_list_tokens      (int argc,
+                                    char *argv[]);
+
 int       p11_kit_list_objects     (int argc,
                                     char *argv[]);
 
@@ -97,6 +100,7 @@ int       p11_kit_external         (int argc,
 
 static const p11_tool_command commands[] = {
 	{ "list-modules", p11_kit_list_modules, N_("List modules and tokens") },
+	{ "list-tokens", p11_kit_list_tokens, N_("List tokens") },
 	{ "list-objects", p11_kit_list_objects, N_("List objects of a token") },
 	{ "export-object", p11_kit_export_object, N_("Export object matching PKCS#11 URI") },
 	{ "delete-object", p11_kit_delete_object, N_("Delete objects matching PKCS#11 URI") },

--- a/p11-kit/test-list-tokens.sh
+++ b/p11-kit/test-list-tokens.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# Test public key export from mock-twelve.so (mock-module-ep10.c).
+
+test "${abs_top_builddir+set}" = set || {
+	echo "set abs_top_builddir" 1>&2
+	exit 1
+}
+
+. "$abs_top_builddir/common/test-init.sh"
+
+setup() {
+	testdir=$PWD/test-objects-$$
+	test -d "$testdir" || mkdir "$testdir"
+	cd "$testdir"
+}
+
+teardown() {
+	rm -rf "$testdir"
+}
+
+test_list_tokens_without_uri() {
+	cat > list.exp <<EOF
+usage: p11-kit list-tokens
+
+  -v, --verbose       show verbose debug output
+  -q, --quiet         suppress command output
+  --only-uris         only print token URIs
+EOF
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable list-tokens -q 2>&1 > list.out; then
+		assert_fail "p11-kit list-tokens succeeded without token URI"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains incorrect result"
+	fi
+}
+
+test_list_tokens() {
+	cat > list.exp <<EOF
+token: PUBKEY LABEL
+    uri: pkcs11:model=PUBKEY%20MODEL;manufacturer=PUBKEY%20MANUFACTURER;serial=PUBKEY%20SERIAL;token=PUBKEY%20LABEL
+    manufacturer: PUBKEY MANUFACTURER
+    model: PUBKEY MODEL
+    serial-number: PUBKEY SERIAL
+    hardware-version: 75.175
+    firmware-version: 85.185
+    flags:
+          login-required
+          user-pin-initialized
+          clock-on-token
+          token-initialized
+EOF
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-tokens -q "pkcs11:model=PUBKEY%20MODEL" > list.out; then
+		assert_fail "unable to run: p11-kit list-tokens"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains incorrect result"
+	fi
+}
+
+test_list_tokens_only_uris() {
+	cat > list.exp <<EOF
+pkcs11:model=PUBKEY%20MODEL;manufacturer=PUBKEY%20MANUFACTURER;serial=PUBKEY%20SERIAL;token=PUBKEY%20LABEL
+EOF
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-tokens -q --only-uris "pkcs11:model=PUBKEY%20MODEL" > list.out; then
+		assert_fail "unable to run: p11-kit list-tokens --only-uris"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains incorrect result"
+	fi
+}
+
+run test_list_tokens_without_uri test_list_tokens test_list_tokens_only_uris


### PR DESCRIPTION
This adds a new subcommand "list-tokens" to the p11-kit command, which
is similar to "list-modules" but only prints tokens.  This would make
scripting tasks easier.

Fixes: #554