### PR TITLE
p11-kit generate-keypair: Support EdDSA key generation

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,9 +1,9 @@
-FROM fedora:34
+FROM fedora:38
 
 MAINTAINER Daiki Ueno <ueno@gnu.org>
 
 RUN dnf -y update
 RUN dnf -y install 'dnf-command(builddep)'
 RUN dnf -y builddep 'p11-kit'
-RUN dnf install -y gettext-devel git libtool make opensc openssl valgrind meson ninja-build bash-completion lcov python-pip libasan libubsan clang-analyzer mingw64-gcc mingw64-libffi mingw64-libtasn1 wine cppcheck gnutls-utils
+RUN dnf install -y gettext-devel git libtool make opensc openssl valgrind meson ninja-build bash-completion lcov python-pip libasan libubsan clang-analyzer mingw64-gcc mingw64-libffi mingw64-libtasn1 wine cppcheck gnutls-utils p11-kit-devel softhsm
 RUN dnf clean all

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -434,6 +434,7 @@ sh_tests += \
 	p11-kit/test-server.sh \
 	p11-kit/test-list-mechanisms.sh \
 	p11-kit/test-list-tokens.sh \
+	p11-kit/test-generate-keypair.sh \
 	$(NULL)
 
 if WITH_ASN1
@@ -641,4 +642,5 @@ EXTRA_DIST += \
 	p11-kit/test-list-tokens.sh \
 	p11-kit/test-export-public.sh \
 	p11-kit/test-list-mechanisms.sh \
+	p11-kit/test-generate-keypair.sh \
 	$(NULL)

--- a/p11-kit/fixtures/package-modules/softhsm2.module
+++ b/p11-kit/fixtures/package-modules/softhsm2.module
@@ -1,0 +1,4 @@
+
+module: libsofthsm2.so
+managed: yes
+enable-in: p11-kit-testable

--- a/p11-kit/generate-keypair.c
+++ b/p11-kit/generate-keypair.c
@@ -80,7 +80,8 @@ get_mechanism (const char *type)
 		m.mechanism = CKM_RSA_PKCS_KEY_PAIR_GEN;
 	else if (p11_ascii_strcaseeq (type, "ecdsa"))
 		m.mechanism = CKM_ECDSA_KEY_PAIR_GEN;
-	else if (p11_ascii_strcaseeq (type, "ed25519"))
+	else if (p11_ascii_strcaseeq (type, "ed25519") ||
+		 p11_ascii_strcaseeq (type, "ed448"))
 		m.mechanism = CKM_EC_EDWARDS_KEY_PAIR_GEN;
 
 	return m;
@@ -93,6 +94,8 @@ get_ec_params (const char *curve,
 	static const uint8_t OID_SECP256R1[] = { 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
 	static const uint8_t OID_SECP384R1[] = { 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x22 };
 	static const uint8_t OID_SECP521R1[] = { 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x23 };
+	static const uint8_t OID_ED25519[] = { 0x06, 0x03, 0x2b, 0x65, 0x70 };
+	static const uint8_t OID_ED448[] = { 0x06, 0x03, 0x2b, 0x65, 0x71 };
 
 	if (p11_ascii_strcaseeq (curve, "secp256r1")) {
 		*ec_params_len = sizeof (OID_SECP256R1);
@@ -103,6 +106,12 @@ get_ec_params (const char *curve,
 	} else if (p11_ascii_strcaseeq (curve, "secp521r1")) {
 		*ec_params_len = sizeof (OID_SECP521R1);
 		return OID_SECP521R1;
+	} else if (p11_ascii_strcaseeq (curve, "ed25519")) {
+		*ec_params_len = sizeof (OID_ED25519);
+		return OID_ED25519;
+	} else if (p11_ascii_strcaseeq (curve, "ed448")) {
+		*ec_params_len = sizeof (OID_ED448);
+		return OID_ED448;
 	}
 
 	return NULL;

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -407,6 +407,10 @@ if get_option('test')
     test('test-list-tokens.sh',
          find_program('test-list-tokens.sh'),
          env: p11_kit_tests_env)
+
+    test('test-generate-keypair.sh',
+         find_program('test-generate-keypair.sh'),
+         env: p11_kit_tests_env)
   endif
 
   if with_asn1 and host_system != 'windows'

--- a/p11-kit/test-generate-keypair.sh
+++ b/p11-kit/test-generate-keypair.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+test "${abs_top_builddir+set}" = set || {
+	echo "set abs_top_builddir" 1>&2
+	exit 1
+}
+
+. "$abs_top_builddir/common/test-init.sh"
+
+: ${P11_MODULE_PATH="$abs_top_builddir"/.libs}
+
+setup() {
+	testdir=$PWD/test-objects-$$
+	test -d "$testdir" || mkdir "$testdir"
+	cd "$testdir"
+	mkdir tokens
+	cat > softhsm2.conf <<EOF
+directories.tokendir = $PWD/tokens/
+EOF
+	export SOFTHSM2_CONF=$PWD/softhsm2.conf
+
+	: ${SOFTHSM2_UTIL=softhsm2-util}
+	if ! "$SOFTHSM2_UTIL" --version >/dev/null; then
+		skip "softhsm2-util not found"
+		return
+	fi
+	softhsm2-util --init-token --free --label test-genkey --so-pin 12345 --pin 12345
+
+	: ${PKG_CONFIG=pkg-config}
+	if ! "$PKG_CONFIG" p11-kit-1 --exists; then
+		skip "pkgconfig(p11-kit-1) not found"
+		return
+	fi
+
+	module_path=$("$PKG_CONFIG" p11-kit-1 --variable=p11_module_path)
+	if ! test -e "$module_path/libsofthsm2.so"; then
+		skip "unable to resolve libsofthsm2.so"
+		return
+	fi
+
+	ln -sf "$module_path"/libsofthsm2.so "$P11_MODULE_PATH"
+}
+
+teardown() {
+	unset SOFTHSM2_CONF
+	rm -rf "$testdir"
+}
+
+test_generate_keypair_rsa() {
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label=rsa --type=rsa --bits=2048 "pkcs11:token=test-genkey?pin-value=12345"; then
+		assert_fail "unable to run: p11-kit generate-keypair"
+	fi
+}
+
+test_generate_keypair_ecdsa() {
+	for curve in secp256r1 secp384r1 secp521r1; do
+		if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="ecdsa-$curve" --type=ecdsa --curve="$curve" "pkcs11:token=test-genkey?pin-value=12345"; then
+			assert_fail "unable to run: p11-kit generate-keypair"
+		fi
+	done
+
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="ecdsa-unknown" --type=ecdsa --curve=unknown "pkcs11:token=test-genkey?pin-value=12345"; then
+		assert_fail "p11-kit generate-keypair succeeded for unknown ecdsa curve"
+	fi
+}
+
+test_generate_keypair_eddsa() {
+	curves=
+	mech=$("$abs_top_builddir"/p11-kit/p11-kit-testable list-mechanisms "pkcs11:token=test-genkey" | sed -n '/CKM_EDDSA/p')
+	if test -z "$mech"; then
+		skip "no support for EdDSA"
+		return
+	fi
+	if expr "$mech" : ".*key-size=256-" > /dev/null; then
+		curve="$curve ed25519"
+	fi
+	if expr "$mech" : ".*key-size=.*-456" > /dev/null; then
+		curve="$curve ed448"
+	fi
+	for curve in $curves; do
+		if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="eddsa-$curve" --type=eddsa --curve="$curve" "pkcs11:token=test-genkey?pin-value=12345"; then
+			assert_fail "unable to run: p11-kit generate-keypair"
+		fi
+	done
+
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="eddsa-unknown" --type=eddsa --curve=unknown "pkcs11:token=test-genkey?pin-value=12345"; then
+		assert_fail "p11-kit generate-keypair succeeded for unknown eddsa curve"
+	fi
+}
+
+run test_generate_keypair_rsa test_generate_keypair_ecdsa \
+    test_generate_keypair_ecdsa

--- a/p11-kit/test-server.sh
+++ b/p11-kit/test-server.sh
@@ -58,6 +58,7 @@ test_server_access() {
 		fi
 	else
 		skip "p11tool not found"
+		return
 	fi
 
 	"$abs_top_builddir"/p11-kit/p11-kit-server-testable -s -k > stop.env 2> stop.err


### PR DESCRIPTION
Also add tests for the p11-kit generate-keypair command using SoftHSM2.