### PR TITLE
Fix CI warnings and errors

### DIFF
--- a/.github/actions/basic-meson/action.yaml
+++ b/.github/actions/basic-meson/action.yaml
@@ -10,7 +10,7 @@ runs:
 
     - name: Setup
       run: |
-        $GITHUB_WORKSPACE/build/run-wrapper.sh meson $GITHUB_WORKSPACE/$BUILDDIR -Dstrict=true -Dprefix=$GITHUB_WORKSPACE/$INSTALLDIR -Dlibdir=$GITHUB_WORKSPACE/$INSTALLDIR/lib -Dsysconfdir=$GITHUB_WORKSPACE/$INSTALLDIR/etc -Dtrust_paths=$GITHUB_WORKSPACE/$INSTALLDIR/etc/pki/ca-trust-source:$GITHUB_WORKSPACE/$INSTALLDIR/share/pki/ca-trust-source -Dsystemd=disabled -Dbash_completion=disabled $MESON_BUILD_OPTS
+        $GITHUB_WORKSPACE/build/run-wrapper.sh meson setup $GITHUB_WORKSPACE/$BUILDDIR -Dstrict=true -Dprefix=$GITHUB_WORKSPACE/$INSTALLDIR -Dlibdir=$GITHUB_WORKSPACE/$INSTALLDIR/lib -Dsysconfdir=$GITHUB_WORKSPACE/$INSTALLDIR/etc -Dtrust_paths=$GITHUB_WORKSPACE/$INSTALLDIR/etc/pki/ca-trust-source:$GITHUB_WORKSPACE/$INSTALLDIR/share/pki/ca-trust-source -Dsystemd=disabled -Dbash_completion=disabled $MESON_BUILD_OPTS
       shell: bash
 
     - name: Build (scan-build)

--- a/build/cross_file_mingw64.txt
+++ b/build/cross_file_mingw64.txt
@@ -4,7 +4,7 @@ cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
 
-[properties]
+[built-in options]
 c_args = ['-fstack-protector']
 c_link_args = ['-fstack-protector']
 

--- a/common/compat.c
+++ b/common/compat.c
@@ -322,15 +322,18 @@ char *
 p11_dl_error (void)
 {
 	DWORD code = GetLastError();
-	LPVOID msg_buf;
+	LPVOID msg_buf = NULL;
 	char *result;
 
 	FormatMessageA (FORMAT_MESSAGE_ALLOCATE_BUFFER |
-	                FORMAT_MESSAGE_FROM_SYSTEM |
-	                FORMAT_MESSAGE_IGNORE_INSERTS,
-	                NULL, code,
-	                MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT),
-	                (LPSTR)&msg_buf, 0, NULL);
+			FORMAT_MESSAGE_FROM_SYSTEM |
+			FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, code,
+			MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT),
+			(LPSTR)&msg_buf, 0, NULL);
+
+	if (msg_buf == NULL);
+		return NULL;
 
 	result = strdup (msg_buf);
 	LocalFree (msg_buf);

--- a/common/test-hash.c
+++ b/common/test-hash.c
@@ -50,12 +50,12 @@ test_murmur3 (void)
 
 	assert (sizeof (one) == P11_HASH_MURMUR3_LEN);
 
-	p11_hash_murmur3 ((unsigned char *)&one, "one", 3, NULL);
-	p11_hash_murmur3 ((unsigned char *)&two, "two", 3, NULL);
-	p11_hash_murmur3 ((unsigned char *)&four, "four", 4, NULL);
-	p11_hash_murmur3 ((unsigned char *)&seven, "seven", 5, NULL);
-	p11_hash_murmur3 ((unsigned char *)&eleven, "eleven", 6, NULL);
-	p11_hash_murmur3 ((unsigned char *)&split, "ele", 3, "ven", 3, NULL);
+	p11_hash_murmur3 ((unsigned char *)&one, "one", (size_t)3, NULL);
+	p11_hash_murmur3 ((unsigned char *)&two, "two", (size_t)3, NULL);
+	p11_hash_murmur3 ((unsigned char *)&four, "four", (size_t)4, NULL);
+	p11_hash_murmur3 ((unsigned char *)&seven, "seven", (size_t)5, NULL);
+	p11_hash_murmur3 ((unsigned char *)&eleven, "eleven", (size_t)6, NULL);
+	p11_hash_murmur3 ((unsigned char *)&split, "ele", (size_t)3, "ven", (size_t)3, NULL);
 
 	assert (one != two);
 	assert (one != four);

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -1207,7 +1207,7 @@ p11_rpc_buffer_get_date_value (p11_buffer *buffer,
 			       void *value,
 			       CK_ULONG *value_length)
 {
-	CK_DATE date_value;
+	CK_DATE date_value = { 0 };
 	const unsigned char *array;
 	size_t array_length;
 
@@ -1540,13 +1540,13 @@ p11_rpc_buffer_get_ibm_attrbound_wrap_mechanism_value (p11_buffer *buffer,
 						       void *value,
 						       CK_ULONG *value_length)
 {
-	uint64_t val;
+	uint64_t val = 0;
 
 	if (!p11_rpc_buffer_get_uint64 (buffer, offset, &val))
 		return false;
 
 	if (value) {
-		CK_IBM_ATTRIBUTEBOUND_WRAP_PARAMS params;
+		CK_IBM_ATTRIBUTEBOUND_WRAP_PARAMS params = { 0 };
 
 		params.hSignVerifyKey = val;
 

--- a/p11-kit/test-iter.c
+++ b/p11-kit/test-iter.c
@@ -91,7 +91,7 @@ has_handle (CK_ULONG *objects,
 static void
 test_all (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_FUNCTION_LIST_PTR *modules;
 	CK_FUNCTION_LIST_PTR module;
 	CK_SESSION_HANDLE session;
@@ -179,7 +179,7 @@ on_iter_callback (P11KitIter *iter,
 static void
 test_callback (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_FUNCTION_LIST_PTR *modules;
 	P11KitIter *iter;
 	CK_RV rv;
@@ -273,7 +273,7 @@ test_callback_destroyer (void)
 static void
 test_with_session (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_SESSION_HANDLE session;
 	CK_FUNCTION_LIST_PTR module;
 	CK_SLOT_ID slot;
@@ -331,7 +331,7 @@ test_with_session (void)
 static void
 test_with_slot (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_FUNCTION_LIST_PTR module;
 	CK_SLOT_ID slot;
 	P11KitIter *iter;
@@ -379,7 +379,7 @@ test_with_slot (void)
 static void
 test_with_module (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_FUNCTION_LIST_PTR module;
 	P11KitIter *iter;
 	CK_RV rv;
@@ -483,7 +483,7 @@ test_unrecognized (void)
 static void
 test_uri_with_type (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_FUNCTION_LIST_PTR *modules;
 	P11KitIter *iter;
 	P11KitUri *uri;
@@ -556,7 +556,7 @@ test_set_uri (void)
 static void
 test_filter (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_FUNCTION_LIST_PTR *modules;
 	P11KitIter *iter;
 	CK_RV rv;
@@ -1625,7 +1625,7 @@ test_exhaustive_match (void)
 static void
 test_profile (void)
 {
-	CK_OBJECT_HANDLE objects[128];
+	CK_OBJECT_HANDLE objects[128] = { 0 };
 	CK_SESSION_HANDLE session;
 	CK_FUNCTION_LIST_PTR module;
 	CK_SLOT_ID slot;

--- a/p11-kit/test-mock.c
+++ b/p11-kit/test-mock.c
@@ -509,8 +509,8 @@ test_get_attribute_value (void)
 	CK_FUNCTION_LIST_PTR module;
 	CK_SESSION_HANDLE session = 0;
 	CK_ATTRIBUTE attrs[8];
-	char label[32];
-	CK_OBJECT_CLASS klass;
+	char label[32] = { '\0' };
+	CK_OBJECT_CLASS klass = -1ul;
 	CK_RV rv;
 
 	module = setup_mock_module (&session);
@@ -711,7 +711,7 @@ test_copy_object (void)
 	CK_SESSION_HANDLE session = 0;
 	CK_OBJECT_HANDLE object;
 	CK_ATTRIBUTE attrs[8];
-	char label[32];
+	char label[32] = { '\0' };
 	CK_ULONG bits;
 	CK_RV rv;
 
@@ -751,7 +751,7 @@ test_copy_object_private (void)
 	CK_SESSION_HANDLE session = 0;
 	CK_OBJECT_HANDLE object;
 	CK_ATTRIBUTE attrs[8];
-	char label[32];
+	char label[32] = { '\0' };
 	CK_ULONG bits;
 	CK_RV rv;
 
@@ -1619,7 +1619,7 @@ test_generate_key (void)
 	CK_MECHANISM mech = { CKM_MOCK_GENERATE, NULL, 0 };
 	CK_ATTRIBUTE attrs[8];
 	char label[32];
-	char value[64];
+	char value[64] = { '\0' };
 	CK_ULONG bits;
 	CK_RV rv;
 
@@ -1674,9 +1674,9 @@ test_generate_key_pair (void)
 	CK_ATTRIBUTE pub_attrs[8];
 	CK_ATTRIBUTE priv_attrs[8];
 	char pub_label[32];
-	char pub_value[64];
+	char pub_value[64] = { '\0' };
 	char priv_label[32];
-	char priv_value[64];
+	char priv_value[64] = { '\0' };
 	CK_ULONG pub_bits;
 	CK_ULONG priv_bits;
 	CK_RV rv;
@@ -1797,7 +1797,7 @@ test_unwrap_key (void)
 	CK_MECHANISM mech = { CKM_MOCK_WRAP, NULL, 0 };
 	CK_ATTRIBUTE attrs[8];
 	char label[32];
-	char value[64];
+	char value[64] = { '\0' };
 	CK_ULONG bits;
 	CK_RV rv;
 
@@ -1852,7 +1852,7 @@ test_derive_key (void)
 	CK_MECHANISM mech = { CKM_MOCK_DERIVE, NULL, 0 };
 	CK_ATTRIBUTE attrs[8];
 	char label[32];
-	char value[64];
+	char value[64] = { '\0' };
 	CK_ULONG bits;
 	CK_RV rv;
 


### PR DESCRIPTION
The numeric values that were passed into `p11_hash_murmur3`, a variable argument function, were smaller then `size_t` which resulted in a memory access error when they were read inside the function as variable argument of length `size_t` .
Other then that, this MR fixes some deprecated meson usage.