### PR TITLE
p11-kit commands: Add --login option

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -55,6 +55,12 @@ if !OS_WIN32
 libp11_tool_la_SOURCES += \
 	common/unix-peer.c common/unix-peer.h \
 	$(NULL)
+
+if NEED_READPASSPHRASE
+libp11_tool_la_SOURCES += \
+	common/readpassphrase.c \
+	$(NULL)
+endif
 endif
 
 # Tests ----------------------------------------------------------------

--- a/common/compat.h
+++ b/common/compat.h
@@ -381,6 +381,27 @@ int        isatty           (int fd);
 
 #endif /* HAVE_ISATTY */
 
+#ifdef HAVE_READPASSPHRASE
+
+#include <readpassphrase.h>
+
+#else
+
+#define RPP_ECHO_OFF    0x00		/* Turn off echo (default). */
+#define RPP_ECHO_ON     0x01		/* Leave echo on. */
+#define RPP_REQUIRE_TTY 0x02		/* Fail if there is no tty. */
+#define RPP_FORCELOWER  0x04		/* Force input to lower case. */
+#define RPP_FORCEUPPER  0x08		/* Force input to upper case. */
+#define RPP_SEVENBIT    0x10		/* Strip the high bit from input. */
+#define RPP_STDIN       0x20		/* Read from stdin, not /dev/tty */
+
+char      *readpassphrase   (const char *prompt,
+                             char *buf,
+                             size_t bufsiz,
+                             int flags);
+
+#endif /* HAVE_READPASSPHRASE */
+
 /* If either locale_t or newlocale() is not available, strerror_l()
  * cannot be used */
 #if !defined(HAVE_LOCALE_T) || !defined(HAVE_NEWLOCALE)

--- a/common/meson.build
+++ b/common/meson.build
@@ -58,6 +58,16 @@ libp11_tool_sources = [
 
 if host_system != 'windows'
   libp11_tool_sources += ['unix-peer.c', 'unix-peer.h']
+
+  rpl_functions = [
+    'readpassphrase',
+  ]
+
+  foreach f : rpl_functions
+    if not cc.has_function(f)
+      libp11_tool_sources += '@0@.c'.format(f)
+    endif
+  endforeach
 endif
 
 libp11_tool = static_library('p11-tool', libp11_tool_sources,

--- a/common/readpassphrase.c
+++ b/common/readpassphrase.c
@@ -1,0 +1,208 @@
+/*	$OpenBSD: readpassphrase.c,v 1.26 2016/10/18 12:47:18 millert Exp $	*/
+
+/*
+ * Copyright (c) 2000-2002, 2007, 2010
+ *	Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+
+#include "compat.h"
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <paths.h>
+#include <pwd.h>
+#include <signal.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+#ifndef TCSASOFT
+#define TCSASOFT 0
+#endif
+
+#ifndef _NSIG
+#if defined(NSIG)
+#define _NSIG NSIG
+#else
+/* The SIGRTMAX define might be set to a function such as sysconf(). */
+#define _NSIG (SIGRTMAX + 1)
+#endif
+#endif
+
+static volatile sig_atomic_t signo[_NSIG];
+
+static void handler(int);
+
+char *
+readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)
+{
+	ssize_t nr;
+	int input, output, save_errno, i, need_restart;
+	char ch, *p, *end;
+	struct termios term, oterm;
+	struct sigaction sa, savealrm, saveint, savehup, savequit, saveterm;
+	struct sigaction savetstp, savettin, savettou, savepipe;
+
+	/* I suppose we could alloc on demand in this case (XXX). */
+	if (bufsiz == 0) {
+		errno = EINVAL;
+		return(NULL);
+	}
+
+restart:
+	for (i = 0; i < _NSIG; i++)
+		signo[i] = 0;
+	nr = -1;
+	save_errno = 0;
+	need_restart = 0;
+	/*
+	 * Read and write to /dev/tty if available.  If not, read from
+	 * stdin and write to stderr unless a tty is required.
+	 */
+	if ((flags & RPP_STDIN) ||
+	    (input = output = open(_PATH_TTY, O_RDWR)) == -1) {
+		if (flags & RPP_REQUIRE_TTY) {
+			errno = ENOTTY;
+			return(NULL);
+		}
+		input = STDIN_FILENO;
+		output = STDERR_FILENO;
+	}
+
+	/*
+	 * Turn off echo if possible.
+	 * If we are using a tty but are not the foreground pgrp this will
+	 * generate SIGTTOU, so do it *before* installing the signal handlers.
+	 */
+	if (input != STDIN_FILENO && tcgetattr(input, &oterm) == 0) {
+		memcpy(&term, &oterm, sizeof(term));
+		if (!(flags & RPP_ECHO_ON))
+			term.c_lflag &= ~(ECHO | ECHONL);
+#ifdef VSTATUS
+		if (term.c_cc[VSTATUS] != _POSIX_VDISABLE)
+			term.c_cc[VSTATUS] = _POSIX_VDISABLE;
+#endif
+		(void)tcsetattr(input, TCSAFLUSH|TCSASOFT, &term);
+	} else {
+		memset(&term, 0, sizeof(term));
+		term.c_lflag |= ECHO;
+		memset(&oterm, 0, sizeof(oterm));
+		oterm.c_lflag |= ECHO;
+	}
+
+	/*
+	 * Catch signals that would otherwise cause the user to end
+	 * up with echo turned off in the shell.  Don't worry about
+	 * things like SIGXCPU and SIGVTALRM for now.
+	 */
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;		/* don't restart system calls */
+	sa.sa_handler = handler;
+	(void)sigaction(SIGALRM, &sa, &savealrm);
+	(void)sigaction(SIGHUP, &sa, &savehup);
+	(void)sigaction(SIGINT, &sa, &saveint);
+	(void)sigaction(SIGPIPE, &sa, &savepipe);
+	(void)sigaction(SIGQUIT, &sa, &savequit);
+	(void)sigaction(SIGTERM, &sa, &saveterm);
+	(void)sigaction(SIGTSTP, &sa, &savetstp);
+	(void)sigaction(SIGTTIN, &sa, &savettin);
+	(void)sigaction(SIGTTOU, &sa, &savettou);
+
+	if (!(flags & RPP_STDIN))
+		(void)write(output, prompt, strlen(prompt));
+	end = buf + bufsiz - 1;
+	p = buf;
+	while ((nr = read(input, &ch, 1)) == 1 && ch != '\n' && ch != '\r') {
+		if (p < end) {
+			if ((flags & RPP_SEVENBIT))
+				ch &= 0x7f;
+			if (isalpha((unsigned char)ch)) {
+				if ((flags & RPP_FORCELOWER))
+					ch = (char)tolower((unsigned char)ch);
+				if ((flags & RPP_FORCEUPPER))
+					ch = (char)toupper((unsigned char)ch);
+			}
+			*p++ = ch;
+		}
+	}
+	*p = '\0';
+	save_errno = errno;
+	if (!(term.c_lflag & ECHO))
+		(void)write(output, "\n", 1);
+
+	/* Restore old terminal settings and signals. */
+	if (memcmp(&term, &oterm, sizeof(term)) != 0) {
+		const int sigttou = signo[SIGTTOU];
+
+		/* Ignore SIGTTOU generated when we are not the fg pgrp. */
+		while (tcsetattr(input, TCSAFLUSH|TCSASOFT, &oterm) == -1 &&
+		    errno == EINTR && !signo[SIGTTOU])
+			continue;
+		signo[SIGTTOU] = sigttou;
+	}
+	(void)sigaction(SIGALRM, &savealrm, NULL);
+	(void)sigaction(SIGHUP, &savehup, NULL);
+	(void)sigaction(SIGINT, &saveint, NULL);
+	(void)sigaction(SIGQUIT, &savequit, NULL);
+	(void)sigaction(SIGPIPE, &savepipe, NULL);
+	(void)sigaction(SIGTERM, &saveterm, NULL);
+	(void)sigaction(SIGTSTP, &savetstp, NULL);
+	(void)sigaction(SIGTTIN, &savettin, NULL);
+	(void)sigaction(SIGTTOU, &savettou, NULL);
+	if (input != STDIN_FILENO)
+		(void)close(input);
+
+	/*
+	 * If we were interrupted by a signal, resend it to ourselves
+	 * now that we have restored the signal handlers.
+	 */
+	for (i = 0; i < _NSIG; i++) {
+		if (signo[i]) {
+			kill(getpid(), i);
+			switch (i) {
+			case SIGTSTP:
+			case SIGTTIN:
+			case SIGTTOU:
+				need_restart = 1;
+			}
+		}
+	}
+	if (need_restart)
+		goto restart;
+
+	if (save_errno)
+		errno = save_errno;
+	return(nr == -1 ? NULL : buf);
+}
+
+#if 0
+char *
+getpass(const char *prompt)
+{
+	static char buf[_PASSWORD_LEN + 1];
+
+	return(readpassphrase(prompt, buf, sizeof(buf), RPP_ECHO_OFF));
+}
+#endif
+
+static void handler(int s)
+{
+
+	signo[s] = 1;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,8 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_FUNCS([getpeerucred])
 	AC_CHECK_FUNCS([issetugid])
 	AC_CHECK_FUNCS([isatty])
+	AC_CHECK_FUNCS([readpassphrase])
+	AM_CONDITIONAL([NEED_READPASSPHRASE], [test "$ac_cv_func_readpassphrase" != "yes"])
 
 	AC_CHECK_FUNC(
 		[strerror_r],

--- a/meson.build
+++ b/meson.build
@@ -176,7 +176,7 @@ if host_system != 'windows'
   headers = [
     'sys/resource.h',
     'sys/un.h',
-    'ucred.h'
+    'ucred.h',
   ]
 
   foreach h : headers
@@ -197,6 +197,7 @@ if host_system != 'windows'
     'issetugid',
     'mkdtemp',
     'mkstemp',
+    'readpassphrase',
     'secure_getenv',
     'strndup'
   ]

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -275,6 +275,10 @@ p11_kit_p11_kit_SOURCES = \
 	p11-kit/print-config.c \
 	$(NULL)
 
+if !OS_WIN32
+p11_kit_p11_kit_SOURCES += p11-kit/tty.c p11-kit/tty.h
+endif
+
 p11_kit_p11_kit_CFLAGS = $(COMMON_CFLAGS)
 p11_kit_p11_kit_LDADD =
 
@@ -296,20 +300,7 @@ bashcomp_DATA += bash-completion/p11-kit
 endif
 
 check_PROGRAMS += p11-kit/p11-kit-testable
-p11_kit_p11_kit_testable_SOURCES = \
-	p11-kit/add-profile.c \
-	p11-kit/delete-object.c \
-	p11-kit/delete-profile.c \
-	p11-kit/export-object.c \
-	p11-kit/generate-keypair.c \
-	p11-kit/list-objects.c \
-	p11-kit/list-profiles.c \
-	p11-kit/list-mechanisms.c \
-	p11-kit/list-tokens.c \
-	p11-kit/lists.c \
-	p11-kit/p11-kit.c \
-	p11-kit/print-config.c \
-	$(NULL)
+p11_kit_p11_kit_testable_SOURCES = $(p11_kit_p11_kit_SOURCES)
 
 p11_kit_p11_kit_testable_CFLAGS =
 p11_kit_p11_kit_testable_LDADD =

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -43,6 +43,10 @@
 #include "message.h"
 #include "tool.h"
 
+#ifdef OS_UNIX
+#include "tty.h"
+#endif
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -62,7 +66,8 @@ p11_kit_delete_profile (int argc,
 
 static int
 delete_profile (const char *token_str,
-		CK_PROFILE_ID profile)
+		CK_PROFILE_ID profile,
+		bool login)
 {
 	int ret = 1;
 	CK_RV rv;
@@ -99,8 +104,12 @@ delete_profile (const char *token_str,
 	}
 
 	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS;
-	if (p11_kit_uri_get_pin_value (uri))
+	if (login) {
 		behavior |= P11_KIT_ITER_WITH_LOGIN;
+#ifdef OS_UNIX
+		p11_kit_uri_set_pin_source (uri, "tty");
+#endif
+	}
 	iter = p11_kit_iter_new (uri, behavior);
 	if (iter == NULL) {
 		p11_message (_("failed to initialize iterator"));
@@ -171,12 +180,14 @@ p11_kit_delete_profile (int argc,
 	int opt, ret = 2;
 	CK_ULONG profile = CKA_INVALID;
 	p11_dict *profile_nicks = NULL;
+	bool login = false;
 
 	enum {
 		opt_verbose = 'v',
 		opt_quiet = 'q',
 		opt_help = 'h',
 		opt_profile = 'p',
+		opt_login = 'l',
 	};
 
 	struct option options[] = {
@@ -184,12 +195,14 @@ p11_kit_delete_profile (int argc,
 		{ "quiet", no_argument, NULL, opt_quiet },
 		{ "help", no_argument, NULL, opt_help },
 		{ "profile", required_argument, NULL, opt_profile },
+		{ "login", no_argument, NULL, opt_login },
 		{ 0 },
 	};
 
 	p11_tool_desc usages[] = {
 		{ 0, "usage: p11-kit delete-profile --profile profile pkcs11:token" },
 		{ opt_profile, "specify the profile to delete" },
+		{ opt_login, "login to the token" },
 		{ 0 },
 	};
 
@@ -225,6 +238,9 @@ p11_kit_delete_profile (int argc,
 				goto cleanup;
 			}
 			break;
+		case opt_login:
+			login = true;
+			break;
 		case '?':
 			goto cleanup;
 		default:
@@ -246,9 +262,19 @@ p11_kit_delete_profile (int argc,
 		goto cleanup;
 	}
 
-	ret = delete_profile (*argv, profile);
+#ifdef OS_UNIX
+	/* Register a fallback PIN callback that reads from terminal.
+	 * We don't care whether the registration succeeds as it is a fallback.
+	 */
+	(void)p11_kit_pin_register_callback ("tty", p11_pin_tty_callback, NULL, NULL);
+#endif
+
+	ret = delete_profile (*argv, profile, login);
 
 cleanup:
+#ifdef OS_UNIX
+	p11_kit_pin_unregister_callback ("tty", p11_pin_tty_callback, NULL);
+#endif
 	p11_dict_free (profile_nicks);
 
 	return ret;

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -66,15 +66,14 @@ delete_profile (const char *token_str,
 {
 	int ret = 1;
 	CK_RV rv;
-	const char *pin = NULL;
 	CK_OBJECT_HANDLE objects[MAX_OBJECTS];
 	CK_ULONG i, count = 0;
 	CK_SESSION_HANDLE session = 0;
-	CK_SLOT_ID slot = 0;
 	CK_FUNCTION_LIST *module = NULL;
 	CK_FUNCTION_LIST **modules = NULL;
 	P11KitUri *uri = NULL;
 	P11KitIter *iter = NULL;
+	P11KitIterBehavior behavior;
 	CK_OBJECT_CLASS klass = CKO_PROFILE;
 	CK_ATTRIBUTE template[] = {
 		{ CKA_CLASS, &klass, sizeof (klass) },
@@ -99,7 +98,10 @@ delete_profile (const char *token_str,
 		goto cleanup;
 	}
 
-	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS);
+	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS;
+	if (p11_kit_uri_get_pin_value (uri))
+		behavior |= P11_KIT_ITER_WITH_LOGIN;
+	iter = p11_kit_iter_new (uri, behavior);
 	if (iter == NULL) {
 		p11_message (_("failed to initialize iterator"));
 		goto cleanup;
@@ -115,27 +117,11 @@ delete_profile (const char *token_str,
 		goto cleanup;
 	}
 
+	/* Module and session should always be set at this point.  */
 	module = p11_kit_iter_get_module (iter);
-	if (module == NULL) {
-		p11_message (_("failed to obtain module"));
-		goto cleanup;
-	}
-	slot = p11_kit_iter_get_slot (iter);
-
-	rv = module->C_OpenSession (slot, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL, NULL, &session);
-	if (rv != CKR_OK) {
-		p11_message (_("failed to open session: %s"), p11_kit_strerror (rv));
-		goto cleanup;
-	}
-
-	pin = p11_kit_uri_get_pin_value (uri);
-	if (pin != NULL) {
-		rv = module->C_Login (session, CKU_USER, (unsigned char *)pin, strlen (pin));
-		if (rv != CKR_OK) {
-			p11_message (_("failed to login: %s"), p11_kit_strerror (rv));
-			goto cleanup;
-		}
-	}
+	return_val_if_fail (module != NULL, 1);
+	session = p11_kit_iter_get_session (iter);
+	return_val_if_fail (session != CK_INVALID_HANDLE, 1);
 
 	rv = module->C_FindObjectsInit (session, template, template_len);
 	if (rv != CKR_OK) {
@@ -170,8 +156,6 @@ delete_profile (const char *token_str,
 	ret = 0;
 
 cleanup:
-	if (session != 0)
-		module->C_CloseSession (session);
 	p11_kit_iter_free (iter);
 	p11_kit_uri_free (uri);
 	if (modules != NULL)

--- a/p11-kit/export-object.c
+++ b/p11-kit/export-object.c
@@ -46,6 +46,10 @@
 #include "pem.h"
 #include "tool.h"
 
+#ifdef OS_UNIX
+#include "tty.h"
+#endif
+
 #ifdef WITH_ASN1
 #include "asn1.h"
 #include "oid.h"
@@ -424,13 +428,15 @@ export_certificate (P11KitIter *iter,
 }
 
 static int
-export_object (const char *token_str)
+export_object (const char *token_str,
+	       bool login)
 {
 	int ret = 1;
 	CK_RV rv;
 	CK_FUNCTION_LIST **modules = NULL;
 	P11KitUri *uri = NULL;
 	P11KitIter *iter = NULL;
+	P11KitIterBehavior behavior;
 	CK_OBJECT_CLASS klass;
 	CK_ATTRIBUTE attr = { CKA_CLASS, &klass, sizeof (klass) };
 	p11_buffer buf;
@@ -455,7 +461,14 @@ export_object (const char *token_str)
 		goto cleanup;
 	}
 
-	iter = p11_kit_iter_new (uri, P11_KIT_ITER_WITH_LOGIN);
+	behavior = 0;
+	if (login) {
+		behavior |= P11_KIT_ITER_WITH_LOGIN;
+#ifdef OS_UNIX
+		p11_kit_uri_set_pin_source (uri, "tty");
+#endif
+	}
+	iter = p11_kit_iter_new (uri, behavior);
 	if (iter == NULL) {
 		p11_message (_("failed to initialize iterator"));
 		goto cleanup;
@@ -512,23 +525,27 @@ int
 p11_kit_export_object (int argc,
 		       char *argv[])
 {
-	int opt;
+	int opt, ret;
+	bool login = false;
 
 	enum {
 		opt_verbose = 'v',
 		opt_quiet = 'q',
 		opt_help = 'h',
+		opt_login = 'l',
 	};
 
 	struct option options[] = {
 		{ "verbose", no_argument, NULL, opt_verbose },
 		{ "quiet", no_argument, NULL, opt_quiet },
 		{ "help", no_argument, NULL, opt_help },
+		{ "login", no_argument, NULL, opt_login },
 		{ 0 },
 	};
 
 	p11_tool_desc usages[] = {
 		{ 0, "usage: p11-kit export-object pkcs11:token" },
+		{ opt_login, "login to the token" },
 		{ 0 },
 	};
 
@@ -543,6 +560,9 @@ p11_kit_export_object (int argc,
 		case opt_help:
 			p11_tool_usage (usages, options);
 			return 0;
+		case opt_login:
+			login = true;
+			break;
 		case '?':
 			return 2;
 		default:
@@ -559,5 +579,18 @@ p11_kit_export_object (int argc,
 		return 2;
 	}
 
-	return export_object (*argv);
+#ifdef OS_UNIX
+	/* Register a fallback PIN callback that reads from terminal.
+	 * We don't care whether the registration succeeds as it is a fallback.
+	 */
+	(void)p11_kit_pin_register_callback ("tty", p11_pin_tty_callback, NULL, NULL);
+#endif
+
+	ret = export_object (*argv, login);
+
+#ifdef OS_UNIX
+	p11_kit_pin_unregister_callback ("tty", p11_pin_tty_callback, NULL);
+#endif
+
+	return ret;
 }

--- a/p11-kit/iter.c
+++ b/p11-kit/iter.c
@@ -36,14 +36,23 @@
 
 #include "array.h"
 #include "attrs.h"
+#include "compat.h"
 #include "debug.h"
 #include "iter.h"
 #include "pin.h"
 #include "private.h"
 
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#define _(x) dgettext(PACKAGE_NAME, x)
+#else
+#define _(x) (x)
+#endif
 
 typedef struct _Callback {
 	p11_kit_iter_callback func;
@@ -66,7 +75,8 @@ struct p11_kit_iter {
 	CK_ATTRIBUTE *match_attrs;
 	CK_SLOT_ID match_slot_id;
 	Callback *callbacks;
-	char *pin;
+	char *pin_value;
+	char *pin_source;
 
 	/* The input modules */
 	p11_array *modules;
@@ -202,7 +212,7 @@ p11_kit_iter_set_uri (P11KitIter *iter,
 	CK_SLOT_INFO *sinfo;
 	CK_INFO *minfo;
 	CK_ULONG count;
-	const char *pin;
+	const char *pin_value;
 
 	return_if_fail (iter != NULL);
 
@@ -229,9 +239,20 @@ p11_kit_iter_set_uri (P11KitIter *iter,
 			if (tinfo != NULL)
 				memcpy (&iter->match_token, tinfo, sizeof (CK_TOKEN_INFO));
 
-			pin = p11_kit_uri_get_pin_value (uri);
-			if (pin != NULL)
-				iter->pin = strdup (pin);
+			pin_value = p11_kit_uri_get_pin_value (uri);
+			if (pin_value != NULL)
+				iter->pin_value = strdup (pin_value);
+			else {
+				/* If the PIN is not immediately available
+				 * through pin-value, keep pin-source for later
+				 * retrieval.
+				 */
+				const char *pin_source;
+
+				pin_source = p11_kit_uri_get_pin_source (uri);
+				if (pin_source != NULL)
+					iter->pin_source = strdup (pin_source);
+			}
 		}
 	} else {
 		/* Match any module version number and slot ID */
@@ -516,6 +537,32 @@ call_all_filters (P11KitIter *iter,
 #define COROUTINE_RETURN(name,i,x) do { iter->name ## _state = i; return x; case i:; } while (0)
 #define COROUTINE_END(name) }
 
+static P11KitPin *
+request_pin (P11KitIter *iter)
+{
+	P11KitPin *pin;
+	char *pin_description;
+
+	if (iter->pin_value) {
+		return p11_kit_pin_new_for_string (iter->pin_value);
+	}
+
+	if (asprintf (&pin_description,
+		      _("PIN for %.*s"),
+		      (int) p11_kit_space_strlen (iter->token_info.label,
+						  sizeof (iter->token_info.label)),
+		      iter->token_info.label) < 0) {
+		return NULL;
+	}
+
+	pin = p11_kit_pin_request (iter->pin_source,
+				   NULL,
+				   pin_description,
+				   P11_KIT_PIN_FLAGS_USER_LOGIN);
+	free (pin_description);
+	return pin;
+}
+
 static CK_RV
 move_next_session (P11KitIter *iter)
 {
@@ -588,10 +635,6 @@ move_next_session (P11KitIter *iter)
 		rv = (iter->module->C_GetTokenInfo) (iter->slot, &iter->token_info);
 		if (rv != CKR_OK || !p11_match_uri_token_info (&iter->match_token, &iter->token_info))
 			continue;
-		if (iter->with_tokens) {
-			iter->kind = P11_KIT_ITER_KIND_TOKEN;
-			COROUTINE_RETURN (move_next_session, 3, CKR_OK);
-		}
 
 		session_flags = CKF_SERIAL_SESSION;
 
@@ -605,18 +648,32 @@ move_next_session (P11KitIter *iter)
 			return finish_iterating (iter, rv);
 
 		if (iter->session != 0) {
-			if (iter->with_login && iter->pin != NULL) {
-				rv = (iter->module->C_Login) (iter->session, CKU_CONTEXT_SPECIFIC,
-							      (unsigned char *)iter->pin,
-							      strlen (iter->pin));
+			if (iter->with_login &&
+			    (iter->pin_value != NULL || iter->pin_source != NULL)) {
+				P11KitPin *pin;
+
+				pin = request_pin (iter);
+				if (!pin)
+					continue;
+
+				rv = (iter->module->C_Login) (iter->session, CKU_USER,
+							      (unsigned char *) p11_kit_pin_get_value (pin, NULL),
+							      p11_kit_pin_get_length (pin));
+				p11_kit_pin_unref (pin);
 				if (rv != CKR_OK)
 					return finish_iterating (iter, rv);
 			}
 
-			iter->move_next_session_state = 0;
-			iter->kind = P11_KIT_ITER_KIND_UNKNOWN;
-			return CKR_OK;
 		}
+
+		if (iter->with_tokens) {
+			iter->kind = P11_KIT_ITER_KIND_TOKEN;
+			COROUTINE_RETURN (move_next_session, 3, CKR_OK);
+		}
+
+		iter->move_next_session_state = 0;
+		iter->kind = P11_KIT_ITER_KIND_UNKNOWN;
+		return CKR_OK;
 	}
 
 	COROUTINE_END (move_next_session);
@@ -1097,7 +1154,8 @@ p11_kit_iter_free (P11KitIter *iter)
 	p11_attrs_free (iter->match_attrs);
 	free (iter->objects);
 	free (iter->slots);
-	free (iter->pin);
+	free (iter->pin_value);
+	free (iter->pin_source);
 
 	for (cb = iter->callbacks; cb != NULL; cb = next) {
 		next = cb->next;

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -224,6 +224,10 @@ p11_kit_sources = [
   'print-config.c'
 ]
 
+if host_system != 'windows'
+  p11_kit_sources += 'tty.c'
+endif
+
 executable('p11-kit',
            p11_kit_sources,
            c_args: common_c_args + libp11_kit_internal_c_args,

--- a/p11-kit/pin.c
+++ b/p11-kit/pin.c
@@ -104,7 +104,7 @@
  *                              const char *pin_description, P11KitPinFlags pin_flags,
  *                              void *callback_data)
  * {
- *     return p11_kit_pin_new_from_string ("pin-value");
+ *     return p11_kit_pin_new_for_string ("pin-value");
  * }
  *
  * p11_kit_pin_register_callback ("my-application", my_application_pin_callback,

--- a/p11-kit/test-generate-keypair.sh
+++ b/p11-kit/test-generate-keypair.sh
@@ -47,19 +47,19 @@ teardown() {
 }
 
 test_generate_keypair_rsa() {
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label=rsa --type=rsa --bits=2048 "pkcs11:token=test-genkey?pin-value=12345"; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --login --label=rsa --type=rsa --bits=2048 "pkcs11:token=test-genkey?pin-value=12345"; then
 		assert_fail "unable to run: p11-kit generate-keypair"
 	fi
 }
 
 test_generate_keypair_ecdsa() {
 	for curve in secp256r1 secp384r1 secp521r1; do
-		if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="ecdsa-$curve" --type=ecdsa --curve="$curve" "pkcs11:token=test-genkey?pin-value=12345"; then
+		if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --login --label="ecdsa-$curve" --type=ecdsa --curve="$curve" "pkcs11:token=test-genkey?pin-value=12345"; then
 			assert_fail "unable to run: p11-kit generate-keypair"
 		fi
 	done
 
-	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="ecdsa-unknown" --type=ecdsa --curve=unknown "pkcs11:token=test-genkey?pin-value=12345"; then
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --login --label="ecdsa-unknown" --type=ecdsa --curve=unknown "pkcs11:token=test-genkey?pin-value=12345"; then
 		assert_fail "p11-kit generate-keypair succeeded for unknown ecdsa curve"
 	fi
 }
@@ -78,12 +78,12 @@ test_generate_keypair_eddsa() {
 		curve="$curve ed448"
 	fi
 	for curve in $curves; do
-		if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="eddsa-$curve" --type=eddsa --curve="$curve" "pkcs11:token=test-genkey?pin-value=12345"; then
+		if ! "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --login --label="eddsa-$curve" --type=eddsa --curve="$curve" "pkcs11:token=test-genkey?pin-value=12345"; then
 			assert_fail "unable to run: p11-kit generate-keypair"
 		fi
 	done
 
-	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --label="eddsa-unknown" --type=eddsa --curve=unknown "pkcs11:token=test-genkey?pin-value=12345"; then
+	if "$abs_top_builddir"/p11-kit/p11-kit-testable generate-keypair --login --label="eddsa-unknown" --type=eddsa --curve=unknown "pkcs11:token=test-genkey?pin-value=12345"; then
 		assert_fail "p11-kit generate-keypair succeeded for unknown eddsa curve"
 	fi
 }

--- a/p11-kit/test-objects.sh
+++ b/p11-kit/test-objects.sh
@@ -125,6 +125,60 @@ EOF
 	fi
 }
 
+test_list_private() {
+	cat > list.exp <<EOF
+Object: #0
+    uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Private%20Capitalize%20Key;type=private
+    class: private-key
+    label: Private Capitalize Key
+    flags:
+          private
+Object: #1
+    uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Private%20Capitalize%20Key;type=private
+    class: private-key
+    label: Private Capitalize Key
+    flags:
+          private
+Object: #2
+    uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Private%20Capitalize%20Key;type=private
+    class: private-key
+    label: Private Capitalize Key
+    flags:
+          private
+Object: #3
+    uri: pkcs11:model=TEST%20MODEL;manufacturer=TEST%20MANUFACTURER;serial=TEST%20SERIAL;token=TEST%20LABEL;object=Private%20Capitalize%20Key;type=private
+    class: private-key
+    label: Private Capitalize Key
+    flags:
+          private
+EOF
+
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects --login -q "pkcs11:token=TEST%20LABEL;object=Private%20Capitalize%20Key;type=private?pin-value=booo" > list.out; then
+		assert_fail "unable to run: p11-kit list-objects"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains wrong result"
+	fi
+}
+
+test_list_private_without_login() {
+	cat > list.exp <<EOF
+EOF
+
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable list-objects -q "pkcs11:token=TEST%20LABEL;object=Private%20Capitalize%20Key;type=private?pin-value=booo" > list.out; then
+		assert_fail "unable to run: p11-kit list-objects"
+	fi
+
+	: ${DIFF=diff}
+	if ! ${DIFF} list.exp list.out > list.diff; then
+		sed 's/^/# /' list.diff
+		assert_fail "output contains wrong result"
+	fi
+}
+
 test_list_exact() {
 	cat > list.exp <<EOF
 Object: #0
@@ -258,4 +312,5 @@ EOF
 
 run test_list_all test_list_with_type test_list_exact test_list_nonexistent \
     test_export_cert test_export_pubkey test_generate_keypair test_generate_keypair_nonexistent_token \
-    test_delete_nonexistent_token
+    test_delete_nonexistent_token \
+    test_list_private test_list_private_without_login

--- a/p11-kit/tty.c
+++ b/p11-kit/tty.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Daiki Ueno
+ */
+
+#include "config.h"
+
+#include "tty.h"
+#include "compat.h"
+#include "debug.h"
+#include "message.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_PIN_LEN 256
+
+P11KitPin *
+p11_pin_tty_callback (const char *pin_source,
+		      P11KitUri *pin_uri,
+		      const char *pin_description,
+		      P11KitPinFlags pin_flags,
+		      void *callback_data)
+{
+	char buf[MAX_PIN_LEN], *prompt = NULL;
+	P11KitPin *pin = NULL;
+
+	return_val_if_fail (pin_description != NULL, NULL);
+
+	/* We don't support retries */
+	if (pin_flags & P11_KIT_PIN_FLAGS_RETRY)
+		return NULL;
+
+	if (asprintf (&prompt, "%s: ", pin_description) < 0)
+		return NULL;
+
+	if (readpassphrase (prompt, buf, sizeof(buf), 0) < 0)
+		goto cleanup;
+
+	pin = p11_kit_pin_new_for_string (buf);
+
+ cleanup:
+	free (prompt);
+	memset (buf, 0, sizeof(buf));
+	return pin;
+}

--- a/p11-kit/tty.h
+++ b/p11-kit/tty.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Daiki Ueno
+ */
+
+#ifndef P11_KIT_TTY_H
+#define P11_KIT_TTY_H
+
+#include "pin.h"
+
+P11KitPin *p11_pin_tty_callback (const char *pin_source,
+                                 P11KitUri *pin_uri,
+                                 const char *pin_description,
+                                 P11KitPinFlags pin_flags,
+                                 void *callback_data);
+
+#endif /* P11_KIT_TTY_H */

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,6 +8,7 @@ p11-kit/delete-profile.c
 p11-kit/export-object.c
 p11-kit/filter.c
 p11-kit/generate-keypair.c
+p11-kit/iter.c
 p11-kit/list-objects.c
 p11-kit/list-profiles.c
 p11-kit/list-mechanisms.c


### PR DESCRIPTION
Previously, those tools determined whether a login is necessary by
checking the presence of "pin-value" query attribute in the URI.  It
was too implicit and against modern security practice.  This instead
asks users to specify --login option and if no "pin-value" is given,
it tries to read a PIN from the terminal.

Fixes: #570 