### PR TITLE
iter: Add option to stop at token with active session

### DIFF
--- a/p11-kit/add-profile.c
+++ b/p11-kit/add-profile.c
@@ -103,7 +103,7 @@ add_profile (const char *token_str,
 		goto cleanup;
 	}
 
-	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS;
+	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_SESSIONS | P11_KIT_ITER_WITHOUT_OBJECTS;
 	if (login) {
 		behavior |= P11_KIT_ITER_WITH_LOGIN;
 #ifdef OS_UNIX

--- a/p11-kit/delete-profile.c
+++ b/p11-kit/delete-profile.c
@@ -103,7 +103,7 @@ delete_profile (const char *token_str,
 		goto cleanup;
 	}
 
-	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS;
+	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_SESSIONS | P11_KIT_ITER_WITHOUT_OBJECTS;
 	if (login) {
 		behavior |= P11_KIT_ITER_WITH_LOGIN;
 #ifdef OS_UNIX

--- a/p11-kit/generate-keypair.c
+++ b/p11-kit/generate-keypair.c
@@ -296,7 +296,7 @@ generate_keypair (const char *token_str,
 		goto cleanup;
 	}
 
-	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS;
+	behavior = P11_KIT_ITER_WANT_WRITABLE | P11_KIT_ITER_WITH_SESSIONS | P11_KIT_ITER_WITHOUT_OBJECTS;
 	if (login) {
 		behavior |= P11_KIT_ITER_WITH_LOGIN;
 #ifdef OS_UNIX

--- a/p11-kit/iter.h
+++ b/p11-kit/iter.h
@@ -63,6 +63,7 @@ typedef enum {
 	P11_KIT_ITER_KIND_SLOT,
 	P11_KIT_ITER_KIND_TOKEN,
 	P11_KIT_ITER_KIND_OBJECT,
+	P11_KIT_ITER_KIND_SESSION,
 	P11_KIT_ITER_KIND_UNKNOWN = -1,
 } P11KitIterKind;
 
@@ -74,6 +75,7 @@ typedef enum {
 	P11_KIT_ITER_WITH_TOKENS = 1 << 5,
 	P11_KIT_ITER_WITHOUT_OBJECTS = 1 << 6,
 	P11_KIT_ITER_WITH_LOGIN = 1 << 7,
+	P11_KIT_ITER_WITH_SESSIONS = 1 << 8,
 } P11KitIterBehavior;
 
 typedef CK_RV      (* p11_kit_iter_callback)                (P11KitIter *iter,

--- a/p11-kit/list-profiles.c
+++ b/p11-kit/list-profiles.c
@@ -100,7 +100,7 @@ list_profiles (const char *token_str,
 		goto cleanup;
 	}
 
-	behavior = P11_KIT_ITER_WITH_TOKENS | P11_KIT_ITER_WITHOUT_OBJECTS;
+	behavior = P11_KIT_ITER_WITH_SESSIONS | P11_KIT_ITER_WITHOUT_OBJECTS;
 	if (login) {
 		behavior |= P11_KIT_ITER_WITH_LOGIN;
 #ifdef OS_UNIX


### PR DESCRIPTION
The commit fd7c819eff1de40619ba0231dc8819af76df72a6 introduced a slight backward incompatibility to the P11KitIter behavior when iterating with P11_KIT_ITER_WITH_TOKENS: previously it stopped before opening a token, while now it stops after that.

This adds a compatibility measure so those two are distinguishable with an explicit flag P11_KIT_ITER_WITH_SESSIONS and a kind P11_KIT_ITER_KIND_SESSION.

Related: #589 