### PR TITLE
pkcs11-json: Make regeneration robuster

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@ CLEANFILES =
 EXTRA_DIST = CONTRIBUTING.md meson.build meson_options.txt po/meson.build \
 	doc/manual/meson.build doc/manual/userdir.xml.in \
 	doc/manual/sysdir.xml.in doc/manual/version.xml.in \
-	bash-completion subprojects
+	bash-completion
 
 incdir = $(includedir)/p11-kit-1/p11-kit
 inc_HEADERS =

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -41,35 +41,35 @@ p11-kit/virtual.c: $(VIRTUAL_GENERATED)
 
 CLEANFILES += $(VIRTUAL_GENERATED)
 
-p11-kit/virtual-ffi-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/pkcs11.json
+p11-kit/virtual-ffi-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/generated/pkcs11.json
 	$(AM_V_GEN)$(PYTHON) $(srcdir)/p11-kit/gen-wrappers.py \
 		--template $(srcdir)/p11-kit/templates/binding-wrappers.py \
 		--excludes $(srcdir)/p11-kit/templates/virtual-excludes.list \
-		--infile $(srcdir)/subprojects/pkcs11-json/pkcs11.json --outfile $@
+		--infile $(srcdir)/subprojects/pkcs11-json/generated/pkcs11.json --outfile $@
 
-p11-kit/virtual-fixed-wrappers.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/pkcs11.json
+p11-kit/virtual-fixed-wrappers.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/generated/pkcs11.json
 	$(AM_V_GEN)$(PYTHON) $(srcdir)/p11-kit/gen-wrappers.py \
 		--template $(srcdir)/p11-kit/templates/fixed-wrappers.py \
 		--excludes $(srcdir)/p11-kit/templates/virtual-excludes.list \
 		--renames C_GetFunctionStatus:short C_CancelFunction:short \
 		--concat-lines \
-		--infile $(srcdir)/subprojects/pkcs11-json/pkcs11.json --outfile $@
+		--infile $(srcdir)/subprojects/pkcs11-json/generated/pkcs11.json --outfile $@
 
 p11-kit/virtual-fixed-closures.h: Makefile p11-kit/gen-fixed-closures.py
 	$(AM_V_GEN)$(PYTHON) $(srcdir)/p11-kit/gen-fixed-closures.py \
 		--closures $(closures) --outfile $@
 
-p11-kit/virtual-stack-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/pkcs11.json
+p11-kit/virtual-stack-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/generated/pkcs11.json
 	$(AM_V_GEN)$(PYTHON) $(srcdir)/p11-kit/gen-wrappers.py \
 		--template $(srcdir)/p11-kit/templates/stack-wrappers.py \
 		--excludes $(srcdir)/p11-kit/templates/virtual-excludes.list \
-		--infile $(srcdir)/subprojects/pkcs11-json/pkcs11.json --outfile $@
+		--infile $(srcdir)/subprojects/pkcs11-json/generated/pkcs11.json --outfile $@
 
-p11-kit/virtual-base-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/pkcs11.json
+p11-kit/virtual-base-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/generated/pkcs11.json
 	$(AM_V_GEN)$(PYTHON) $(srcdir)/p11-kit/gen-wrappers.py \
 		--template $(srcdir)/p11-kit/templates/base-wrappers.py \
 		--excludes $(srcdir)/p11-kit/templates/virtual-excludes.list \
-		--infile $(srcdir)/subprojects/pkcs11-json/pkcs11.json --outfile $@
+		--infile $(srcdir)/subprojects/pkcs11-json/generated/pkcs11.json --outfile $@
 
 lib_LTLIBRARIES += \
 	libp11-kit.la
@@ -114,11 +114,11 @@ p11-kit/proxy.c: $(PROXY_GENERATED)
 
 CLEANFILES += $(PROXY_GENERATED)
 
-p11-kit/proxy-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/pkcs11.json
+p11-kit/proxy-generated.h: Makefile p11-kit/gen-wrappers.py subprojects/pkcs11-json/generated/pkcs11.json
 	$(AM_V_GEN)$(PYTHON) $(srcdir)/p11-kit/gen-wrappers.py \
 		--template $(srcdir)/p11-kit/templates/proxy-wrappers.py \
 		--excludes $(srcdir)/p11-kit/templates/proxy-excludes.list \
-		--infile $(srcdir)/subprojects/pkcs11-json/pkcs11.json --outfile $@
+		--infile $(srcdir)/subprojects/pkcs11-json/generated/pkcs11.json --outfile $@
 
 libp11_kit_la_SOURCES = \
 	p11-kit/proxy.c p11-kit/proxy.h p11-kit/proxy-init.c \


### PR DESCRIPTION
Previously, when common/pkcs11.h is updated and castxml is not installed on the system, an empty pkcs11.json is created.  This makes the build process abort in that case.

This also fixes the path of pkcs11.json referred to by p11-kit/Makefile.am, and only includes necessary files in the distribution.