### PR TITLE
rpc: Fix serialization of NULL mechanism pointer

### DIFF
--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -430,9 +430,13 @@ proto_write_mechanism (p11_rpc_message *msg,
 	/* Make sure this is in the right order */
 	assert (!msg->signature || p11_rpc_message_verify_part (msg, "M"));
 
-	/* This case is valid for C_*Init () functions to cancel operation */
+	/*
+	 * The NULL mechanism is used for C_*Init () functions to
+	 * cancel operation.  We use a special value 0xffffffff as a
+	 * marker to indicate that.
+	 */
 	if (mech == NULL) {
-		p11_rpc_buffer_add_uint32 (msg->output, 0);
+		p11_rpc_buffer_add_uint32 (msg->output, 0xffffffff);
 		return p11_buffer_failed (msg->output) ? CKR_HOST_MEMORY : CKR_OK;
 	}
 

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -2114,8 +2114,14 @@ p11_rpc_buffer_get_mechanism (p11_buffer *buffer,
 
 	mech->mechanism = mechanism;
 
-	/* special NULL case */
-	if (mechanism == 0) {
+	/*
+	 * The NULL mechanism is used for C_*Init () functions to
+	 * cancel operation.  We use a special value 0xffffffff as a
+	 * marker to indicate that.
+	 */
+	if (mechanism == 0xffffffff) {
+		mech->ulParameterLen = 0;
+		mech->pParameter = NULL;
 		return true;
 	}
 

--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -480,8 +480,14 @@ proto_read_mechanism (p11_rpc_message *msg,
 		return PARSE_ERROR;
 	}
 
-	if (temp.mechanism == 0) {
+	/*
+	 * The NULL mechanism is used for C_*Init () functions to
+	 * cancel operation.  We use a special value 0xffffffff as a
+	 * marker to indicate that.
+	 */
+	if (temp.mechanism == 0xffffffff) {
 		*mech = NULL;
+		msg->parsed = offset;
 		return CKR_OK;
 	}
 


### PR DESCRIPTION
A NULL mechanism pointer is valid for C_*Init functions to cancel the
operation.  Since 852ccd8d we encoded it with a CK_MECHANISM_TYPE 0 as
an indicator, though it clashes with CKM_RSA_PKCS_KEY_PAIR_GEN (0).
This patch changes the encoding to use a special value (0xffffffff) to
indicate that and also properly advance the offset when reading.
