### PR TITLE
Add the flags required for libtasn1 to libp11-asn1.la

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -176,6 +176,10 @@ libp11_asn1_la_SOURCES = \
 	$(asn_h) \
 	$(NULL)
 
+libp11_asn1_la_CFLAGS = $(LIBTASN1_CFLAGS)
+
+libp11_asn1_la_LIBADD = $(LIBTASN1_LIBS)
+
 asn1_LIBS = \
 	libp11-asn1.la \
 	$(LIBTASN1_LIBS) \


### PR DESCRIPTION
These were not copied when libp11-asn1.la was seperated from libtrust-data.la as part of d8cc241187775e18de86caf446e9160299e6f157