### PR TITLE
Fixes for GNU/Hurd

### DIFF
--- a/common/compat.c
+++ b/common/compat.c
@@ -859,7 +859,7 @@ mkdtemp (char *template)
 #ifndef HAVE_GETAUXVAL
 
 unsigned long
-getauxval (unsigned long type)
+_p11_getauxval (unsigned long type)
 {
 	static unsigned long secure = 0UL;
 	static bool check_secure_initialized = false;
@@ -908,7 +908,7 @@ getauxval (unsigned long type)
 char *
 secure_getenv (const char *name)
 {
-	if (getauxval (AT_SECURE))
+	if (_p11_getauxval (AT_SECURE))
 		return NULL;
 	return getenv (name);
 }

--- a/common/compat.c
+++ b/common/compat.c
@@ -871,7 +871,7 @@ getauxval (unsigned long type)
 	assert (type == AT_SECURE);
 
 	if (!check_secure_initialized) {
-#if defined(HAVE___LIBC_ENABLE_SECURE)
+#if defined(HAVE___LIBC_ENABLE_SECURE) && !defined(__GNU__)
 		extern int __libc_enable_secure;
 		secure = __libc_enable_secure;
 

--- a/common/compat.h
+++ b/common/compat.h
@@ -353,10 +353,11 @@ time_t      timegm          (struct tm *tm);
 #ifdef HAVE_GETAUXVAL
 
 #include <sys/auxv.h>
+#define _p11_getauxval(X) getauxval(X)
 
 #else /* !HAVE_GETAUXVAL */
 
-unsigned long     getauxval (unsigned long type);
+unsigned long     _p11_getauxval (unsigned long type);
 
 #define AT_SECURE 23
 

--- a/common/frob-getauxval.c
+++ b/common/frob-getauxval.c
@@ -55,7 +55,7 @@ main (int argc,
 		abort ();
 	}
 
-	ret = getauxval (type);
+	ret = _p11_getauxval (type);
 	printf ("getauxval(%lu) == %lu\n", type, ret);
 	return (int)ret;
 }

--- a/common/meson.build
+++ b/common/meson.build
@@ -64,7 +64,7 @@ if host_system != 'windows'
   ]
 
   foreach f : rpl_functions
-    if not cc.has_function(f)
+    if not cc.has_function(f, dependencies: system_deps)
       libp11_tool_sources += '@0@.c'.format(f)
     endif
   endforeach

--- a/common/path.c
+++ b/common/path.c
@@ -114,7 +114,7 @@ expand_homedir (const char *remainder)
 {
 	const char *env;
 
-	if (getauxval (AT_SECURE)) {
+	if (_p11_getauxval (AT_SECURE)) {
 		errno = EPERM;
 		return NULL;
 	}

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,12 @@ case "$host" in
 		os_win32=yes
 		os_unix=no
 		;;
+	*-*-linux*)
+		AC_DEFINE_UNQUOTED(OS_UNIX, 1, [Building for unix])
+		os_win32=no
+		os_unix=yes
+		os_linux=yes
+		;;
 	*)
 		AC_DEFINE_UNQUOTED(OS_UNIX, 1, [Building for unix])
 		os_win32=no
@@ -144,7 +150,11 @@ if test "$os_unix" = "yes"; then
 	AC_CHECK_HEADERS([sys/resource.h sys/un.h ucred.h])
 	AC_CHECK_MEMBERS([struct dirent.d_type],,,[#include <dirent.h>])
 	AC_CHECK_FUNCS([getprogname getexecname basename mkstemp mkdtemp])
-	AC_CHECK_FUNCS([getauxval getresuid secure_getenv])
+	AC_CHECK_FUNCS([getresuid secure_getenv])
+	if test "$os_linux" = "yes"; then
+		# Use getauxval on Linux only.
+		AC_CHECK_FUNCS([getauxval])
+	fi
 	AC_CHECK_FUNCS([strnstr memdup strndup])
 	AC_CHECK_FUNCS([reallocarray])
 	AC_CHECK_DECLS([reallocarray], [], [], [[#include <stdlib.h>]])

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,15 @@ AM_CONDITIONAL(OS_WIN32, test "$os_win32" = "yes")
 
 AC_C_BIGENDIAN
 
+case "$host_os" in
+kfreebsd*-gnu | gnu*)
+	PKG_CHECK_MODULES([LIBBSD], [libbsd-overlay], [
+			   CFLAGS="$CFLAGS $LIBBSD_CFLAGS"
+			   LIBS="$LIBS $LIBBSD_LIBS"
+			   ], AC_MSG_WARN([libbsd-overlay not found but probably needed]))
+;;
+esac
+
 # ------------------------------------------------------------------------------
 # Checks for libraries and headers
 

--- a/meson.build
+++ b/meson.build
@@ -206,7 +206,8 @@ if host_system != 'windows'
     'mkstemp',
     'readpassphrase',
     'secure_getenv',
-    'strndup'
+    'strndup',
+    'strnstr'
   ]
   if ['linux'].contains(host_system)
     functions += [

--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,14 @@ endif
 
 conf.set10('WITH_STRICT', get_option('strict'))
 
+system_deps = []
+
+if ['gnu', 'gnu/kfreebsd'].contains(host_system)
+  libbsd_overlay_dep = dependency('libbsd-overlay')
+  system_deps += libbsd_overlay_dep
+  add_project_dependencies(libbsd_overlay_dep, language: 'c')
+endif
+
 libintl_deps = []
 if get_option('nls') and cc.has_header('libintl.h')
   conf.set('ENABLE_NLS', 1)
@@ -180,7 +188,7 @@ if host_system != 'windows'
   ]
 
   foreach h : headers
-    if cc.has_header(h)
+    if cc.has_header(h, dependencies: system_deps)
       conf.set('HAVE_' + h.underscorify().to_upper(), 1)
     endif
   endforeach
@@ -203,7 +211,7 @@ if host_system != 'windows'
   ]
 
   foreach f : functions
-    if cc.has_function(f)
+    if cc.has_function(f, dependencies: system_deps)
       conf.set('HAVE_' + f.underscorify().to_upper(), 1)
     endif
   endforeach

--- a/meson.build
+++ b/meson.build
@@ -195,7 +195,6 @@ if host_system != 'windows'
 
   functions = [
     'fdwalk',
-    'getauxval',
     'getexecname',
     'getpeereid',
     'getpeerucred',
@@ -209,6 +208,11 @@ if host_system != 'windows'
     'secure_getenv',
     'strndup'
   ]
+  if ['linux'].contains(host_system)
+    functions += [
+      'getauxval'
+    ]
+  endif
 
   foreach f : functions
     if cc.has_function(f, dependencies: system_deps)

--- a/p11-kit/conf.c
+++ b/p11-kit/conf.c
@@ -242,7 +242,7 @@ _p11_conf_load_globals (const char *system_conf, const char *user_conf,
 	}
 
 	if (mode != CONF_USER_NONE && !p11_conf_force_user_config) {
-		if (getauxval (AT_SECURE)) {
+		if (_p11_getauxval (AT_SECURE)) {
 			p11_debug ("skipping user config in setuid or setgid program");
 			mode = CONF_USER_NONE;
 #ifdef OS_UNIX

--- a/p11-kit/frob-setuid.c
+++ b/p11-kit/frob-setuid.c
@@ -70,7 +70,7 @@ main (void)
 	printf ("'setting' on module 'one': %s\n", field ? field : "(null)");
 
 	assert (field != NULL);
-	if (getauxval (AT_SECURE))
+	if (_p11_getauxval (AT_SECURE))
 		assert (strcmp (field, "system1") == 0);
 	else
 		assert (strcmp (field, "user1") == 0);


### PR DESCRIPTION
Hello,

we have been patching p11-kit on Debian for GNU/Hurd and kfreebsd compatibility for a long time. Find attached the latest iteration of the (small) patchset. kfreebsd-compatibilty is untested nowadays since we have dropped the port on Debian. - Please tell me if I should drop the respective code ("kfreebsd*-gnu |")

cu Andreas