### PR TITLE
Add option to specify CKA_ID in generate-keypair and import-object

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -76,6 +76,7 @@ c_tests += \
 	test-hash \
 	test-dict \
 	test-array \
+	test-hex \
 	test-constants \
 	test-attrs \
 	test-buffer \
@@ -92,6 +93,9 @@ test_argv_LDADD = $(common_LIBS)
 
 test_array_SOURCES = common/test-array.c
 test_array_LDADD = $(common_LIBS)
+
+test_hex_SOURCES = common/test-hex.c
+test_hex_LDADD = $(common_LIBS)
 
 test_attrs_SOURCES = common/test-attrs.c
 test_attrs_LDADD = $(common_LIBS)

--- a/common/hex.h
+++ b/common/hex.h
@@ -38,7 +38,12 @@
 
 #include <stddef.h>
 
-char *hex_encode (const unsigned char *data,
-		  size_t n_data);
+char *
+hex_encode (const unsigned char *data,
+	    size_t n_data);
+
+unsigned char *
+hex_decode (const char *hex,
+	    size_t *bin_len);
 
 #endif /* P11_HEX_H */

--- a/common/meson.build
+++ b/common/meson.build
@@ -150,6 +150,7 @@ if get_option('test')
     'test-hash',
     'test-dict',
     'test-array',
+    'test-hex',
     'test-constants',
     'test-attrs',
     'test-buffer',

--- a/common/test-hex.c
+++ b/common/test-hex.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, Red Hat Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+
+#include "hex.h"
+#include "test.h"
+
+static void
+assert_encode_eq (const char *out,
+		  const char *in,
+		  size_t in_len)
+{
+	char *hex = hex_encode ((const unsigned char *)in, in_len);
+	assert_str_eq (out, hex);
+	free (hex);
+}
+
+static void
+assert_decode_eq (const char *out,
+		  size_t out_len,
+		  const char *in)
+{
+	size_t bin_len = 0;
+	char *bin = (char *)hex_decode (in, &bin_len);
+	assert_mem_eq (out, out_len, bin, bin_len);
+	free (bin);
+}
+
+static void
+assert_decode_fail (const char *in)
+{
+	size_t i;
+	assert_ptr_eq (NULL, hex_decode (in, &i));
+}
+
+static void
+test_encode (void)
+{
+	assert_encode_eq ("", "", 0);
+	assert_encode_eq ("3a", "\x3a", 1);
+	assert_encode_eq ("3a:bc:f6:9a", "\x3a\xbc\xf6\x9a", 4);
+}
+
+static void
+test_decode (void)
+{
+	assert_decode_eq ("\x3a", 1, "3a");
+	assert_decode_eq ("\x3a\xbc\xf6\x9a", 4, "3abcf69a");
+	assert_decode_eq ("\x3a\xbc\xf6\x9a", 4, "3AbCf69a");
+	assert_decode_eq ("\x3a\xbc\xf6\x9a", 4, "3ABCF69A");
+	assert_decode_eq ("\x3a\xbc\xf6\x9a", 4, "3a:bc:f6:9a");
+	assert_decode_eq ("\x3a\xbc\xf6\x9a", 4, "3a:Bc:F6:9A");
+	assert_decode_eq ("\x3a\xbc\xf6\x9a", 4, "3a:bc:f6:9a");
+	assert_decode_fail ("");
+	assert_decode_fail ("3");
+	assert_decode_fail (":a");
+	assert_decode_fail ("a:");
+	assert_decode_fail ("3ab");
+	assert_decode_fail ("3a:");
+	assert_decode_fail (":3a");
+	assert_decode_fail ("3a:b");
+	assert_decode_fail ("3:ab");
+	assert_decode_fail ("3a:bc:f6::9a");
+	assert_decode_fail ("3a:bc:f69a");
+	assert_decode_fail ("3a:bc:f6::9");
+	assert_decode_fail ("3a:bc:f69aa");
+	assert_decode_fail ("3a$bc:f6:9a");
+	assert_decode_fail ("3a:bc:f6$9a");
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+	p11_test (test_encode, "/hex/encode");
+	p11_test (test_decode, "/hex/decode");
+	return p11_test_run (argc, argv);
+}

--- a/common/test.h
+++ b/common/test.h
@@ -113,6 +113,14 @@
 	         p1_test_fail (__FILE__, __LINE__, __FUNCTION__, "assertion failed (%s): '%s' does not contain '%s'", \
 	                       #expr, __str, needle); \
 	} while (0)
+#define assert_mem_eq(m1, l1, m2, l2) \
+	do { size_t __l1 = (l1); \
+	     size_t __l2 = (l2); \
+	     const void *__m1 = (m1); \
+	     const void *__m2 = (m2); \
+	     if ((__l1 == 0 && __l2 == 0) || (__l1 == __l2 && __m1 && __m2 && memcmp (__m1, __m2, l1) == 0)) ; else \
+	         p11_test_fail (__FILE__, __LINE__, __FUNCTION__, "assertion failed"); \
+	} while (0)
 
 #endif /* !P11_TEST_SOURCE */
 

--- a/doc/manual/p11-kit.xml
+++ b/doc/manual/p11-kit.xml
@@ -176,7 +176,7 @@ $ <command>pkg-config p11-kit-1 --variable p11_module_path</command>
 	<para>Import object into PKCS#11 token.</para>
 
 <programlisting>
-$ p11-kit import-object --file=file.pem &lsqb;--label=label&rsqb; pkcs11:token
+$ p11-kit import-object --file=file.pem &lsqb;--label=label&rsqb; &lsqb;--id=object_id&rsqb; pkcs11:token
 </programlisting>
 
 	<para>Takes either an X.509 certificate or a public key in the form of a PEM file
@@ -198,6 +198,10 @@ $ p11-kit import-object --file=file.pem &lsqb;--label=label&rsqb; pkcs11:token
 		<varlistentry>
 			<term><option>--label=&lt;label&gt;</option></term>
 			<listitem><para>Assigns label to the imported object.</para></listitem>
+		</varlistentry>
+		<varlistentry>
+			<term><option>--id=&lt;object_id&gt;</option></term>
+			<listitem><para>Assigns ID to the imported object. The ID should be specified in hexadecimal format without '0x' prefix.</para></listitem>
 		</varlistentry>
 		<varlistentry>
 			<term><option>--login</option></term>
@@ -276,7 +280,7 @@ $ <command>pkg-config p11-kit-1 --variable p11_module_path</command>
 	<para>Generate key-pair on a PKCS#11 token.</para>
 
 <programlisting>
-$ p11-kit generate-keypair --type=algorithm &lcub;--bits=n|--curve=name&rcub; &lsqb;--label=label&rsqb; pkcs11:token
+$ p11-kit generate-keypair --type=algorithm &lcub;--bits=n|--curve=name&rcub; &lsqb;--label=label&rsqb; &lsqb;--id=object_id&rsqb; pkcs11:token
 </programlisting>
 
 	<para>Generate private-public key-pair of given type on the first
@@ -310,6 +314,10 @@ $ p11-kit generate-keypair --type=algorithm &lcub;--bits=n|--curve=name&rcub; &l
 		<varlistentry>
 			<term><option>--label=&lt;label&gt;</option></term>
 			<listitem><para>Assigns label to the generated key-pair objects.</para></listitem>
+		</varlistentry>
+		<varlistentry>
+			<term><option>--id=&lt;object_id&gt;</option></term>
+			<listitem><para>Assigns ID to the generated key-pair objects. The ID should be specified in hexadecimal format without '0x' prefix.</para></listitem>
 		</varlistentry>
 		<varlistentry>
 			<term><option>--login</option></term>

--- a/p11-kit/test-import-public.sh
+++ b/p11-kit/test-import-public.sh
@@ -23,11 +23,11 @@ teardown() {
 }
 
 test_import_cert() {
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable import-object -q --login --file="$abs_top_srcdir"/trust/fixtures/cacert3.pem --label=cert "pkcs11:token=PERSIST%20LABEL%20ONE?pin-value=booo"; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable import-object -q --login --file="$abs_top_srcdir"/trust/fixtures/cacert3.pem --label=cert --id="1a:bc:f6:9a" "pkcs11:token=PERSIST%20LABEL%20ONE?pin-value=booo"; then
 		assert_fail "unable to run: p11-kit import-object"
 	fi
 
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q --login "pkcs11:token=PERSIST%20LABEL%20ONE;object=cert?pin-value=booo" > export.out; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q --login "pkcs11:token=PERSIST%20LABEL%20ONE;object=cert;id=%1A%BC%F6%9A?pin-value=booo" > export.out; then
 		assert_fail "unable to run: p11-kit export-object"
 	fi
 
@@ -54,11 +54,11 @@ fQIDAQAB
 -----END PUBLIC KEY-----
 EOF
 
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable import-object -q --login --file="export.exp" --label=rsa "pkcs11:token=PERSIST%20LABEL%20ONE?pin-value=booo"; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable import-object -q --login --file="export.exp" --label=rsa --id="2a:bc:f6:9a" "pkcs11:token=PERSIST%20LABEL%20ONE?pin-value=booo"; then
 		assert_fail "unable to run: p11-kit import-object"
 	fi
 
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q --login "pkcs11:token=PERSIST%20LABEL%20ONE;object=rsa?pin-value=booo" > export.out; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q --login "pkcs11:token=PERSIST%20LABEL%20ONE;object=rsa;id=%2A%BC%F6%9A?pin-value=booo" > export.out; then
 		assert_fail "unable to run: p11-kit export-object"
 	fi
 
@@ -80,11 +80,11 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsaTJt0debXaW7Hpcrpn7X07SsTk9
 -----END PUBLIC KEY-----
 EOF
 
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable import-object -q --login --file="export.exp" --label=ec "pkcs11:token=PERSIST%20LABEL%20ONE?pin-value=booo"; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable import-object -q --login --file="export.exp" --label=ec --id="3a:bc:f6:9a" "pkcs11:token=PERSIST%20LABEL%20ONE?pin-value=booo"; then
 		assert_fail "unable to run: p11-kit import-object"
 	fi
 
-	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q --login "pkcs11:token=PERSIST%20LABEL%20ONE;object=ec?pin-value=booo" > export.out; then
+	if ! "$abs_top_builddir"/p11-kit/p11-kit-testable export-object -q --login "pkcs11:token=PERSIST%20LABEL%20ONE;object=ec;id=%3A%BC%F6%9A?pin-value=booo" > export.out; then
 		assert_fail "unable to run: p11-kit export-object"
 	fi
 


### PR DESCRIPTION
--id option allows users to specify CKA_ID attribute to be associated with imported/generated objects when using p11-kit command. The ID attribute should be specified in hexadecimal format without the "0x" prefix.

Example usage:
`p11-kit import-object --file=cert.pem --id="54:62:70:63:f1:75:84:43:58:8e:d1:16:20:b1:c6:ac:1a:bc:f6:89" --label=cert --login "pkcs11:token=test"`

Closes #607 