### PR TITLE
common/meson.build: fix required headers missing failure

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -113,6 +113,7 @@ if with_asn1
     'p11-asn1', libp11_asn1_sources,
     gnu_symbol_visibility: 'hidden',
     include_directories: configinc,
+    dependencies: asn_h_dep,
   )
 
   libp11_asn1_dep = declare_dependency(


### PR DESCRIPTION
It fails occasionally with missing generated header files:

| ../git/common/asn1.c:42:10: fatal error: openssl.asn.h: No such file or directory
|    42 | #include "openssl.asn.h"
|       |          ^~~~~~~~~~~~~~~
| compilation terminated.

According to meson manual page:

https://mesonbuild.com/Wrap-best-practices-and-tips.html#declare-generated-headers-explicitly

'asn_h_dep' should be a dependency of static_library target 'libp11_asn1' to make sure that required header files generated before compile common/asn1.c.