### PR TITLE
rpc: add support for recursive attributes

### DIFF
--- a/common/attrs.c
+++ b/common/attrs.c
@@ -141,12 +141,12 @@ attrs_build (CK_ATTRIBUTE *attrs,
 		/* The attribute exists and we're not overriding */
 		} else if (!override) {
 			if (take_values)
-				free (add->pValue);
+				p11_attr_clear (add);
 			continue;
 
 		/* The attribute exists but we're overriding */
 		} else {
-			free (attr->pValue);
+			p11_attr_clear (attr);
 		}
 
 		if (take_values) {

--- a/common/persist.c
+++ b/common/persist.c
@@ -562,6 +562,12 @@ field_to_attribute (p11_persist *persist,
 		return false;
 	}
 
+	/* Ignore recursive attributes */
+	if (IS_ATTRIBUTE_ARRAY (&attr)) {
+		free (attr.pValue);
+		return true;
+	}
+
 	*attrs = p11_attrs_take (*attrs, attr.type,
 	                         attr.pValue, attr.ulValueLen);
 	return true;

--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -240,13 +240,8 @@ proto_read_attribute_array (p11_rpc_message *msg,
 		CK_ATTRIBUTE temp;
 
 		memset (&temp, 0, sizeof (temp));
-		if (!p11_rpc_buffer_get_attribute (msg->input, &offset, &temp)) {
+		if (!p11_rpc_message_get_attribute (msg, msg->input, &offset, &temp)) {
 			msg->parsed = offset;
-			return PARSE_ERROR;
-		}
-
-		if (IS_ATTRIBUTE_ARRAY (&temp)) {
-			p11_debug("recursive attribute array is not supported");
 			return PARSE_ERROR;
 		}
 

--- a/p11-kit/rpc-message.h
+++ b/p11-kit/rpc-message.h
@@ -276,9 +276,6 @@ typedef enum _p11_rpc_value_type {
 	P11_RPC_VALUE_BYTE_ARRAY
 } p11_rpc_value_type;
 
-typedef void (*p11_rpc_value_encoder) (p11_buffer *, const void *, CK_ULONG);
-typedef bool (*p11_rpc_value_decoder) (p11_buffer *, size_t *, void *, CK_ULONG *);
-
 typedef enum _p11_rpc_message_type {
 	P11_RPC_REQUEST = 1,
 	P11_RPC_RESPONSE
@@ -294,6 +291,10 @@ typedef struct {
 	const char *sigverify;
 	void *extra;
 } p11_rpc_message;
+
+typedef void (*p11_rpc_value_encoder) (p11_buffer *, const void *, CK_ULONG);
+typedef bool (*p11_rpc_value_decoder) (p11_buffer *, size_t *, void *, CK_ULONG *);
+typedef bool (*p11_rpc_message_decoder) (p11_rpc_message *msg, p11_buffer *, size_t *, void *, CK_ULONG *);
 
 void             p11_rpc_message_init                    (p11_rpc_message *msg,
                                                           p11_buffer *input,
@@ -370,6 +371,11 @@ bool             p11_rpc_message_read_space_string       (p11_rpc_message *msg,
 
 bool             p11_rpc_message_read_version            (p11_rpc_message *msg,
                                                           CK_VERSION* version);
+
+bool             p11_rpc_message_get_attribute           (p11_rpc_message *msg,
+							  p11_buffer *buffer,
+							  size_t *offset,
+							  CK_ATTRIBUTE *attr);
 
 p11_buffer *     p11_rpc_buffer_new                      (size_t reserve);
 


### PR DESCRIPTION
Allow usage of recursive attributes like CKA_WRAP_TEMPLATE inside RPC protocol.