### PR TITLE
log: Avoid buffer overflow

### DIFF
--- a/p11-kit/log.c
+++ b/p11-kit/log.c
@@ -731,7 +731,11 @@ log_token_info (p11_buffer *buf,
 		          (unsigned int)info->firmwareVersion.minor);
 		p11_buffer_add (buf, temp, -1);
 		p11_buffer_add (buf, "\n\tutcTime: ", -1);
-		p11_buffer_add (buf, (info->flags & CKF_CLOCK_ON_TOKEN) ? (const char*)info->utcTime : "", sizeof (info->utcTime));
+		if (info->flags & CKF_CLOCK_ON_TOKEN) {
+			p11_buffer_add (buf, (const char*)info->utcTime, sizeof (info->utcTime));
+		} else {
+			p11_buffer_add (buf, "(not supported)", -1);
+		}
 		p11_buffer_add (buf, "\n      }\n", -1);
 	}
 }


### PR DESCRIPTION
There was attempt to fix this in bb3a3cb1, but it fixed only the case when this value was actually provided by the token. When the token does not support clock, it would print behind the "" buffer, causing random constant string to be printed instead of the actual value, for example

	utcTime: ../common/attrs

This simplifies the long line for readability and prints additional information about this value being unsupported by the token.