### PR TITLE
p11-kit: Expose version information through macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ frob-*
 /p11-kit/pkcs11.conf.example
 /p11-kit/p11-kit-server.service
 /p11-kit/proxy-generated.h
+/p11-kit/version.h
 /p11-kit/virtual-*-generated.h
 /p11-kit/virtual-fixed-wrappers.h
 /p11-kit/virtual-fixed-closures.h

--- a/configure.ac
+++ b/configure.ac
@@ -638,11 +638,20 @@ AC_SUBST(GENHTML)
 P11KIT_LT_RELEASE=$P11KIT_CURRENT:$P11KIT_REVISION:$P11KIT_AGE
 AC_SUBST(P11KIT_LT_RELEASE)
 
-echo $PACKAGE_VERSION | tr '.' ' ' | while read major minor unused; do
-	AC_DEFINE_UNQUOTED(PACKAGE_MAJOR, $major, [Major version of package])
-	AC_DEFINE_UNQUOTED(PACKAGE_MINOR, $minor, [Minor version of package])
-	break
-done
+v=$PACKAGE_VERSION
+PACKAGE_MAJOR=${v%%\.*}
+v=${v#$PACKAGE_MAJOR\.}
+PACKAGE_MINOR=${v%%\.*}
+v=${v#$PACKAGE_MINOR\.}
+PACKAGE_MICRO=${v%%\.*}
+
+AC_SUBST(PACKAGE_MAJOR)
+AC_SUBST(PACKAGE_MINOR)
+AC_SUBST(PACKAGE_MICRO)
+
+AC_DEFINE_UNQUOTED(PACKAGE_MAJOR, $PACKAGE_MAJOR, [Major version of package])
+AC_DEFINE_UNQUOTED(PACKAGE_MINOR, $PACKAGE_MINOR, [Minor version of package])
+AC_DEFINE_UNQUOTED(PACKAGE_MICRO, $PACKAGE_MICRO, [Micro version of package])
 
 case "$host" in
 *-*-darwin*)
@@ -711,6 +720,7 @@ AC_CONFIG_FILES([Makefile
 	po/Makefile.in
 	p11-kit/p11-kit-1.pc
 	p11-kit/pkcs11.conf.example
+	p11-kit/version.h
 ])
 AC_OUTPUT
 

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ conf = configuration_data()
 conf.set_quoted('PACKAGE_NAME', meson.project_name())
 conf.set('PACKAGE_MAJOR', major_version)
 conf.set('PACKAGE_MINOR', minor_version)
+conf.set('PACKAGE_MICRO', micro_version)
 
 host_system = host_machine.system()
 if host_system == 'windows'

--- a/p11-kit/Makefile.am
+++ b/p11-kit/Makefile.am
@@ -507,6 +507,7 @@ c_tests += \
 	test-filter \
 	test-transport \
 	test-transport3 \
+	test-version \
 	$(NULL)
 
 test_log_SOURCES = p11-kit/test-log.c
@@ -531,6 +532,9 @@ test_transport3_CFLAGS = $(AM_CPPFLAGS) $(libp11_kit_testable_la_CFLAGS)
 
 test_virtual_SOURCES = p11-kit/test-virtual.c
 test_virtual_LDADD = $(p11_kit_LIBS)
+
+test_version_SOURCES = p11-kit/test-version.c
+test_version_LDADD = $(p11_kit_LIBS)
 
 check_LTLIBRARIES += \
 	mock-one.la \

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -1,9 +1,18 @@
+version_h = configure_file(
+  input: 'version.h.in',
+  output: '@BASENAME@',
+  configuration: conf,
+)
+
+version_h_dep = declare_dependency(sources: version_h)
+
 install_headers('deprecated.h',
                 'iter.h',
                 'p11-kit.h',
                 'pin.h',
                 'remote.h',
                 'uri.h',
+                version_h,
                 subdir: 'p11-kit-1/p11-kit')
 
 libp11_kit_internal_sources = [
@@ -341,7 +350,8 @@ if get_option('test')
     'test-log3',
     'test-filter',
     'test-transport',
-    'test-transport3'
+    'test-transport3',
+    'test-version',
   ]
 
   # Some tests fail to link on macOS because they need p11_library_mutex, but
@@ -366,7 +376,7 @@ if get_option('test')
     t = executable(name, '@0@.c'.format(name),
                    c_args: tests_c_args + libp11_kit_testable_c_args,
                    include_directories: [configinc, commoninc],
-                   dependencies: [libp11_test_dep] + libffi_deps + dlopen_deps,
+                   dependencies: [libp11_test_dep, version_h_dep] + libffi_deps + dlopen_deps,
                    link_with: link_with,
                    link_whole: link_whole)
     test(name, t)

--- a/p11-kit/test-version.c
+++ b/p11-kit/test-version.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Red Hat Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Daiki Ueno
+ */
+
+#include "config.h"
+
+#include "p11-kit/version.h"
+#include "library.h"
+#include "test.h"
+
+static void
+test_check (void)
+{
+#if !P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO)
+	assert_not_reached ();
+#endif
+
+#if !P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, 0)
+	assert_not_reached ();
+#endif
+
+#if !P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR, 0, 0)
+	assert_not_reached ();
+#endif
+
+#if P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR + 1, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO)
+	assert_not_reached ();
+#endif
+
+#if P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR + 1, P11_KIT_VERSION_MICRO)
+	assert_not_reached ();
+#endif
+
+#if P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO + 1)
+	assert_not_reached ();
+#endif
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+	p11_library_init ();
+
+	p11_test (test_check, "/version/test_check");
+
+	return p11_test_run (argc, argv);
+}

--- a/p11-kit/version.h.in
+++ b/p11-kit/version.h.in
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the
+ *       following disclaimer.
+ *     * Redistributions in binary form must reproduce the
+ *       above copyright notice, this list of conditions and
+ *       the following disclaimer in the documentation and/or
+ *       other materials provided with the distribution.
+ *     * The names of contributors to this software may not be
+ *       used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * Author: Daiki Ueno
+ */
+
+#ifndef P11_KIT_VERSION_H
+#define P11_KIT_VERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define P11_KIT_VERSION_MAJOR (@PACKAGE_MAJOR@)
+#define P11_KIT_VERSION_MINOR (@PACKAGE_MINOR@)
+#define P11_KIT_VERSION_MICRO (@PACKAGE_MICRO@)
+
+#define P11_KIT_CHECK_VERSION(major, minor, micro)	\
+	(P11_KIT_VERSION_MAJOR > (major) ||		\
+	 (P11_KIT_VERSION_MAJOR == (major) &&		\
+	  P11_KIT_VERSION_MINOR > (minor)) ||		\
+	 (P11_KIT_VERSION_MAJOR == (major) &&		\
+	  P11_KIT_VERSION_MINOR == (minor) &&		\
+	  P11_KIT_VERSION_MICRO >= (micro)))
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* P11_KIT_VERSION_H */


### PR DESCRIPTION
This provides P11_KIT_VERSION_{MAJOR,MINOR,MICRO} from the <p11-kit/version.h> header, along with a helper macro P11_KIT_CHECK_VERSION(major, minor, micro) for checking the version requirement with `#if` directive.

Fixes: #523 