### PR TITLE
Add function to check run-time version of the library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ NULL =
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/common \
+	-I$(top_builddir) \
 	-I$(top_builddir)/common \
 	-DBINDIR=\"$(bindir)\" \
 	-DBUILDDIR=\"$(abs_builddir)\" \

--- a/p11-kit/test-version.c
+++ b/p11-kit/test-version.c
@@ -39,7 +39,7 @@
 #include "test.h"
 
 static void
-test_check (void)
+test_check_compile_time (void)
 {
 #if !P11_KIT_CHECK_VERSION (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO)
 	assert_not_reached ();
@@ -66,13 +66,25 @@ test_check (void)
 #endif
 }
 
+static void
+test_check_run_time (void)
+{
+	assert_num_eq (1, p11_kit_check_version (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO));
+	assert_num_eq (1, p11_kit_check_version (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, 0));
+	assert_num_eq (1, p11_kit_check_version (P11_KIT_VERSION_MAJOR, 0, 0));
+	assert_num_eq (0, p11_kit_check_version (P11_KIT_VERSION_MAJOR + 1, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO));
+	assert_num_eq (0, p11_kit_check_version (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR + 1, P11_KIT_VERSION_MICRO));
+	assert_num_eq (0, p11_kit_check_version (P11_KIT_VERSION_MAJOR, P11_KIT_VERSION_MINOR, P11_KIT_VERSION_MICRO + 1));
+}
+
 int
 main (int argc,
       char *argv[])
 {
 	p11_library_init ();
 
-	p11_test (test_check, "/version/test_check");
+	p11_test (test_check_compile_time, "/version/test_check_compile_time");
+	p11_test (test_check_run_time, "/version/test_check_run_time");
 
 	return p11_test_run (argc, argv);
 }

--- a/p11-kit/util.c
+++ b/p11-kit/util.c
@@ -44,6 +44,7 @@
 #include "message.h"
 #include "p11-kit.h"
 #include "private.h"
+#include <p11-kit/version.h>
 
 #include <assert.h>
 #include <stdarg.h>
@@ -235,4 +236,22 @@ _p11_get_progname_unlocked (void)
 	if (p11_my_progname[0] == '\0')
 		return NULL;
 	return p11_my_progname;
+}
+
+/**
+ * p11_kit_check_version:
+ * @major: major version
+ * @minor: minor version
+ * @micro: micro version
+ *
+ * Check if the run-time version of p11-kit meets the requirement
+ * given by a triple: @major, @minor, and @micro.
+ *
+ * Returns: 1 if the version requirement meets; 0 otherwise.
+ * Since: 0.25.4
+ */
+int
+p11_kit_check_version (int major, int minor, int micro)
+{
+	return P11_KIT_CHECK_VERSION (major, minor, micro);
 }

--- a/p11-kit/version.h.in
+++ b/p11-kit/version.h.in
@@ -51,6 +51,8 @@ extern "C" {
 	  P11_KIT_VERSION_MINOR == (minor) &&		\
 	  P11_KIT_VERSION_MICRO >= (micro)))
 
+int p11_kit_check_version (int major, int minor, int micro);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
This adds p11_kit_check_version function, which can be used to check the run-time version of p11-kit.

Fixes: #523 