### PR TITLE
build: Set LC_ALL=C for test suite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,9 @@ AM_TESTS_ENVIRONMENT = \
 	abs_top_srcdir="$(abs_top_srcdir)"; \
 	export abs_top_srcdir; \
 	P11_MODULE_PATH="$(abs_top_builddir)/.libs"; \
-	export P11_MODULE_PATH;
+	export P11_MODULE_PATH; \
+	LC_ALL=C; \
+	export LC_ALL;
 AM_TESTS_FD_REDIRECT = 9>&2;
 
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -399,6 +399,7 @@ if get_option('test')
   p11_kit_tests_env.set('abs_top_builddir', top_build_dir)
   p11_kit_tests_env.set('abs_top_srcdir', top_source_dir)
   p11_kit_tests_env.set('P11_MODULE_PATH', meson.current_build_dir())
+  p11_kit_tests_env.set('LC_ALL', 'C')
 
   if host_system != 'windows'
     test('test-objects.sh',


### PR DESCRIPTION
Otherwise the error messages may be translated, causing a match failure.