### PR TITLE
p11-kit: Move CRYPTOKI_GNU definitions to <p11-kit/p11-kit.h>

### DIFF
--- a/p11-kit/iter.h
+++ b/p11-kit/iter.h
@@ -45,16 +45,6 @@ extern "C" {
 
 #ifdef P11_KIT_FUTURE_UNSTABLE_API
 
-/*
- * If the caller is using the PKCS#11 GNU calling convention, then we cater
- * to that here.
- */
-#ifdef CRYPTOKI_GNU
-typedef unsigned char CK_BBOOL;
-typedef ck_object_handle_t CK_OBJECT_HANDLE;
-typedef ck_session_handle_t CK_SESSION_HANDLE;
-#endif
-
 typedef struct p11_kit_iter P11KitIter;
 typedef P11KitIter p11_kit_iter;
 

--- a/p11-kit/p11-kit.h
+++ b/p11-kit/p11-kit.h
@@ -42,11 +42,23 @@
  * to that here.
  */
 #ifdef CRYPTOKI_GNU
-typedef ck_rv_t CK_RV;
+typedef ck_attribute_type_t CK_ATTRIBUTE_TYPE;
 typedef ck_object_handle_t CK_OBJECT_HANDLE;
-typedef unsigned long int CK_ULONG;
-typedef struct ck_function_list* CK_FUNCTION_LIST_PTR;
+typedef ck_rv_t CK_RV;
+typedef ck_session_handle_t CK_SESSION_HANDLE;
+typedef ck_slot_id_t CK_SLOT_ID;
+typedef struct ck_attribute *CK_ATTRIBUTE_PTR;
+typedef struct ck_attribute CK_ATTRIBUTE;
 typedef struct ck_function_list CK_FUNCTION_LIST;
+typedef struct ck_function_list* CK_FUNCTION_LIST_PTR;
+typedef struct ck_info *CK_INFO_PTR;
+typedef struct ck_info CK_INFO;
+typedef struct ck_slot_info *CK_SLOT_INFO_PTR;
+typedef struct ck_slot_info CK_SLOT_INFO;
+typedef struct ck_token_info *CK_TOKEN_INFO_PTR;
+typedef struct ck_token_info CK_TOKEN_INFO;
+typedef unsigned char CK_BBOOL;
+typedef unsigned long int CK_ULONG;
 #endif
 
 #include "p11-kit/deprecated.h"

--- a/p11-kit/uri.h
+++ b/p11-kit/uri.h
@@ -79,17 +79,6 @@ typedef enum {
  * to that here.
  */
 #ifdef CRYPTOKI_GNU
-typedef struct ck_info CK_INFO;
-typedef struct ck_info *CK_INFO_PTR;
-typedef struct ck_token_info CK_TOKEN_INFO;
-typedef struct ck_token_info *CK_TOKEN_INFO_PTR;
-typedef ck_attribute_type_t CK_ATTRIBUTE_TYPE;
-typedef struct ck_attribute CK_ATTRIBUTE;
-typedef struct ck_attribute *CK_ATTRIBUTE_PTR;
-typedef unsigned long int CK_ULONG;
-typedef struct ck_slot_info CK_SLOT_INFO;
-typedef struct ck_slot_info *CK_SLOT_INFO_PTR;
-typedef ck_slot_id_t CK_SLOT_ID;
 typedef P11KitUriType p11_kit_uri_type_t;
 typedef P11KitUriResult p11_kit_uri_result_t;
 #endif


### PR DESCRIPTION
Previously, the same fallback types are defined in `<p11-kit/uri.h>` and `<p11-kit/iter.h>` if `CRYPTOKI_GNU` is defined. This moves those to `<p11-kit/p11-kit.h>` so they are not redefined.

Fixes: #649 