### PR TITLE
doc/manual: Fix chapter id collision: proxy/sharing

### DIFF
--- a/doc/manual/p11-kit-proxy.xml
+++ b/doc/manual/p11-kit-proxy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>
-<chapter xml:id="sharing">
+<chapter xml:id="proxy">
 	<title>Proxy Module</title>
 
 	<para>When an application is aware of the fact that coordination


### PR DESCRIPTION
The chapter id in p11-kit-proxy.xml collides with the one in p11-kit-sharing.xml, which makes the HTML generated page overwriting each other.

This results in duplicate page content for both "Sharing PKCS#11 modules" section and "Proxy Module" section. Both provide content from p11-kit-proxy.xml and make p11-kit-sharing.xml content unavailable to the reader.

Changing the chapter id fixes the issue.