### PR TITLE
rpc: include <limits.h> for definition of ULONG_MAX

### DIFF
--- a/p11-kit/rpc-server.c
+++ b/p11-kit/rpc-server.c
@@ -55,6 +55,7 @@
 #include <sys/param.h>
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixes build failure on Solaris 11.4 with gcc 14.2:
```
../p11-kit/rpc-server.c: In function ‘proto_read_attribute_buffer_array’:
../p11-kit/rpc-server.c:289:46: error: ‘ULONG_MAX’ undeclared (first use in this function)
  289 |                         if ((n_array != 0 && ULONG_MAX / n_array < sizeof (CK_ATTRIBUTE)) ||
      |                                              ^~~~~~~~~
../p11-kit/rpc-server.c:64:1: note: ‘ULONG_MAX’ is defined in header ‘<limits.h>’; this is probably fixable by adding ‘#include <limits.h>’
```