### PR TITLE
Fix definition of NEED_READPASSPHRASE on non-unix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,9 @@ if test "$os_unix" = "yes"; then
 	                AC_MSG_RESULT([yes])],
 	               [AC_MSG_RESULT([no])])
 else
+    # ($os_unix != "yes")
+    # termios-based passphrase query is only supported on Unix platforms
+    # See common/Makefile.am
     AM_CONDITIONAL([NEED_READPASSPHRASE], [false])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -228,7 +228,8 @@ if test "$os_unix" = "yes"; then
 	                          [Whether vsock support available])
 	                AC_MSG_RESULT([yes])],
 	               [AC_MSG_RESULT([no])])
-
+else
+    AM_CONDITIONAL([NEED_READPASSPHRASE], [false])
 fi
 
 # These are thngs we can work around


### PR DESCRIPTION
On non-unix platform (e.g. mingw), the Automake conditional is not defined `NEED_READPASSPHRASE` by `configure`, which causes
```
configure: error: conditional "NEED_READPASSPHRASE" was never defined.
Usually this means the macro was only invoked conditionally.
```