### PR TITLE
server: Remove libsystemd dependency for socket activation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -687,9 +687,6 @@ AC_ARG_WITH([systemd],
                            [Disable systemd socket activation]))
 
 AS_IF([test "$with_systemd" != "no"], [
-	PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd], [],
-		[with_systemd=no])
-
 	PKG_CHECK_VAR([systemduserunitdir], [systemd], [systemduserunitdir], [],
 		[with_systemd=no])
 

--- a/meson.build
+++ b/meson.build
@@ -456,14 +456,9 @@ conf.set_quoted('TRUST_PATHS', trust_paths)
 # systemd
 
 with_systemd = false
-libsystemd_deps = []
-libsystemd = dependency('libsystemd', required: get_option('systemd'))
 systemd = dependency('systemd', required: get_option('systemd'))
-if libsystemd.found() and systemd.found()
+if systemd.found()
   systemduserunitdir = systemd.get_variable(pkgconfig : 'systemduserunitdir')
-  conf.set('WITH_SYSTEMD', 1)
-  libsystemd_deps += libsystemd
-  with_systemd = true
 endif
 
 configure_file(output: 'config.h', configuration: conf)

--- a/p11-kit/meson.build
+++ b/p11-kit/meson.build
@@ -277,7 +277,7 @@ executable('p11-kit-server',
            c_args: common_c_args + [
              '-DP11_KIT_REMOTE="p11-kit-remote"'
            ],
-           dependencies: [libp11_tool_dep] + libsystemd_deps + libintl_deps + libffi_deps + dlopen_deps,
+           dependencies: [libp11_tool_dep] + libintl_deps + libffi_deps + dlopen_deps,
            implicit_include_directories: false,
            link_with: libp11_kit,
            install: true,
@@ -290,7 +290,7 @@ if get_option('test')
                '-DP11_KIT_REMOTE="p11-kit-remote-testable"'
              ],
              implicit_include_directories: false,
-             dependencies: [libp11_tool_dep] + libsystemd_deps + libffi_deps + dlopen_deps,
+             dependencies: [libp11_tool_dep] + libffi_deps + dlopen_deps,
              link_whole: libp11_kit_testable)
 endif
 


### PR DESCRIPTION
While libsystemd provides rich facilities to interact with systemd, the server uses it only for socket activation, which is now also supported by other service managers. This avoids the dependency by embedding the minimal implementation of socket activation.