### PR TITLE
Fix running of test teardown on failure

### DIFF
--- a/common/test.c
+++ b/common/test.c
@@ -319,7 +319,7 @@ p11_test_run (int argc,
 	test_item *next;
 	int count;
 	int ret = 0;
-	int setup;
+	volatile int setup;
 	int opt;
 
 	/* p11-kit specific stuff */


### PR DESCRIPTION
The variable `setup` is set to 1 between `setjmp` and call to `longjmp` in `p11_test_fail`, so its value is indeterminate upon the second return from `setjmp`. If the variable is stored in a register, `setjmp` resets it to the value before the call (0), and the teardown function is not executed. Fix by making the variable `volatile`.

This bug can be observed, for example, by modifying `test-argv` to fail and building with LeakSanitizer and optimizations.