### PR TITLE
rpc: Add module configuration option to specify server address

### DIFF
--- a/doc/manual/pkcs11.conf.xml
+++ b/doc/manual/pkcs11.conf.xml
@@ -186,6 +186,13 @@ remote: |ssh user@remote p11-kit remote /path/to/module.so
 			<para>This argument is optional and defaults to <literal>no</literal>.</para>
 		</listitem>
 	</varlistentry>
+	<varlistentry id="option-server-address">
+		<term><option>server-address:</option></term>
+		<listitem>
+			<para>A socket address which the p11-kit server is listening on. Only applicable to the <literal>p11-kit-client</literal> module.</para>
+			<para>This option can be overridden with the <literal>P11_KIT_SERVER_ADDRESS</literal> environment variable.</para>
+		</listitem>
+	</varlistentry>
 	</variablelist>
 
 	<para>Do not specify both <literal>enable-in</literal> and <literal>disable-in</literal>

--- a/p11-kit/client.h
+++ b/p11-kit/client.h
@@ -35,6 +35,17 @@
 #ifndef __P11_CLIENT_H__
 #define __P11_CLIENT_H__
 
+#include "pkcs11.h"
+
+#define P11_CLIENT_INTERFACE_NAME "Vendor p11-kit client"
+
+typedef void (*set_server_address_func) (const char *server_address);
+
+struct p11_client_function_list {
+	CK_VERSION version;
+	set_server_address_func set_server_address;
+};
+
 void       p11_client_module_cleanup                  (void);
 
 


### PR DESCRIPTION
This adds "server-address" option to the module configuration, which would be useful when connecting to p11-kit-server running as a system service. The option has a higher precedence over any other alternatives, the P11_KIT_SERVER_ADDRESS envvar, or the default $XDG_RUNTIME_DIR/pkcs11.

For this to work, p11-kit-client.so exposes a vendor interface through C_GetInterface. This interface is hidden from the list obtained from C_GetInterfaceList.

Fixes: #706 