### PR TITLE
Revert "rpc: Correctly map Mozilla certificate distrust attributes"

### DIFF
--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -828,8 +828,6 @@ map_attribute_to_value_type (CK_ATTRIBUTE_TYPE type)
 	case CKA_IBM_USE_AS_DATA:
 	case CKA_IBM_PROTKEY_EXTRACTABLE:
 	case CKA_IBM_PROTKEY_NEVER_EXTRACTABLE:
-	case CKA_NSS_MOZILLA_CA_POLICY:
-	case CKA_X_DISTRUSTED:
 		return P11_RPC_VALUE_BYTE;
 	case CKA_CLASS:
 	case CKA_CERTIFICATE_TYPE:
@@ -866,6 +864,10 @@ map_attribute_to_value_type (CK_ATTRIBUTE_TYPE type)
 	case CKA_START_DATE:
 	case CKA_END_DATE:
 		return P11_RPC_VALUE_DATE;
+	default:
+		p11_debug ("cannot determine the type of attribute value for %lu; assuming byte array",
+			   type);
+		/* fallthrough */
 	case CKA_LABEL:
 	case CKA_APPLICATION:
 	case CKA_VALUE:
@@ -889,7 +891,6 @@ map_attribute_to_value_type (CK_ATTRIBUTE_TYPE type)
 	case CKA_EXPONENT_1:
 	case CKA_EXPONENT_2:
 	case CKA_COEFFICIENT:
-	case CKA_PUBLIC_KEY_INFO:
 	case CKA_PRIME:
 	case CKA_SUBPRIME:
 	case CKA_BASE:
@@ -920,12 +921,6 @@ map_attribute_to_value_type (CK_ATTRIBUTE_TYPE type)
 	case CKA_IBM_KYBER_MODE:
 	case CKA_IBM_KYBER_PK:
 	case CKA_IBM_KYBER_SK:
-	case CKA_NSS_SERVER_DISTRUST_AFTER: /* timestamp from Unix epoch, encoded in DER */
-	case CKA_NSS_EMAIL_DISTRUST_AFTER: /* timestamp from Unix epoch, encoded in DER */
-		return P11_RPC_VALUE_BYTE_ARRAY;
-	default:
-		p11_debug ("cannot determine the type of attribute value for %lu; assuming byte array",
-			   type);
 		return P11_RPC_VALUE_BYTE_ARRAY;
 	}
 }


### PR DESCRIPTION
This reverts commit 5a8430413c88e9ee34feebe98566ab35c0a1bb96, which broke RPC compatibility with the existing servers. Ideally, this should be conditionalized by the negotiated protocol version, though that wouldn't be straightforward as this is a low level function.