### PR TITLE
Fix issues found by static analysis

### DIFF
--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -1716,25 +1716,27 @@ p11_rpc_buffer_get_ibm_kyber_mech_param_update (p11_buffer *buffer,
 		if (!p11_rpc_buffer_get_byte(buffer, offset, &has_data))
 			return false;
 
-		if (has_data == 0) {
+		if (has_data) {
+			if (!p11_rpc_buffer_get_byte_array(buffer, offset, &data, &len))
+				return false;
+		} else {
 			if (!p11_rpc_buffer_get_uint32(buffer, offset, &length))
 				return false;
 			len = length;
-		} else {
-			if (!p11_rpc_buffer_get_byte_array(buffer, offset, &data, &len))
-				return false;
 		}
 
 		if (value) {
 			CK_IBM_KYBER_PARAMS *params = (CK_IBM_KYBER_PARAMS *) value;
 
-			if (params->pCipher && params->ulCipherLen == len) {
-				memcpy(params->pCipher, data, len);
-				params->ulCipherLen = len;
-			} else {
-				params->pCipher = (void *) data;
-				params->ulCipherLen = len;
+			if (has_data) {
+				assert (data != NULL);
+
+				if (params->pCipher && params->ulCipherLen == len)
+					memcpy(params->pCipher, data, len);
+				else
+					params->pCipher = (void *) data;
 			}
+			params->ulCipherLen = len;
 		}
 	}
 
@@ -1781,25 +1783,27 @@ p11_rpc_buffer_get_ibm_btc_derive_mech_param_update (p11_buffer *buffer,
 	if (!p11_rpc_buffer_get_byte(buffer, offset, &has_data))
 		return false;
 
-	if (has_data == 0) {
+	if (has_data) {
+		if (!p11_rpc_buffer_get_byte_array(buffer, offset, &data, &len))
+			return false;
+	} else {
 		if (!p11_rpc_buffer_get_uint32(buffer, offset, &length))
 			return false;
 		len = length;
-	} else {
-		if (!p11_rpc_buffer_get_byte_array(buffer, offset, &data, &len))
-			return false;
 	}
 
 	if (value) {
 		CK_IBM_BTC_DERIVE_PARAMS *params = (CK_IBM_BTC_DERIVE_PARAMS *) value;
 
-		if (params->pChainCode && params->ulChainCodeLen == len) {
-			memcpy(params->pChainCode, data, len);
-			params->ulChainCodeLen = len;
-		} else {
-			params->pChainCode = (void *) data;
-			params->ulChainCodeLen = len;
+		if (has_data) {
+			assert (data != NULL);
+
+			if (params->pChainCode && params->ulChainCodeLen == len)
+				memcpy(params->pChainCode, data, len);
+			else
+				params->pChainCode = (void *) data;
 		}
+		params->ulChainCodeLen = len;
 	}
 
 	if (value_length)


### PR DESCRIPTION
A slight overhaul of `p11_rpc_buffer_get_ibm_kyber_mech_param_update` and `p11_rpc_buffer_get_ibm_btc_derive_mech_param_update` functions where variable `data` could potentially be used uninitialized.

Report from static analysis:
```
1. Defect type: UNINIT 
1. p11-kit-0.26.1/p11-kit/rpc-message.c:1706:2: var_decl: Declaring variable "data" without initializer.
11. p11-kit-0.26.1/p11-kit/rpc-message.c:1732:5: uninit_use_in_call: Using uninitialized value "data" when calling "memcpy". [Note: The source code implementation of the function has been overridden by a builtin model.]
#  1730|   
#  1731|   			if (params->pCipher && params->ulCipherLen == len) {
#  1732|-> 				memcpy(params->pCipher, data, len);
#  1733|   				params->ulCipherLen = len;
#  1734|   			} else {
```

```
2. Defect type: UNINIT
1. p11-kit-0.26.1/p11-kit/rpc-message.c:1706:2: var_decl: Declaring variable "data" without initializer.
11. p11-kit-0.26.1/p11-kit/rpc-message.c:1735:5: uninit_use: Using uninitialized value "data".
#  1733|   				params->ulCipherLen = len;
#  1734|   			} else {
#  1735|-> 				params->pCipher = (void *) data;
#  1736|   				params->ulCipherLen = len;
#  1737|   			}
```

```
3. Defect type: UNINIT 
1. p11-kit-0.26.1/p11-kit/rpc-message.c:1776:2: var_decl: Declaring variable "data" without initializer.
9. p11-kit-0.26.1/p11-kit/rpc-message.c:1797:4: uninit_use_in_call: Using uninitialized value "data" when calling "memcpy". [Note: The source code implementation of the function has been overridden by a builtin model.]
#  1795|   
#  1796|   		if (params->pChainCode && params->ulChainCodeLen == len) {
#  1797|-> 			memcpy(params->pChainCode, data, len);
#  1798|   			params->ulChainCodeLen = len;
#  1799|   		} else {
```

```
4. Defect type: UNINIT
1. p11-kit-0.26.1/p11-kit/rpc-message.c:1776:2: var_decl: Declaring variable "data" without initializer.
9. p11-kit-0.26.1/p11-kit/rpc-message.c:1800:4: uninit_use: Using uninitialized value "data".
#  1798|   			params->ulChainCodeLen = len;
#  1799|   		} else {
#  1800|-> 			params->pChainCode = (void *) data;
#  1801|   			params->ulChainCodeLen = len;
#  1802|   		}
```