### PR TITLE
Fix client compatibility with older servers

### DIFF
--- a/p11-kit/rpc-client.c
+++ b/p11-kit/rpc-client.c
@@ -419,7 +419,8 @@ mechanism_list_purge (CK_MECHANISM_TYPE_PTR mechs,
 
 static CK_RV
 proto_write_mechanism (p11_rpc_message *msg,
-                       CK_MECHANISM_PTR mech)
+                       CK_MECHANISM_PTR mech,
+		       int rpc_version)
 {
 	assert (msg != NULL);
 	assert (msg->output != NULL);
@@ -433,7 +434,10 @@ proto_write_mechanism (p11_rpc_message *msg,
 	 * marker to indicate that.
 	 */
 	if (mech == NULL) {
-		p11_rpc_buffer_add_uint32 (msg->output, 0xffffffff);
+		if (rpc_version < 1)
+			p11_rpc_buffer_add_uint32 (msg->output, 0);
+		else
+			p11_rpc_buffer_add_uint32 (msg->output, 0xffffffff);
 		return p11_buffer_failed (msg->output) ? CKR_HOST_MEMORY : CKR_OK;
 	}
 
@@ -452,7 +456,7 @@ proto_write_mechanism (p11_rpc_message *msg,
 	 * pointing to garbage if they don't think it's going to be used.
 	 */
 
-	p11_rpc_buffer_add_mechanism (msg->output, mech);
+	p11_rpc_buffer_add_mechanism (msg->output, mech, rpc_version);
 
 	return p11_buffer_failed (msg->output) ? CKR_HOST_MEMORY : CKR_OK;
 }
@@ -690,7 +694,7 @@ proto_read_sesssion_info (p11_rpc_message *msg,
 		{ _ret = CKR_HOST_MEMORY; goto _cleanup; }
 
 #define IN_MECHANISM(val) \
-	_ret = proto_write_mechanism (&_msg, val); \
+	_ret = proto_write_mechanism (&_msg, val, RPC_VERSION);	\
 	if (_ret != CKR_OK) goto _cleanup;
 
 

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -2554,7 +2554,7 @@ p11_rpc_mechanism_is_supported (CK_MECHANISM_TYPE mech)
 }
 
 void
-p11_rpc_buffer_add_mechanism (p11_buffer *buffer, const CK_MECHANISM *mech)
+p11_rpc_buffer_add_mechanism (p11_buffer *buffer, const CK_MECHANISM *mech, int rpc_version)
 {
 	p11_rpc_mechanism_serializer *serializer = NULL;
 	size_t i;
@@ -2563,16 +2563,20 @@ p11_rpc_buffer_add_mechanism (p11_buffer *buffer, const CK_MECHANISM *mech)
 	p11_rpc_buffer_add_uint32 (buffer, mech->mechanism);
 
 	if (mechanism_has_no_parameters (mech->mechanism)) {
+		if (rpc_version < 2)
+			p11_rpc_buffer_add_byte_array (buffer, NULL, 0);
 		return;
 	}
 
 	assert (mechanism_has_sane_parameters (mech->mechanism));
 
-	if (mech->pParameter == NULL && mech->ulParameterLen == 0) {
-		p11_rpc_buffer_add_byte (buffer, 0);
-		return;
-	} else {
-		p11_rpc_buffer_add_byte (buffer, 1);
+	if (rpc_version >= 2) {
+		if (mech->pParameter == NULL && mech->ulParameterLen == 0) {
+			p11_rpc_buffer_add_byte (buffer, 0);
+			return;
+		} else {
+			p11_rpc_buffer_add_byte (buffer, 1);
+		}
 	}
 
 	for (i = 0; i < ELEMS (p11_rpc_mechanism_serializers); i++) {

--- a/p11-kit/rpc-message.h
+++ b/p11-kit/rpc-message.h
@@ -511,7 +511,8 @@ bool             p11_rpc_buffer_get_byte_array_value     (p11_buffer *buffer,
 bool             p11_rpc_mechanism_is_supported          (CK_MECHANISM_TYPE mech);
 
 void             p11_rpc_buffer_add_mechanism            (p11_buffer *buffer,
-							  const CK_MECHANISM *mech);
+							  const CK_MECHANISM *mech,
+							  int rpc_version);
 
 bool             p11_rpc_buffer_get_mechanism            (p11_buffer *buffer,
 							  size_t *offset,

--- a/p11-kit/test-rpc-message.c
+++ b/p11-kit/test-rpc-message.c
@@ -751,7 +751,7 @@ test_mechanism_value (void)
 	for (i = 0; i < ELEMS (mechs); i++) {
 		size_t offset2 = offset;
 
-		p11_rpc_buffer_add_mechanism (&buffer, &mechs[i]);
+		p11_rpc_buffer_add_mechanism (&buffer, &mechs[i], P11_RPC_PROTOCOL_VERSION_MAXIMUM);
 		assert (!p11_buffer_failed (&buffer));
 
 		memset (&val, 0, sizeof (val));


### PR DESCRIPTION
We changed the format of the mechanism parameter without actually checking the server version. This broke SignInit() when using older servers.
