### PR TITLE
ci: Fix coverage reporting

### DIFF
--- a/.github/actions/basic-meson/action.yaml
+++ b/.github/actions/basic-meson/action.yaml
@@ -33,7 +33,7 @@ runs:
       shell: bash
 
     - name: Prepare for post-install tests
-      if: ${{ env.PROFILE != 'static-analysis' }}
+      if: ${{ env.PROFILE != 'static-analysis' && env.PROFILE != 'coverage' }}
       run: |
         # This is necessary for 'trust/test-extract.sh'
         mkdir -p $GITHUB_WORKSPACE/$INSTALLDIR/etc/pki/ca-trust-source
@@ -49,6 +49,6 @@ runs:
       shell: bash
 
     - name: Install
-      if: ${{ env.PROFILE != 'static-analysis' }}
+      if: ${{ env.PROFILE != 'static-analysis' && env.PROFILE != 'coverage' }}
       run: ninja -C $GITHUB_WORKSPACE/$BUILDDIR install
       shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,18 +122,21 @@ jobs:
       image: ghcr.io/p11-glue/p11-kit:master
     env:
       MESON_BUILD_OPTS: -Db_coverage=true
+      PROFILE: coverage
+      RUN_AS_ROOT: true
     steps:
       # Checkout repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          submodules: true
+          submodules: recursive
       - uses: ./.github/actions/basic-meson
       - name: Genereate coverage
-        run: runuser -u user -- ninja coverage -C $GITHUB_WORKSPACE/$BUILDDIR
+        run: $GITHUB_WORKSPACE/build/run-wrapper.sh ninja coverage-xml -C $GITHUB_WORKSPACE/$BUILDDIR
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v1.1.2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          path-to-lcov: ./builddir/meson-logs/coverage.info
+          file: ./builddir/meson-logs/coverage.xml
+          format: cobertura
           github-token: ${{ secrets.github_token }}
 
   macos:

--- a/build/run-wrapper.sh
+++ b/build/run-wrapper.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-if test $(id -u) -eq 0; then
+if test "$RUN_AS_ROOT" = true; then
+    exec "$@"
+elif test $(id -u) -eq 0; then
     case "$RUNNER_OS" in
 	Linux)
 	    exec runuser -u "$RUNUSER" -- "$@"


### PR DESCRIPTION
This updates the coveralls action to 2.3.6, which supports the cobertura format.