### PR TITLE
Release 0.26.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.26.5 (stable)
+* rpc: guard against overflow when decoding nested attributes (CVE-2026-18938) [PR#777]
+
 0.26.4 (stable)
 * Build fix [PR#773]
 * Update translations [PR#743, PR#772]

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.61)
 
 AC_INIT([p11-kit],
-	[0.26.4],
+	[0.26.5],
 	[https://github.com/p11-glue/p11-kit/issues],
 	[p11-kit],
 	[https://p11-glue.github.io/p11-glue/p11-kit.html])
@@ -14,7 +14,7 @@ AC_INIT([p11-kit],
 #    ?    :    +1    :  ?   == internal changes that doesn't break anything.
 
 P11KIT_CURRENT=4
-P11KIT_REVISION=10
+P11KIT_REVISION=11
 P11KIT_AGE=4
 
 # ------------------------------------------------------------------------------

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('p11-kit', 'c',
-        version: '0.26.4',
+        version: '0.26.5',
         meson_version: '>= 0.51')
 
 version_arr = meson.project_version().split('.')
@@ -10,7 +10,7 @@ micro_version = version_arr[2].to_int()
 cc = meson.get_compiler('c')
 
 current = 4
-revision = 10
+revision = 11
 age = 4
 
 soversion = current - age

--- a/p11-kit/rpc-message.c
+++ b/p11-kit/rpc-message.c
@@ -976,6 +976,10 @@ p11_rpc_message_get_attribute_array_value (p11_rpc_message *msg,
 	if (!p11_rpc_buffer_get_uint32 (buffer, offset, &count))
 		return false;
 
+	/* Guard against overflow */
+	if (count != 0 && (SIZE_MAX / count) < sizeof (CK_ATTRIBUTE))
+		return false;
+
 	if (value_length != NULL)
 		*value_length = count * sizeof (CK_ATTRIBUTE);
 
@@ -1283,6 +1287,10 @@ p11_rpc_buffer_get_mechanism_type_array_value (p11_buffer *buffer,
 	CK_MECHANISM_TYPE *mech, temp;
 
 	if (!p11_rpc_buffer_get_uint32 (buffer, offset, &count))
+		return false;
+
+	/* Guard against overflow */
+	if (count != 0 && (SIZE_MAX / count) < sizeof (CK_MECHANISM_TYPE))
 		return false;
 
 	if (!value) {


### PR DESCRIPTION
* rpc: guard against overflow when decoding nested attributes (CVE-2026-18938)